### PR TITLE
Revert "Always return headers as array"

### DIFF
--- a/src/Mocks/MockHttpService/Mappers/ProviderServiceRequestMapper.php
+++ b/src/Mocks/MockHttpService/Mappers/ProviderServiceRequestMapper.php
@@ -30,10 +30,10 @@ class ProviderServiceRequestMapper implements \PhpPact\Mappers\IMapper
         }
 
         if (!isset($request->headers)) {
-            $request->headers = [];
+            $request->headers = null;
         }
 
-        $providerServiceRequest = new \PhpPact\Mocks\MockHttpService\Models\ProviderServiceRequest($request->method, $request->path, get_object_vars($request->headers), $body);
+        $providerServiceRequest = new \PhpPact\Mocks\MockHttpService\Models\ProviderServiceRequest($request->method, $request->path, $request->headers, $body);
         if (isset($request->query)) {
             $providerServiceRequest->setQuery($request->query);
         }

--- a/src/Mocks/MockHttpService/Mappers/ProviderServiceResponseMapper.php
+++ b/src/Mocks/MockHttpService/Mappers/ProviderServiceResponseMapper.php
@@ -18,8 +18,8 @@ class ProviderServiceResponseMapper implements \PhpPact\Mappers\IMapper
             return $response;
         }
 
-        $headers = isset($response->headers) ? $response->headers : array();
-        $status = isset($response->status) ? $response->status : null;
+        $headers = isset($response->headers)?$response->headers:array();
+        $status = isset($response->status)?$response->status:null;
 
         $body = false;
         if (property_exists($response, "body")) {
@@ -31,7 +31,7 @@ class ProviderServiceResponseMapper implements \PhpPact\Mappers\IMapper
             }
         }
 
-        $providerServiceResponse = new \PhpPact\Mocks\MockHttpService\Models\ProviderServiceResponse($status, get_object_vars($headers), $body);
+        $providerServiceResponse = new \PhpPact\Mocks\MockHttpService\Models\ProviderServiceResponse($status, $headers, $body);
         return $providerServiceResponse;
     }
 

--- a/src/Mocks/MockHttpService/Models/IHttpMessage.php
+++ b/src/Mocks/MockHttpService/Models/IHttpMessage.php
@@ -18,13 +18,13 @@ interface IHttpMessage
     /**
      * @return array
      */
-    public function getHeaders() : array;
+    public function getHeaders();
 
     /**
      * @param array $headers
      * @return mixed
      */
-    public function setHeaders(array $headers);
+    public function setHeaders($headers);
 
     /**
      * Return the header value for Content-Type

--- a/src/Mocks/MockHttpService/Models/ProviderServiceRequest.php
+++ b/src/Mocks/MockHttpService/Models/ProviderServiceRequest.php
@@ -14,13 +14,15 @@ class ProviderServiceRequest implements \JsonSerializable, \PhpPact\Mocks\MockHt
     private $_matchingRules;
     private $_query; //[JsonProperty(PropertyName = "query")]
 
-    public function __construct($method, $path, array $headers = [], $body = false)
+    public function __construct($method, $path, $headers = null, $body = false)
     {
         // enumerate over HttpVerb to set the value of the
         $verb = new \PhpPact\Mocks\MockHttpService\Models\HttpVerb();
         $this->_method = $verb->Enum($method);
         $this->_path = $path;
-        $this->_headers = $headers;
+        if ($headers) {
+            $this->_headers = $headers;
+        }
 
         if ($body !== false) {
             $this->setBody($body);
@@ -77,19 +79,17 @@ class ProviderServiceRequest implements \JsonSerializable, \PhpPact\Mocks\MockHt
     /**
      * @return array
      */
-    public function getHeaders() : array
+    public function getHeaders()
     {
         return $this->_headers;
     }
 
     /**
-     * @param array headers
-     * @return $this
+     * @return mixed
      */
-    public function setHeaders(array $headers)
+    public function setHeaders($headers)
     {
         $this->_headers = $headers;
-
         return $this;
     }
 

--- a/src/Mocks/MockHttpService/Models/ProviderServiceResponse.php
+++ b/src/Mocks/MockHttpService/Models/ProviderServiceResponse.php
@@ -7,7 +7,7 @@ class ProviderServiceResponse implements \JsonSerializable, \PhpPact\Mocks\MockH
 
     private $_bodyWasSet;
     private $_body;
-    private $_headers = []; //[JsonProperty(PropertyName = "headers")] / [JsonConverter(typeof(PreserveCasingDictionaryConverter))]
+    private $_headers; //[JsonProperty(PropertyName = "headers")] / [JsonConverter(typeof(PreserveCasingDictionaryConverter))]
     private $_status;
     private $_matchingRules;
 
@@ -23,22 +23,20 @@ class ProviderServiceResponse implements \JsonSerializable, \PhpPact\Mocks\MockH
     }
 
     /**
-     * @return array
+     * @return mixed
      */
-    public function getHeaders() : array
+    public function getHeaders()
     {
         return $this->_headers;
     }
 
 
     /**
-     * @param array headers
-     * @return $this
+     * @return mixed
      */
-    public function setHeaders(array $headers)
+    public function setHeaders($headers)
     {
         $this->_headers = $headers;
-
         return $this;
     }
 
@@ -51,7 +49,7 @@ class ProviderServiceResponse implements \JsonSerializable, \PhpPact\Mocks\MockH
     }
 
 
-    public function __construct($status = null, array $headers = array(), $body = null)
+    public function __construct($status = null, $headers = array(), $body = null)
     {
         $this->_status = $status;
         $this->_headers = $headers;


### PR DESCRIPTION
Reverts pact-foundation/pact-php#9

This breaks Specification 1.1 : body\empty body no content type.json on https://ci.appveyor.com/project/mattermack/pact-php/build/1.1.46

See:
- https://github.com/pact-foundation/pact-specification/blob/version-1.1/testcases/request/body/empty%20body.json
- https://github.com/pact-foundation/pact-specification/blob/version-1.1/testcases/response/body/empty%20body.json


