### PR TITLE
do not override current php platform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,6 @@
             "email": "nick.brink@mattersight.com"
         }
     ],
-    "config": {
-        "platform": {
-            "php": "7.0"
-        }
-    },
     "require": {
         "php": "^7.0",
         "ext-openssl": "*",


### PR DESCRIPTION
Follow up from https://github.com/pact-foundation/pact-php/pull/69#issuecomment-387530001 

Enables installing symfony 4.x components in CI as well