### PR TITLE
Fix Exception Namespace

### DIFF
--- a/example/tests/Consumer/Service/ConsumerServiceGoodbyeTest.php
+++ b/example/tests/Consumer/Service/ConsumerServiceGoodbyeTest.php
@@ -2,7 +2,7 @@
 
 namespace Consumer\Service;
 
-use PhpPact\Consumer\Exception\MissingEnvVariableException;
+use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Model\ConsumerRequest;
 use PhpPact\Consumer\Model\ProviderResponse;

--- a/src/PhpPact/Consumer/Listener/PactTestListener.php
+++ b/src/PhpPact/Consumer/Listener/PactTestListener.php
@@ -4,7 +4,7 @@ namespace PhpPact\Consumer\Listener;
 
 use GuzzleHttp\Psr7\Uri;
 use PhpPact\Broker\Service\BrokerHttpClient;
-use PhpPact\Consumer\Exception\MissingEnvVariableException;
+use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Http\GuzzleClient;
 use PhpPact\Standalone\MockService\MockServer;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;

--- a/src/PhpPact/Standalone/Exception/HealthCheckFailedException.php
+++ b/src/PhpPact/Standalone/Exception/HealthCheckFailedException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer\Exception;
+namespace PhpPact\Standalone\Exception;
 
 use Exception;
 

--- a/src/PhpPact/Standalone/Exception/MissingEnvVariableException.php
+++ b/src/PhpPact/Standalone/Exception/MissingEnvVariableException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer\Exception;
+namespace PhpPact\Standalone\Exception;
 
 use Exception;
 

--- a/src/PhpPact/Standalone/MockService/MockServer.php
+++ b/src/PhpPact/Standalone/MockService/MockServer.php
@@ -4,8 +4,8 @@ namespace PhpPact\Standalone\MockService;
 
 use Exception;
 use GuzzleHttp\Exception\ConnectException;
-use PhpPact\Consumer\Exception\HealthCheckFailedException;
 use PhpPact\Http\GuzzleClient;
+use PhpPact\Standalone\Exception\HealthCheckFailedException;
 use PhpPact\Standalone\Installer\InstallManager;
 use PhpPact\Standalone\Installer\Service\InstallerInterface;
 use PhpPact\Standalone\MockService\Service\MockServerHttpService;

--- a/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
@@ -2,7 +2,7 @@
 
 namespace PhpPact\Standalone\MockService;
 
-use PhpPact\Consumer\Exception\MissingEnvVariableException;
+use PhpPact\Standalone\Exception\MissingEnvVariableException;
 
 /**
  * An environment variable based mock server configuration.

--- a/tests/PhpPact/Consumer/InteractionBuilderTest.php
+++ b/tests/PhpPact/Consumer/InteractionBuilderTest.php
@@ -6,6 +6,7 @@ use PhpPact\Consumer\Matcher\Matcher;
 use PhpPact\Consumer\Model\ConsumerRequest;
 use PhpPact\Consumer\Model\ProviderResponse;
 use PhpPact\Http\GuzzleClient;
+use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Standalone\MockService\MockServer;
 use PhpPact\Standalone\MockService\MockServerEnvConfig;
 use PhpPact\Standalone\MockService\Service\MockServerHttpService;
@@ -21,7 +22,7 @@ class InteractionBuilderTest extends TestCase
     private $mockServer;
 
     /**
-     * @throws Exception\MissingEnvVariableException
+     * @throws MissingEnvVariableException
      * @throws \Exception
      */
     protected function setUp()
@@ -38,7 +39,7 @@ class InteractionBuilderTest extends TestCase
     }
 
     /**
-     * @throws Exception\MissingEnvVariableException
+     * @throws MissingEnvVariableException
      * @throws \Exception
      */
     public function testSimpleGet()
@@ -71,7 +72,7 @@ class InteractionBuilderTest extends TestCase
     }
 
     /**
-     * @throws Exception\MissingEnvVariableException
+     * @throws MissingEnvVariableException
      */
     public function testPostWithBody()
     {
@@ -109,7 +110,7 @@ class InteractionBuilderTest extends TestCase
     }
 
     /**
-     * @throws Exception\MissingEnvVariableException
+     * @throws MissingEnvVariableException
      */
     public function testBuildWithEachLikeMatcher()
     {

--- a/tests/PhpPact/Standalone/MockServer/MockServerTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Consumer;
 
+use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Standalone\MockService\MockServer;
 use PhpPact\Standalone\MockService\MockServerEnvConfig;
 use PHPUnit\Framework\TestCase;
@@ -9,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 class MockServerTest extends TestCase
 {
     /**
-     * @throws Exception\MissingEnvVariableException
+     * @throws MissingEnvVariableException
      * @throws \Exception
      */
     public function testStartAndStop()

--- a/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
+++ b/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
@@ -3,7 +3,7 @@
 namespace PhpPact\Standalone\MockService\Service;
 
 use GuzzleHttp\Exception\ServerException;
-use PhpPact\Consumer\Exception\MissingEnvVariableException;
+use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Matcher\Matcher;
 use PhpPact\Consumer\Model\ConsumerRequest;


### PR DESCRIPTION
The current namespace for the Exceptions doesn't reflect the directory structure.
This leads to "Class not found" Exceptions. This PR fixes this.