### PR TITLE
configurable ssl configuration for broker

### DIFF
--- a/src/PhpPact/Consumer/Listener/PactTestListener.php
+++ b/src/PhpPact/Consumer/Listener/PactTestListener.php
@@ -111,6 +111,10 @@ class PactTestListener implements TestListener
                     ];
                 }
 
+                if (($sslVerify = \getenv('PACT_BROKER_SSL_VERIFY'))) {
+                    $clientConfig['verify'] = $sslVerify !== 'no';
+                }
+
                 $client = new GuzzleClient($clientConfig);
 
                 $brokerHttpService = new BrokerHttpClient($client, new Uri($pactBrokerUri));


### PR DESCRIPTION
Defines a env-variable (`PACT_BROKER_SSL_VERIFY`) that allows to disable SSL-verification .
It solves #103 