### PR TITLE
symfony backward compatibility support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "php": "^7.0",
         "ext-openssl": "*",
-        "symfony/process": "^3.3 || ^4.0",
-        "symfony/filesystem": "^3.0 || ^4.0",
+        "symfony/process": ">=2.8 <4.1",
+        "symfony/filesystem": ">=2.8 <4.1",
         "guzzlehttp/guzzle": "^6.3",
-        "symfony/console": "^3.3 || ^4.0"
+        "symfony/console": ">=2.8 <4.1"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     "require-dev": {
         "roave/security-advisories": "dev-master",
         "phpunit/phpunit": "^6.4",
-        "friendsofphp/php-cs-fixer": "^2.10",
         "mockery/mockery": "^1.0",
-        "slim/slim": "^3.9"
+        "slim/slim": "^3.9",
+        "tm/tooly-composer-script": "^1.2"
     },
     "autoload": {
         "psr-4": {
@@ -53,10 +53,23 @@
         }
     },
     "scripts": {
-        "post-update-cmd": "\\PhpPact\\Standalone\\Installer\\InstallManager::uninstall",
+        "post-install-cmd": [
+            "\\Tooly\\ScriptHandler::installPharTools"
+        ],
+        "post-update-cmd": [
+            "\\Tooly\\ScriptHandler::installPharTools",
+            "\\PhpPact\\Standalone\\Installer\\InstallManager::uninstall"
+        ],
         "start-provider": "php -S localhost:58000 -t example/src/Provider/public/",
-        "lint": "php-cs-fixer fix --config .php_cs --dry-run",
-        "fix": "php-cs-fixer fix --config .php_cs",
+        "lint": "php-cs-fixer.phar fix --config .php_cs --dry-run",
+        "fix": "php-cs-fixer.phar fix --config .php_cs",
         "test": "phpunit --debug"
+    },
+    "extra": {
+        "tools": {
+            "php-cs-fixer": {
+                "url": "http://cs.sensiolabs.org/download/php-cs-fixer-v2.phar"
+            }
+        }
     }
 }

--- a/src/PhpPact/Standalone/MockService/MockServer.php
+++ b/src/PhpPact/Standalone/MockService/MockServer.php
@@ -13,6 +13,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Ruby Standalone Mock Server Wrapper
@@ -55,7 +56,8 @@ class MockServer
     {
         $scripts = $this->installManager->install();
 
-        $this->process = new Process(\array_merge([$scripts->getMockService()], $this->getArguments()));
+        $this->process = ProcessBuilder::create(\array_merge(['exec', $scripts->getMockService()], $this->getArguments()))
+            ->getProcess();
         $this->process
             ->setTimeout(600)
             ->setIdleTimeout(60);

--- a/src/PhpPact/Standalone/MockService/MockServer.php
+++ b/src/PhpPact/Standalone/MockService/MockServer.php
@@ -9,11 +9,11 @@ use PhpPact\Standalone\Exception\HealthCheckFailedException;
 use PhpPact\Standalone\Installer\InstallManager;
 use PhpPact\Standalone\Installer\Service\InstallerInterface;
 use PhpPact\Standalone\MockService\Service\MockServerHttpService;
+use PhpPact\Standalone\Runner\ProcessRunner;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Ruby Standalone Mock Server Wrapper
@@ -56,8 +56,7 @@ class MockServer
     {
         $scripts = $this->installManager->install();
 
-        $this->process = ProcessBuilder::create(\array_merge(['exec', $scripts->getMockService()], $this->getArguments()))
-            ->getProcess();
+        $this->process = ProcessRunner::run($scripts->getMockService(), $this->getArguments());
         $this->process
             ->setTimeout(600)
             ->setIdleTimeout(60);

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -3,7 +3,6 @@
 namespace PhpPact\Standalone\Runner;
 
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Wrapper around Process with backwards-compatibility support.
@@ -30,7 +29,7 @@ class ProcessRunner
         if ($useProcess) {
             $process = new Process(\array_merge([$command], $arguments));
         } else {
-            $pb      = new ProcessBuilder(\array_merge([$command], $arguments));
+            $pb      = new \Symfony\Component\Process\ProcessBuilder(\array_merge([$command], $arguments));
             //see https://symfony.com/doc/current/components/process.html#process-signals
             if (self::isPosixPlatform()) {
                 $pb->setPrefix('exec');

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace PhpPact\Standalone\Runner;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+/**
+ * Wrapper around Process with backwards-compatibility support.
+ * Can be replaced with usual Process as soon as symfony 2.x support is dropped
+ *
+ * @see https://symfony.com/doc/current/components/process.html#process-signals for POSIX workaround
+ * @see https://github.com/symfony/symfony/pull/21474 how it works in symfony/process ^3.3
+ * @see Process
+ */
+class ProcessRunner
+{
+    public static function run(string $command, array $arguments): Process
+    {
+        // ProcessBuilder is deprecated in symfony/process version 3.4,
+        // but Process doesn't accept an array of arguments in versions <3.3,
+        // in which ProcessUtils::escapeArgument() is not marked as deprecated
+        $useProcess = true;
+        if (\method_exists('Symfony\Component\Process\ProcessUtils', 'escapeArgument')) {
+            $r = new \ReflectionMethod('Symfony\Component\Process\ProcessUtils', 'escapeArgument');
+            if ($r->isPublic() && false === \strpos($r->getDocComment(), '@deprecated')) {
+                $useProcess = false;
+            }
+        }
+        if ($useProcess) {
+            $process = new Process(\array_merge([$command], $arguments));
+        } else {
+            $pb      = new ProcessBuilder(\array_merge([$command], $arguments));
+            //see https://symfony.com/doc/current/components/process.html#process-signals
+            if (self::isPosixPlatform()) {
+                $pb->setPrefix('exec');
+            }
+            $process = $pb->getProcess();
+        }
+
+        return $process;
+    }
+
+    private static function isPosixPlatform(): bool
+    {
+        return DIRECTORY_SEPARATOR === '/';
+    }
+}

--- a/src/PhpPact/Standalone/StubService/StubServer.php
+++ b/src/PhpPact/Standalone/StubService/StubServer.php
@@ -9,6 +9,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Ruby Standalone Stub Server Wrapper
@@ -51,7 +52,9 @@ class StubServer
     {
         $scripts = $this->installManager->install();
 
-        $this->process = new Process(\array_merge([$scripts->getStubService()], $this->getArguments()));
+        $this->process = ProcessBuilder::create(\array_merge(['exec', $scripts->getMockService()], $this->getArguments()))
+            ->getProcess();
+
         $this->process
             ->setTimeout(600)
             ->setIdleTimeout(60);

--- a/src/PhpPact/Standalone/StubService/StubServer.php
+++ b/src/PhpPact/Standalone/StubService/StubServer.php
@@ -5,11 +5,11 @@ namespace PhpPact\Standalone\StubService;
 use Exception;
 use PhpPact\Standalone\Installer\InstallManager;
 use PhpPact\Standalone\Installer\Service\InstallerInterface;
+use PhpPact\Standalone\Runner\ProcessRunner;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 
 /**
  * Ruby Standalone Stub Server Wrapper
@@ -52,8 +52,7 @@ class StubServer
     {
         $scripts = $this->installManager->install();
 
-        $this->process = ProcessBuilder::create(\array_merge(['exec', $scripts->getMockService()], $this->getArguments()))
-            ->getProcess();
+        $this->process = ProcessRunner::run($scripts->getStubService(), $this->getArguments());
 
         $this->process
             ->setTimeout(600)


### PR DESCRIPTION
Depends on #68 

In the end it was about replacing `Process` with `ProcessBuilder`. Other than that works smoothly.

WIP until #68 is merged and I have settled out proper travis setup for symfony 2.x/3.x/4.x components