### PR TITLE
Fixed some issues with default pact dir and required envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -255,3 +255,4 @@ vendor/*
 .buildpath
 
 test_results
+pact

--- a/.php_cs
+++ b/.php_cs
@@ -120,7 +120,6 @@ return PhpCsFixer\Config::create()
             'return_type_declaration' => ['space_before' => 'none'],
             'self_accessor' => true,
             'short_scalar_cast' => true,
-            'simplified_null_return' => true,
             'single_blank_line_at_eof' => true,
             'single_import_per_statement' => true,
             'single_line_after_imports' => true,

--- a/src/PhpPact/Standalone/Exception/MissingEnvVariableException.php
+++ b/src/PhpPact/Standalone/Exception/MissingEnvVariableException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PhpPact\Consumer\Exception;
+
+use Exception;
+
+/**
+ * Exception for a required environmental variable.
+ * Class MissingEnvVariableException
+ */
+class MissingEnvVariableException extends Exception
+{
+    public function __construct(string $variableName)
+    {
+        parent::__construct("Please provide required environmental variable {$variableName}!", 0, null);
+    }
+}

--- a/src/PhpPact/Standalone/Installer/InstallManager.php
+++ b/src/PhpPact/Standalone/Installer/InstallManager.php
@@ -28,7 +28,7 @@ class InstallManager
 
     public function __construct()
     {
-        $this->destinationDir = \sys_get_temp_dir();
+        $this->destinationDir = __DIR__.'/../../../../';
         $this
             ->registerInstaller(new InstallerWindows())
             ->registerInstaller(new InstallerMac())

--- a/src/PhpPact/Standalone/Installer/InstallManager.php
+++ b/src/PhpPact/Standalone/Installer/InstallManager.php
@@ -28,7 +28,7 @@ class InstallManager
 
     public function __construct()
     {
-        $this->destinationDir = __DIR__.'/../../../../';
+        $this->destinationDir = __DIR__ . '/../../../..';
         $this
             ->registerInstaller(new InstallerWindows())
             ->registerInstaller(new InstallerMac())

--- a/src/PhpPact/Standalone/MockService/MockServerConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfig.php
@@ -186,7 +186,7 @@ class MockServerConfig implements MockServerConfigInterface
     /**
      * @inheritDoc
      */
-    public function setPactDir(string $pactDir): MockServerConfigInterface
+    public function setPactDir($pactDir): MockServerConfigInterface
     {
         $this->pactDir = $pactDir;
 

--- a/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
@@ -81,11 +81,11 @@ interface MockServerConfigInterface
     public function getPactDir();
 
     /**
-     * @param string $pactDir url to place the pact files when written to disk
+     * @param null|string $pactDir url to place the pact files when written to disk
      *
      * @return MockServerConfigInterface
      */
-    public function setPactDir(string $pactDir): self;
+    public function setPactDir($pactDir): self;
 
     /**
      * @return string 'merge' or 'overwrite' merge means that interactions are added and overwrite means that the entire file is overwritten

--- a/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
@@ -2,15 +2,43 @@
 
 namespace PhpPact\Standalone\MockService;
 
+use PhpPact\Consumer\Exception\MissingEnvVariableException;
+
+/**
+ * An environment variable based mock server configuration.
+ * Class MockServerEnvConfig
+ */
 class MockServerEnvConfig extends MockServerConfig
 {
     public function __construct()
     {
         $this
-            ->setHost(\getenv('PACT_MOCK_SERVER_HOST'))
-            ->setPort(\getenv('PACT_MOCK_SERVER_PORT'))
-            ->setConsumer(\getenv('PACT_CONSUMER_NAME'))
-            ->setProvider(\getenv('PACT_PROVIDER_NAME'))
-            ->setPactDir(\getenv('PACT_OUTPUT_DIR'));
+            ->setHost($this->parseEnv('PACT_MOCK_SERVER_HOST'))
+            ->setPort($this->parseEnv('PACT_MOCK_SERVER_PORT'))
+            ->setConsumer($this->parseEnv('PACT_CONSUMER_NAME'))
+            ->setProvider($this->parseEnv('PACT_PROVIDER_NAME'))
+            ->setPactDir($this->parseEnv('PACT_OUTPUT_DIR', false));
+    }
+
+    /**
+     * Parse environmental variables to be either null if not required or throw an error if required.
+     *
+     * @param string $variableName
+     * @param bool   $required
+     *
+     * @throws MissingEnvVariableException
+     *
+     * @return null|string
+     */
+    private function parseEnv(string $variableName, bool $required = true)
+    {
+        if (\getenv($variableName) !== false) {
+            return \getenv($variableName);
+        }
+        if ($required === true) {
+            throw new MissingEnvVariableException($variableName);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
1. Fixed an issue where pact_dir was defaulting to "". This was causing it to default to the root directory "/" which is restricted in Travis CI.

2. Moved the install directory of the Pact binaries to the root of the project. This should make it easier to visualize where it is located and also allow for it to be uninstalled with PACT.