### PR TITLE
use phar distribution of php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     "require-dev": {
         "roave/security-advisories": "dev-master",
         "phpunit/phpunit": "^6.4",
-        "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
-        "slim/slim": "^3.9"
+        "slim/slim": "^3.9",
+        "tm/tooly-composer-script": "^1.2"
     },
     "autoload": {
         "psr-4": {
@@ -53,10 +53,23 @@
         }
     },
     "scripts": {
-        "post-update-cmd": "\\PhpPact\\Standalone\\Installer\\InstallManager::uninstall",
+        "post-install-cmd": [
+            "\\Tooly\\ScriptHandler::installPharTools"
+        ],
+        "post-update-cmd": [
+            "\\Tooly\\ScriptHandler::installPharTools",
+            "\\PhpPact\\Standalone\\Installer\\InstallManager::uninstall"
+        ],
         "start-provider": "php -S localhost:58000 -t example/src/Provider/public/",
-        "lint": "php-cs-fixer fix --config .php_cs --dry-run",
-        "fix": "php-cs-fixer fix --config .php_cs",
+        "lint": "php-cs-fixer.phar fix --config .php_cs --dry-run",
+        "fix": "php-cs-fixer.phar fix --config .php_cs",
         "test": "phpunit --debug"
+    },
+    "extra": {
+        "tools": {
+            "php-cs-fixer": {
+                "url": "http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"
+            }
+        }
     }
 }


### PR DESCRIPTION
Another step towards symfony 2.x support. `php-cs-fixer` has dependencies on symfony 3.x . By using phar instead dependencies are not being leaked to the overall library. This PR includes [tm/tooly-composer-script](https://github.com/tommy-muehle/tooly-composer-script) which actually just installs the same phar in the end of the composer command.

I've also updated composer scripts to use local phpunit and php-cs-fixer instead of global one

PS It looks like `composer fix` haven't been run for a while, but I leave it up to maintainers to define/revisit CS rules and CI pipeline for it