### PR TITLE
test also lowest available dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,20 @@ os:
 
 language: php
 
-php:
-  - 7.0
-  - 7.1
-  - 7.2
+matrix:
+    include:
+        - php: 7.0
+        - php: 7.1
+        - php: 7.2
+        - php: 7.2
+          env: deps=low
 
 install:
-  - composer install
+  - |
+    if [[ $deps = low ]]; then
+        composer update --prefer-lowest
+    else
+        composer update
+    fi
 
 script: composer test

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
     "require": {
         "php": "^7.0",
         "ext-openssl": "*",
-        "symfony/process": "^3.0 || ^4.0",
+        "symfony/process": "^3.3 || ^4.0",
         "symfony/filesystem": "^3.0 || ^4.0",
         "guzzlehttp/guzzle": "^6.3",
         "symfony/console": "^3.3 || ^4.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^6.4",
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
         "slim/slim": "^3.9"


### PR DESCRIPTION
To verify that pact-php works also with minimal declared dependencies (which appeared it's not).

Original intention was to lower `symfony/*` dependencies to be able to use in symfony 2.x projects. But after that I've realised that dependencies should be not lowered but bumped up :-/.

If I can contribute PR for support of symfony 2.x (yay, we have some legacy here) will it have chances to be accepted?