### PR TITLE
Fixed pact bin version mismatch after composer update.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "symfony/console": "^3.3 || ^4.0"
     },
     "require-dev": {
+        "roave/security-advisories": "dev-master",
         "phpunit/phpunit": "^6.0",
         "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
@@ -52,6 +53,7 @@
         }
     },
     "scripts": {
+        "post-update-cmd": "\\PhpPact\\Standalone\\Installer\\InstallManager::uninstall",
         "start-provider": "php -S localhost:58000 -t example/src/Provider/public/",
         "fix": "php-cs-fixer fix --config .php_cs",
         "test": "phpunit --debug"

--- a/src/PhpPact/Standalone/Installer/InstallManager.php
+++ b/src/PhpPact/Standalone/Installer/InstallManager.php
@@ -24,11 +24,10 @@ class InstallManager
      *
      * @var string
      */
-    private $destinationDir;
+    private static $destinationDir = __DIR__ . '/../../../..';
 
     public function __construct()
     {
-        $this->destinationDir = __DIR__ . '/../../../..';
         $this
             ->registerInstaller(new InstallerWindows())
             ->registerInstaller(new InstallerMac())
@@ -73,16 +72,16 @@ class InstallManager
     {
         $downloader = $this->getDownloader();
 
-        return $downloader->install($this->destinationDir);
+        return $downloader->install(self::$destinationDir);
     }
 
     /**
      * Uninstall.
      */
-    public function uninstall()
+    public static function uninstall()
     {
         $fs = new Filesystem();
-        $fs->remove($this->destinationDir . DIRECTORY_SEPARATOR . 'pact');
+        $fs->remove(self::$destinationDir . DIRECTORY_SEPARATOR . 'pact');
     }
 
     /**


### PR DESCRIPTION
After a `composer update` pact-php did not updates the pact binaries. This is related to #64 .
The fix will uninstall pact standalone after an composer update.