### PR TITLE
Allow null providerState

### DIFF
--- a/src/PhpPact/Consumer/Model/Interaction.php
+++ b/src/PhpPact/Consumer/Model/Interaction.php
@@ -51,7 +51,7 @@ class Interaction implements \JsonSerializable
     /**
      * @return string
      */
-    public function getProviderState(): string
+    public function getProviderState(): ?string
     {
         return $this->providerState;
     }


### PR DESCRIPTION
Not setting the providerState should be valid and that means the `getProviderState()` signature needs to change.

If not set, the providerState property will be omitted from the interaction as expected.

In my case there are a lot of cases where no provider state is needed (and not provided) - the service is written in Java and there is no requirement to have a `@State` annotation in order to run provider tests...