### PR TITLE
make health check timeout of mock server configurable

### DIFF
--- a/example/phpunit.consumer.xml
+++ b/example/phpunit.consumer.xml
@@ -24,6 +24,7 @@
         <env name="PACT_CONSUMER_TAG" value="master"/>
         <env name="PACT_PROVIDER_NAME" value="someProvider"/>
         <env name="PACT_OUTPUT_DIR" value=".\example\output"/>
+        <env name="PACT_MOCK_SERVER_HEALTH_CHECK_TIMEOUT" value="10"/>
         <!-- <env name="PACT_BROKER_URI" value="http://localhost"/> -->
     </php>
 </phpunit>

--- a/src/PhpPact/Standalone/MockService/MockServerConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfig.php
@@ -81,6 +81,13 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
     private $cors = false;
 
     /**
+     * The max allowed time the mock server has to be available in. Otherwise it is considered as sick.
+     *
+     * @var int
+     */
+    private $healthCheckTimeout;
+
+    /**
      * {@inheritdoc}
      */
     public function getHost(): string
@@ -286,5 +293,23 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         }
 
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setHealthCheckTimeout($timeout): MockServerConfigInterface
+    {
+        $this->healthCheckTimeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getHealthCheckTimeout(): int
+    {
+        return $this->healthCheckTimeout;
     }
 }

--- a/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
@@ -74,4 +74,16 @@ interface MockServerConfigInterface
      * @return MockServerConfigInterface
      */
     public function setCors($flag): self;
+
+    /**
+     * @param int $timeout
+     *
+     * @return MockServerConfigInterface
+     */
+    public function setHealthCheckTimeout($timeout): self;
+
+    /**
+     * @return int
+     */
+    public function getHealthCheckTimeout(): int;
 }

--- a/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
@@ -27,6 +27,12 @@ class MockServerEnvConfig extends MockServerConfig
             ->setPactDir($this->parseEnv('PACT_OUTPUT_DIR', false))
             ->setCors($this->parseEnv('PACT_CORS', false));
 
+        $timeout = $this->parseEnv('PACT_MOCK_SERVER_HEALTH_CHECK_TIMEOUT', false);
+        if (!$timeout) {
+            $timeout = 10;
+        }
+        $this->setHealthCheckTimeout($timeout);
+
         $version = $this->parseEnv('PACT_SPECIFICATION_VERSION', false);
         if (!$version) {
             $version = static::DEFAULT_SPECIFICATION_VERSION;

--- a/tests/PhpPact/Standalone/MockServer/MockServerTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerTest.php
@@ -2,9 +2,12 @@
 
 namespace PhpPact\Consumer;
 
+use GuzzleHttp\Exception\ConnectException;
+use PhpPact\Standalone\Exception\HealthCheckFailedException;
 use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Standalone\MockService\MockServer;
 use PhpPact\Standalone\MockService\MockServerEnvConfig;
+use PhpPact\Standalone\MockService\Service\MockServerHttpService;
 use PHPUnit\Framework\TestCase;
 
 class MockServerTest extends TestCase
@@ -22,6 +25,44 @@ class MockServerTest extends TestCase
         } finally {
             $result = $mockServer->stop();
             $this->assertTrue($result);
+        }
+    }
+
+    /**
+     * @throws MissingEnvVariableException
+     * @throws \Exception
+     */
+    public function testStartAndStopWithRecognizedTimeout()
+    {
+        // the mock server actually takes more than one second to be ready
+        // we use this fact to test the timeout
+        $orig = \getenv('PACT_MOCK_SERVER_HEALTH_CHECK_TIMEOUT');
+        \putenv('PACT_MOCK_SERVER_HEALTH_CHECK_TIMEOUT=1');
+
+        $httpService = $this->getMockBuilder(MockServerHttpService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connectionException = $this->getMockBuilder(ConnectException::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        // take sth lower than the default value
+        $httpService->expects($this->atMost(5))
+            ->method('healthCheck')
+            ->will($this->returnCallback(function () use ($connectionException) {
+                throw $connectionException;
+            }));
+
+        try {
+            $mockServer = new MockServer(new MockServerEnvConfig(), $httpService);
+            $mockServer->start();
+            $this->fail('MockServer should not pass defined health check.');
+        } catch (HealthCheckFailedException $e) {
+            $this->assertTrue(true);
+        } finally {
+            $mockServer->stop();
+            \putenv('PACT_MOCK_SERVER_HEALTH_CHECK_TIMEOUT=' . $orig);
         }
     }
 }


### PR DESCRIPTION
In my local setup I am not able to start the MockServer within 10 retries/seconds. It takes about 12-14 seconds.
After I patch the allowed timeout in the health check directly everything works as expected.

For better stability I want to define this timeout on my own. Other ppl out there probably too.
Therefore I introduced the env var `PACT_MOCK_SERVER_HEALTH_CHECK_TIMEOUT`. When this env var is not set the timeout the used timeout of 10 retries/seconds is used.