### PR TITLE
Fix Broker HTTP Authentication

### DIFF
--- a/src/PhpPact/Consumer/Listener/PactTestListener.php
+++ b/src/PhpPact/Consumer/Listener/PactTestListener.php
@@ -103,8 +103,8 @@ class PactTestListener implements TestListener
                 print 'PACT_CONSUMER_TAG environment variable was not set. Skipping PACT file upload.';
             } else {
                 $clientConfig = [];
-                if (!($user = \getenv('PACT_BROKER_HTTP_AUTH_USER')) &&
-                    !($pass = \getenv('PACT_BROKER_HTTP_AUTH_PASS'))
+                if (($user = \getenv('PACT_BROKER_HTTP_AUTH_USER')) &&
+                    ($pass = \getenv('PACT_BROKER_HTTP_AUTH_PASS'))
                 ) {
                     $clientConfig = [
                         'auth' => [$user, $pass],


### PR DESCRIPTION
While trying to integrate Pact consumer tests into my existing CI, I couldn't get HTTP auth working with the Pact Broker.

Seems like a typo and a quick fix to me