### PR TITLE
Add query to ProviderServiceRequest model class when json is serialized

### DIFF
--- a/src/Mocks/MockHttpService/Models/ProviderServiceRequest.php
+++ b/src/Mocks/MockHttpService/Models/ProviderServiceRequest.php
@@ -146,6 +146,10 @@ class ProviderServiceRequest implements \JsonSerializable, \PhpPact\Mocks\MockHt
         $obj->method = $this->_method;
         $obj->path = $this->_path;
 
+        if ($this->_query) {
+            $obj->query = $this->_query;
+        }
+
         $header = $this->_headers;
         if (is_array($header)) {
             $header = (object)$header;


### PR DESCRIPTION
Hi,

From my experience using the library, if the query is not returned in the jsonSerialize result, then it won't be persisted in the pact file generated.

Please disregard the change if it makes no sense to you.