### PR TITLE
Added cors header support to the MockService.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Alternatively, you can start and stop as in whatever means you would like by fol
     $config->setPort(7200);
     $config->setConsumer('SomeConsumer');
     $config->setProvider('SomeProvider');
+    $config->setCors(true);
 
     // Instantiate the mock server object with the config. This can be any
     // instance of MockServerConfigInterface.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,5 +22,6 @@
         <env name="PACT_CONSUMER_VERSION" value="1.0.0"/>
         <env name="PACT_PROVIDER_NAME" value="someProvider"/>
         <env name="PACT_BROKER_URI" value="http://localhost"/>
+        <env name="PACT_CORS" value="true"/>
     </php>
 </phpunit>

--- a/src/PhpPact/Standalone/MockService/MockServer.php
+++ b/src/PhpPact/Standalone/MockService/MockServer.php
@@ -124,6 +124,10 @@ class MockServer
         $results[] = "--host={$this->config->getHost()}";
         $results[] = "--port={$this->config->getPort()}";
 
+        if ($this->config->hasCors()) {
+            $results[] = "-o";
+        }
+
         if ($this->config->getPactSpecificationVersion() !== null) {
             $results[] = "--pact-specification-version={$this->config->getPactSpecificationVersion()}";
         }

--- a/src/PhpPact/Standalone/MockService/MockServerConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfig.php
@@ -75,6 +75,9 @@ class MockServerConfig implements MockServerConfigInterface
      */
     private $log;
 
+    /** @var bool */
+    private $cors = false;
+
     /**
      * @inheritdoc
      */
@@ -255,6 +258,24 @@ class MockServerConfig implements MockServerConfigInterface
     public function setLog(string $log): MockServerConfigInterface
     {
         $this->log = $log;
+
+        return $this;
+    }
+
+    public function hasCors(): bool
+    {
+        return $this->cors;
+    }
+
+    public function setCors($flag): MockServerConfigInterface
+    {
+        if ($flag === 'true') {
+            $this->cors = true;
+        } elseif ($flag === 'false') {
+            $this->cors = false;
+        } else {
+            $this->cors = (bool) $flag;
+        }
 
         return $this;
     }

--- a/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
@@ -122,4 +122,16 @@ interface MockServerConfigInterface
      * @return MockServerConfigInterface
      */
     public function setLog(string $log): self;
+
+    /**
+     * @return bool
+     */
+    public function hasCors(): bool;
+
+    /**
+     * @param bool|string $flag
+     *
+     * @return MockServerConfigInterface
+     */
+    public function setCors($flag): self;
 }

--- a/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
@@ -22,7 +22,8 @@ class MockServerEnvConfig extends MockServerConfig
             ->setPort($this->parseEnv('PACT_MOCK_SERVER_PORT'))
             ->setConsumer($this->parseEnv('PACT_CONSUMER_NAME'))
             ->setProvider($this->parseEnv('PACT_PROVIDER_NAME'))
-            ->setPactDir($this->parseEnv('PACT_OUTPUT_DIR', false));
+            ->setPactDir($this->parseEnv('PACT_OUTPUT_DIR', false))
+            ->setCors($this->parseEnv('PACT_CORS', false));
     }
 
     /**
@@ -37,13 +38,21 @@ class MockServerEnvConfig extends MockServerConfig
      */
     private function parseEnv(string $variableName, bool $required = true)
     {
-        if (\getenv($variableName) !== false) {
-            return \getenv($variableName);
+        $result = null;
+
+        if (\getenv($variableName) === 'false') {
+            $result = false;
+        } elseif (\getenv($variableName) === 'true') {
+            $result = true;
         }
-        if ($required === true) {
+        if (\getenv($variableName) !== false) {
+            $result = \getenv($variableName);
+        }
+
+        if ($required === true && $result === null) {
             throw new MissingEnvVariableException($variableName);
         }
 
-        return null;
+        return $result;
     }
 }

--- a/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
@@ -16,6 +16,7 @@ class MockServerConfigTest extends TestCase
         $pactDir                  = 'test-pact-dir/';
         $pactFileWriteMode        = 'merge';
         $log                      = 'test-log-dir/';
+        $cors                     = true;
         $pactSpecificationVersion = 2.0;
 
         $subject = (new MockServerConfig)
@@ -26,7 +27,8 @@ class MockServerConfigTest extends TestCase
             ->setPactDir($pactDir)
             ->setPactFileWriteMode($pactFileWriteMode)
             ->setLog($log)
-            ->setPactSpecificationVersion($pactSpecificationVersion);
+            ->setPactSpecificationVersion($pactSpecificationVersion)
+            ->setCors($cors);
 
         static::assertSame($host, $subject->getHost());
         static::assertSame($port, $subject->getPort());
@@ -36,5 +38,6 @@ class MockServerConfigTest extends TestCase
         static::assertSame($pactFileWriteMode, $subject->getPactFileWriteMode());
         static::assertSame($log, $subject->getLog());
         static::assertSame($pactSpecificationVersion, $subject->getPactSpecificationVersion());
+        static::assertSame($cors, $subject->hasCors());
     }
 }

--- a/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
+++ b/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
@@ -157,6 +157,7 @@ class MockServerHttpServiceTest extends TestCase
 
         $body = $response->getBody()->getContents();
         $this->assertEquals(\json_encode($expectedResponseBody), $body);
+        $this->assertEquals($response->getHeaderLine('Access-Control-Allow-Origin'), '*', 'CORS flag not set properly');
         $this->assertEquals(200, $response->getStatusCode());
     }
 


### PR DESCRIPTION
Enables the support of the header `Access-Control-Allow-Origin` setting.