### PR TITLE
Fix broker request when all consumer urls should be fetched

### DIFF
--- a/src/PhpPact/Broker/Service/BrokerHttpClient.php
+++ b/src/PhpPact/Broker/Service/BrokerHttpClient.php
@@ -66,7 +66,11 @@ class BrokerHttpClient implements BrokerHttpClientInterface
      */
     public function getAllConsumerUrls(string $provider, string $version = 'latest'): array
     {
-        $uri = $this->baseUri->withPath("/pacts/provider/{$provider}/{$version}");
+        if ($version !== 'latest') {
+            @\trigger_error(\sprintf('The second argument "version" in "%s()" method makes no sense and will be removed in any upcoming major version', __METHOD__), E_USER_DEPRECATED);
+        }
+
+        $uri = $this->baseUri->withPath("/pacts/provider/{$provider}/latest");
 
         $response = $this->httpClient->get($uri, [
             'headers' => [

--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -11,7 +11,6 @@ use PhpPact\Standalone\Installer\InstallManager;
 use PhpPact\Standalone\Installer\Service\InstallerInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\VerifierConfigInterface;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use Symfony\Component\Process\Process;
 
 /**
  * Wrapper for the Ruby Standalone Verifier service.
@@ -37,13 +36,22 @@ class Verifier
     /** @var ConsoleOutput */
     protected $console;
 
-    public function __construct(VerifierConfigInterface $config)
-    {
+    public function __construct(
+        VerifierConfigInterface $config,
+        InstallManager $installManager = null,
+        VerifierProcess $verifierProcess = null,
+        BrokerHttpClient $brokerHttpClient = null
+    ) {
         $this->config             = $config;
-        $this->installManager     = new InstallManager();
+        $this->installManager     = $installManager?: new InstallManager();
         $this->console            = new ConsoleOutput();
+        $this->verifierProcess    = $verifierProcess?: new VerifierProcess($this->installManager, $this->console);
         $this->processTimeout     = $config->getProcessTimeout();
         $this->processIdleTimeout = $config->getProcessIdleTimeout();
+
+        if ($brokerHttpClient) {
+            $this->brokerHttpClient = $brokerHttpClient;
+        }
     }
 
     /**
@@ -154,7 +162,7 @@ class Verifier
      */
     public function verifyAll()
     {
-        $arguments = $this->getBrokerHttpClient()->getAllConsumerUrls($this->config->getProviderName(), $this->config->getProviderVersion());
+        $arguments = $this->getBrokerHttpClient()->getAllConsumerUrls($this->config->getProviderName());
 
         $arguments = \array_merge($arguments, $this->getArguments());
 
@@ -198,7 +206,7 @@ class Verifier
     }
 
     /**
-     * Execute the Pact Verifier Service.
+     * Trigger execution of the Pact Verifier Service.
      *
      * @param array $arguments
      *
@@ -207,25 +215,7 @@ class Verifier
      */
     protected function verifyAction(array $arguments)
     {
-        $scripts = $this->installManager->install();
-
-        $arguments = \array_merge([$scripts->getProviderVerifier()], $arguments);
-
-        $process = new Process($arguments, null, null, null, $this->processTimeout);
-        $process->setIdleTimeout($this->processIdleTimeout);
-
-        $cmd = $process->getCommandLine();
-
-        // handle deps=low requirements
-        if (\is_array($cmd)) {
-            $cmd = \implode(' ', $cmd);
-        }
-
-        $this->console->write("Verifying PACT with script:\n{$cmd}\n\n");
-
-        $process->mustRun(function ($type, $buffer) {
-            $this->console->write("{$type} > {$buffer}");
-        });
+        $this->verifierProcess->run($arguments, $this->processTimeout, $this->processIdleTimeout);
     }
 
     protected function getBrokerHttpClient(): BrokerHttpClient

--- a/src/PhpPact/Standalone/ProviderVerifier/VerifierProcess.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/VerifierProcess.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier;
+
+use PhpPact\Standalone\Installer\InstallManager;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Process\Process;
+
+class VerifierProcess
+{
+    /**
+     * @var InstallManager
+     */
+    private $installManager;
+
+    /**
+     * @var ConsoleOutput
+     */
+    private $output;
+
+    /**
+     * VerifierProcess constructor.
+     *
+     * @param null|InstallManager         $installManager
+     * @param null|ConsoleOutputInterface $output
+     */
+    public function __construct(InstallManager $installManager, ConsoleOutputInterface $output)
+    {
+        $this->installManager = $installManager;
+        $this->output         = $output;
+    }
+
+    /**
+     * Execute the Pact Verifier Service.
+     *
+     * @param array $arguments
+     * @param int   $processTimeout
+     * @param int   $processIdleTimeout
+     *
+     * @throws \PhpPact\Standalone\Installer\Exception\FileDownloadFailureException
+     * @throws \PhpPact\Standalone\Installer\Exception\NoDownloaderFoundException
+     */
+    public function run(array $arguments, $processTimeout, $processIdleTimeout)
+    {
+        $scripts = $this->installManager->install();
+
+        $arguments = \array_merge([$scripts->getProviderVerifier()], $arguments);
+
+        $process = new Process($arguments, null, null, null, $processTimeout);
+        $process->setIdleTimeout($processIdleTimeout);
+
+        $cmd = $process->getCommandLine();
+
+        // handle deps=low requirements
+        if (\is_array($cmd)) {
+            $cmd = \implode(' ', $cmd);
+        }
+
+        $this->output->write("Verifying PACT with script:\n{$cmd}\n\n");
+
+        $process->mustRun(
+            function ($type, $buffer) {
+                $this->output->write("{$type} > {$buffer}");
+            }
+        );
+    }
+}

--- a/tests/PhpPact/Broker/Service/BrokerHttpClientTest.php
+++ b/tests/PhpPact/Broker/Service/BrokerHttpClientTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PhpPactTest\Broker\Service;
+
+use PhpPact\Broker\Service\BrokerHttpClient;
+use PhpPact\Http\ClientInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+
+class BrokerHttpClientTest extends TestCase
+{
+    public function testAllConsumerUrlsAreExtractedCorrectly()
+    {
+        $provider         = 'someProvider';
+        $expectedPath     = "/pacts/provider/{$provider}/latest";
+        $expectedContents = \json_encode(
+            [
+                '_links' => [
+                    'pacts' => [
+                        ['href' => 'pact-url-1'],
+                        ['href' => 'pact-url-2'],
+                    ],
+                ],
+            ]
+        );
+
+        $streamMock = $this->createMock(StreamInterface::class);
+        $streamMock->expects($this->once())
+            ->method('getContents')
+            ->will($this->returnValue($expectedContents));
+
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->expects($this->once())
+            ->method('getBody')
+            ->will($this->returnValue($streamMock));
+
+        $httpClientMock = $this->createMock(ClientInterface::class);
+        $httpClientMock->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($responseMock));
+
+        $uriMock = $this->createMock(UriInterface::class);
+        $uriMock->expects($this->once())
+            ->method('withPath')
+            ->with($this->equalTo($expectedPath))
+            ->will($this->returnValue($uriMock));
+
+        $broker = new BrokerHttpClient($httpClientMock, $uriMock);
+        $broker->getAllConsumerUrls($provider);
+    }
+}


### PR DESCRIPTION
This fixes the confirmed bug in https://github.com/pact-foundation/pact-php/issues/92.

It was not possible to fetch the existing pacts from the broker. [`Verifier::verifyAll`](https://github.com/pact-foundation/pact-php/blob/master/src/PhpPact/Standalone/ProviderVerifier/Verifier.php#L157) assigned always the provider version to the request for fetching the pacts. As a provider version might not exist on the broker yet this resulted in 404 in some cases.
However the provider version should only be used for the publishing process after the verification process.

Example:
```
# broken when verifyAll is done the first time
/pacts/provider/{provider}/1.0.0

# works ...
/pacts/provider/{provider}/latest
```

As I didn't want to introduce any BC break for this simple change I didn't remove the unneeded second argument in [`BrokerHttpClient::getAllConsumerUrls`](https://github.com/pact-foundation/pact-php/blob/master/src/PhpPact/Broker/Service/BrokerHttpClient.php#L67) but trigger a deprecated warning instead.

I did some refactoring on the Verifier class to be able to test it better. The Verifier is now a real wrapper and does no more the process handling. Process handling is done within a dedicated class now.

