### PR TITLE
make latest Symfony 4 components installable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
     "require": {
         "php": "^7.1",
         "ext-openssl": "*",
-        "symfony/process": ">=3.3 <4.1",
-        "symfony/filesystem": ">=2.8 <4.1",
+        "symfony/process": "^3.3 || ^4.0",
+        "symfony/filesystem": "^2.8 || ^3.0 || ^4.0",
         "composer/semver": "1.4.2",
         "guzzlehttp/guzzle": "^6.3",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   broker_app:
     image: dius/pact-broker
     ports:
-      - "80:80"
+      - "8080:80"
     links:
       - postgres
     environment:

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,28 @@
+# Pact PHP Usage examples
+
+This folder contains some integration tests which demonstrate the functionality of `pact-php`.
+All examples could be run within tests.
+
+## Consumer Tests
+
+    docker-compose up -d 
+    vendor/bin/phpunit -c example/phpunit.consumer.xml
+    docker-compose down
+    
+## Provider Verification Tests
+
+    vendor/bin/phpunit -c example/phpunit.provider.xml
+    
+## Consumer Tests for Message Processing
+
+    vendor/bin/phpunit -c example/phpunit.message.consumer.xml
+
+## Provider Verification Tests for Message Processing
+
+    vendor/bin/phpunit -c example/phpunit.message.provider.xml
+    
+## All tests together 
+
+    docker-compose up -d 
+    vendor/bin/phpunit -c example/phpunit.all.xml
+    docker-compose down

--- a/example/phpunit.all.xml
+++ b/example/phpunit.all.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../vendor/autoload.php">
+<phpunit bootstrap="../vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="PhpPact Core Tests">
             <directory>../tests</directory>

--- a/example/phpunit.consumer.xml
+++ b/example/phpunit.consumer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../vendor/autoload.php">
+<phpunit bootstrap="../vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="PhpPact Example Tests">
             <directory>./tests/Consumer</directory>

--- a/example/phpunit.message.consumer.xml
+++ b/example/phpunit.message.consumer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../vendor/autoload.php">
+<phpunit bootstrap="../vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="PhpPact Example Tests">
             <directory>./tests/MessageConsumer</directory>

--- a/example/phpunit.message.provider.xml
+++ b/example/phpunit.message.provider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../vendor/autoload.php">
+<phpunit bootstrap="../vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="PhpPact Example Message Provider Tests">
             <directory>./tests/MessageProvider</directory>

--- a/example/phpunit.provider.xml
+++ b/example/phpunit.provider.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="../vendor/autoload.php">
+<phpunit bootstrap="../vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="PhpPact Provider Example Tests">
             <directory>./tests/Provider</directory>

--- a/example/src/Consumer/publish_json_example.php
+++ b/example/src/Consumer/publish_json_example.php
@@ -6,7 +6,7 @@ use PhpPact\Http\GuzzleClient;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
-$httpService = new BrokerHttpClient(new GuzzleClient(), new Uri('http://localhost:80/'));
+$httpService = new BrokerHttpClient(new GuzzleClient(), new Uri('http://localhost:8080/'));
 
 $json = \json_encode([
     'consumer' => 'someConsumer',

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./vendor/autoload.php">
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="PhpPact Core Test Suite">
             <directory>./tests/PhpPact</directory>


### PR DESCRIPTION
Currently it is not possible to install this library within a new Symfony 4 application (>= 4.1!). This has huge impact on the acceptance for this library in our company.
Besides I see no reason why the Symfony 4 components should be pinned to only < 4.0 and therefore I loose the requirements [once more](https://github.com/pact-foundation/pact-php/commit/527184daab0404a9380e2a277c5b08ae83795be4#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780).
All upcoming Symfony 4.* versions are installable now.

I run the integration tests in the `examples` directory to check if something broke, but everything looks good.

In addition I moved the pact-broker to port `:8080` as port `:80` is often already in use on a host machine.