### PR TITLE
Loosen symfony/console version bounds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/filesystem": ">=2.8 <4.1",
         "composer/semver": "1.4.2",
         "guzzlehttp/guzzle": "^6.3",
-        "symfony/console": ">=2.8 <4.1",
+        "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "amphp/socket": "^0.10.9",
         "amphp/process": "^0.3.3",
         "amphp/http-server": "^0.8.2",


### PR DESCRIPTION
Since symfony/console uses [semver](https://semver.org/), it's best to use the composer `^` operator instead of strict upper bounds on version.
This allows this library to play nice with other libraries requiring symfony/console versions 4.1 and 4.2

See:
https://getcomposer.org/doc/faqs/why-are-unbound-version-constraints-a-bad-idea.md