### PR TITLE
Added new matchers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,21 @@ Matcher | Explanation | Parameters | Example
 ---|---|---|---
 term | Match a value against a regex pattern. | Value, Regex Pattern | $matcher->term('Hello, Bob', '(Hello, )[A-Za-z]')
 regex | Alias to term matcher. | Value, Regex Pattern | $matcher->regex('Hello, Bob', '(Hello, )[A-Za-z]')
-dateISO8601 | Regex match a date using the ISO8601 format. Example: 2010-01-01 | Value | $matcher->dateISO8601('2010-01-01')
+dateISO8601 | Regex match a date using the ISO8601 format. | Value (Defaults to 2010-01-01) | $matcher->dateISO8601('2010-01-01')
+timeISO8601 | Regex match a time using the ISO8601 format. | Value (Defaults to T22:44:30.652Z) | $matcher->timeISO8601('T22:44:30.652Z')
+dateTimeISO8601 | Regex match a datetime using the ISO8601 format. | Value (Defaults to 2015-08-06T16:53:10+01:00) | $matcher->dateTimeISO8601('2015-08-06T16:53:10+01:00')
+dateTimeWithMillisISO8601 | Regex match a datetime with millis using the ISO8601 format. | Value (Defaults to 2015-08-06T16:53:10.123+01:00) | $matcher->dateTimeWithMillisISO8601('2015-08-06T16:53:10.123+01:00')
+timestampRFC3339 | Regex match a timestamp using the RFC3339 format. | Value (Defaults to Mon, 31 Oct 2016 15:21:41 -0400) | $matcher->timestampRFC3339('Mon, 31 Oct 2016 15:21:41 -0400')
 like | Match a value against its data type. | Value | $matcher->like(12)
+somethingLike | Alias to like matcher. | Value | $matcher->somethingLike(12)
 eachLike | Match on an object like the example. | Value, Min (Defaults to 1) | $matcher->eachLike(12)
+boolean | Match against boolean true. | none | $matcher->boolean()
+integer | Match a value against integer. | Value (Defaults to 13) | $matcher->integer()
+decimal | Match a value against float. | Value (Defaults to 13.01) | $matcher->decimal()
+hexadecimal | Regex to match a hexadecimal number. Example: 3F | Value (Defaults to 3F) | $matcher->hexadecimal('FF')
+uuid | Regex to match a uuid. | Value (Defaults to ce118b6e-d8e1-11e7-9296-cec278b6b50a) | $matcher->uuid('ce118b6e-d8e1-11e7-9296-cec278b6b50a')
+ipv4Address | Regex to match a ipv4 address. | Value (Defaults to 127.0.0.13) | $matcher->ipv4Address('127.0.0.1')
+ipv4Address | Regex to match a ipv6 address. | Value (Defaults to ::ffff:192.0.2.128) | $matcher->ipv6Address('::ffff:192.0.2.1')
 
 ### Build the Interaction
 

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -9,6 +9,25 @@ namespace PhpPact\Consumer\Matcher;
 class Matcher
 {
     const ISO8601_DATE_FORMAT = '^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)$';
+    const ISO8601_DATETIME_FORMAT = '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$';
+    const ISO8601_DATETIME_WITH_MILLIS_FORMAT = '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3}([+-][0-2]\\d:[0-5]\\d|Z)$';
+    const ISO8601_TIME_FORMAT = '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$';
+    const RFC3339_TIMESTAMP_FORMAT = '^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s\\d{2}\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s(\\+|-)\\d{4}$';
+    const UUID_V4_FORMAT = '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$';
+    const IPV4_FORMAT = '^(\\d{1,3}\\.)+\\d{1,3}$';
+    const IPV6_FORMAT = '^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$';
+    const HEX_FORMAT = '^[0-9a-fA-F]+$';
+
+    /**
+     * Alias for the `like()` function.
+     * @param $value
+     * @return array
+     * @throws \Exception
+     */
+    public function somethingLike($value): array
+    {
+        return $this->like($value);
+    }
 
     /**
      * @param mixed $value example of what the expected data would be
@@ -24,7 +43,7 @@ class Matcher
         }
 
         return [
-            'contents'   => $value,
+            'contents' => $value,
             'json_class' => 'Pact::SomethingLike'
         ];
     }
@@ -33,20 +52,18 @@ class Matcher
      * Expect an array of similar data as the value passed in.
      *
      * @param mixed $value example of what the expected data would be
-     * @param int   $min   minimum number of objects to verify against
+     * @param int $min minimum number of objects to verify against
      *
      * @return array
      */
-    public function eachLike($value, int $min = null): array
+    public function eachLike($value, int $min = 1): array
     {
         $result = [
-            'contents'   => $value,
+            'contents' => $value,
             'json_class' => 'Pact::ArrayLike'
         ];
 
-        if ($min !== null) {
-            $result['min'] = $min;
-        }
+        $result['min'] = $min;
 
         return $result;
     }
@@ -54,7 +71,7 @@ class Matcher
     /**
      * Validate that a value will match a regex pattern.
      *
-     * @param mixed  $value   example of what the expected data would be
+     * @param mixed $value example of what the expected data would be
      * @param string $pattern valid Ruby regex pattern
      *
      * @throws \Exception
@@ -74,10 +91,10 @@ class Matcher
         return [
             'data' => [
                 'generate' => $value,
-                'matcher'  => [
+                'matcher' => [
                     'json_class' => 'Regexp',
-                    'o'          => 0,
-                    's'          => $pattern
+                    'o' => 0,
+                    's' => $pattern
                 ]
             ],
             'json_class' => 'Pact::Term'
@@ -108,8 +125,122 @@ class Matcher
      *
      * @return array
      */
-    public function dateISO8601(string $value): array
+    public function dateISO8601(string $value = '2013-02-01'): array
     {
         return $this->term($value, self::ISO8601_DATE_FORMAT);
+    }
+
+    /**
+     * ISO8601 Time Matcher, matches a pattern of the format "'T'HH:mm:ss".
+     *
+     * @param string $value
+     * @return array
+     * @throws \Exception
+     */
+    public function timeISO8601(string $value = 'T22:44:30.652Z'): array
+    {
+        return $this->term($value, self::ISO8601_TIME_FORMAT);
+    }
+
+    /**
+     * ISO8601 DateTime matcher.
+     * @param string $value
+     * @return array
+     * @throws \Exception
+     */
+    public function dateTimeISO8601(string $value = '2015-08-06T16:53:10+01:00'): array
+    {
+        return $this->term($value, self::ISO8601_DATETIME_FORMAT);
+    }
+
+    /**
+     * ISO8601 DateTime matcher with required millisecond precision
+     * @param string $value
+     * @return array
+     * @throws \Exception
+     */
+    public function dateTimeWithMillisISO8601(string $value = '2015-08-06T16:53:10.123+01:00'): array
+    {
+        return $this->term($value, self::ISO8601_DATETIME_WITH_MILLIS_FORMAT);
+    }
+
+    /**
+     * RFC3339 Timestamp matcher, a subset of ISO8609
+     * @param string $value
+     * @return array
+     * @throws \Exception
+     */
+    public function timestampRFC3339(string $value = 'Mon, 31 Oct 2016 15:21:41 -0400'): array
+    {
+        return $this->term($value, self::RFC3339_TIMESTAMP_FORMAT);
+    }
+
+    /**
+     * @return array
+     * @throws \Exception
+     */
+    public function boolean(): array
+    {
+        return $this->like(true);
+    }
+
+    /**
+     * @param int $int
+     * @return array
+     * @throws \Exception
+     */
+    public function integer(int $int = 13): array
+    {
+        return $this->like($int);
+    }
+
+    /**
+     * @param float $float
+     * @return array
+     * @throws \Exception
+     */
+    public function decimal(float $float = 13.01): array
+    {
+        return $this->like($float);
+    }
+
+    /**
+     * @param string $hex
+     * @return array
+     * @throws \Exception
+     */
+    public function hexadecimal(string $hex = '3F'): array
+    {
+        return $this->term($hex, self::HEX_FORMAT);
+    }
+
+    /**
+     * @param string $uuid
+     * @return array
+     * @throws \Exception
+     */
+    public function uuid(string $uuid = 'ce118b6e-d8e1-11e7-9296-cec278b6b50a'): array
+    {
+        return $this->term($uuid, self::UUID_V4_FORMAT);
+    }
+
+    /**
+     * @param string $ip
+     * @return array
+     * @throws \Exception
+     */
+    public function ipv4Address(string $ip = '127.0.0.13'): array
+    {
+        return $this->term($ip, self::IPV4_FORMAT);
+    }
+
+    /**
+     * @param string $ip
+     * @return array
+     * @throws \Exception
+     */
+    public function ipv6Address(string $ip = '::ffff:192.0.2.128'): array
+    {
+        return $this->term($ip, self::IPV6_FORMAT);
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -139,4 +139,202 @@ class MatcherTest extends TestCase
 
         $this->assertEquals($expected, $actual);
     }
+
+    /**
+     * @throws Exception
+     */
+    public function testTime()
+    {
+        $expected = [
+            'data' => [
+                'generate' => 'T22:44:30.652Z',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $actual = $this->matcher->timeISO8601('T22:44:30.652Z');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testDateTime()
+    {
+        $expected = [
+            'data' => [
+                'generate' => '2015-08-06T16:53:10+01:00',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $actual = $this->matcher->dateTimeISO8601('2015-08-06T16:53:10+01:00');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testDateTimeWithMillis()
+    {
+        $expected = [
+            'data' => [
+                'generate' => '2015-08-06T16:53:10.123+01:00',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3}([+-][0-2]\\d:[0-5]\\d|Z)$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $actual = $this->matcher->dateTimeWithMillisISO8601('2015-08-06T16:53:10.123+01:00');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testTimestampRFC3339()
+    {
+        $expected = [
+            'data' => [
+                'generate' => 'Mon, 31 Oct 2016 15:21:41 -0400',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s\\d{2}\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s(\\+|-)\\d{4}$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $actual = $this->matcher->timestampRFC3339('Mon, 31 Oct 2016 15:21:41 -0400');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testInteger()
+    {
+        $json = \json_encode($this->matcher->integer());
+
+        $this->assertEquals('{"contents":13,"json_class":"Pact::SomethingLike"}', $json);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testBoolean()
+    {
+        $json = \json_encode($this->matcher->boolean());
+
+        $this->assertEquals('{"contents":true,"json_class":"Pact::SomethingLike"}', $json);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testDecimal()
+    {
+        $json = \json_encode($this->matcher->decimal());
+
+        $this->assertEquals('{"contents":13.01,"json_class":"Pact::SomethingLike"}', $json);
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testHexadecimal()
+    {
+        $expected = [
+            'data' => [
+                'generate' => '3F',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^[0-9a-fA-F]+$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $this->assertEquals($expected, $this->matcher->hexadecimal());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testUuid()
+    {
+        $expected = [
+            'data' => [
+                'generate' => 'ce118b6e-d8e1-11e7-9296-cec278b6b50a',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $this->assertEquals($expected, $this->matcher->uuid());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testIpv4Address()
+    {
+        $expected = [
+            'data' => [
+                'generate' => '127.0.0.13',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^(\\d{1,3}\\.)+\\d{1,3}$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $this->assertEquals($expected, $this->matcher->ipv4Address());
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function testIpv6Address()
+    {
+        $expected = [
+            'data' => [
+                'generate' => '::ffff:192.0.2.128',
+                'matcher'  => [
+                    'json_class' => 'Regexp',
+                    'o'          => 0,
+                    's'          => '^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$'
+                ]
+            ],
+            'json_class' => 'Pact::Term'
+        ];
+
+        $this->assertEquals($expected, $this->matcher->ipv6Address());
+    }
 }


### PR DESCRIPTION
Added following new matchers:

Matcher | Explanation | Parameters | Example
---|---|---|---
timeISO8601 | Regex match a time using the ISO8601 format. | Value (Defaults to T22:44:30.652Z) | $matcher->timeISO8601('T22:44:30.652Z')
dateTimeISO8601 | Regex match a datetime using the ISO8601 format. | Value (Defaults to 2015-08-06T16:53:10+01:00) | $matcher->dateTimeISO8601('2015-08-06T16:53:10+01:00')
dateTimeWithMillisISO8601 | Regex match a datetime with millis using the ISO8601 format. | Value (Defaults to 2015-08-06T16:53:10.123+01:00) | $matcher->dateTimeWithMillisISO8601('2015-08-06T16:53:10.123+01:00')
timestampRFC3339 | Regex match a timestamp using the RFC3339 format. | Value (Defaults to Mon, 31 Oct 2016 15:21:41 -0400) | $matcher->timestampRFC3339('Mon, 31 Oct 2016 15:21:41 -0400')
somethingLike | Alias to like matcher. | Value | $matcher->somethingLike(12)
boolean | Match against boolean true. | none | $matcher->boolean()
integer | Match a value against integer. | Value (Defaults to 13) | $matcher->integer()
decimal | Match a value against float. | Value (Defaults to 13.01) | $matcher->decimal()
hexadecimal | Regex to match a hexadecimal number. Example: 3F | Value (Defaults to 3F) | $matcher->hexadecimal('FF')
uuid | Regex to match a uuid. | Value (Defaults to ce118b6e-d8e1-11e7-9296-cec278b6b50a) | $matcher->uuid('ce118b6e-d8e1-11e7-9296-cec278b6b50a')
ipv4Address | Regex to match a ipv4 address. | Value (Defaults to 127.0.0.13) | $matcher->ipv4Address('127.0.0.1')
ipv4Address | Regex to match a ipv6 address. | Value (Defaults to ::ffff:192.0.2.128) | $matcher->ipv6Address('::ffff:192.0.2.1')
