### PR TITLE
allow nulls in output and stderr when empty

### DIFF
--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -42,7 +42,7 @@ class ProcessRunner
     /**
      * @return string
      */
-    public function getOutput(): string
+    public function getOutput(): ?string
     {
         return $this->output;
     }
@@ -79,7 +79,7 @@ class ProcessRunner
     /**
      * @return string
      */
-    public function getStderr(): string
+    public function getStderr(): ?string
     {
         return $this->stderr;
     }

--- a/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
+++ b/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
@@ -26,6 +26,7 @@ class ProcessRunnerTest extends TestCase
 
         $this->assertEquals($exitCode, 0, 'Expect the exit code to be 0');
         $this->assertTrue((\stripos($p->getOutput(), $expectedOutput) !== false), "Expect '{$expectedOutput}' to be in the output");
+        $this->assertEquals($p->getStderr(), null, 'Expect a null stderr');
 
         // try an app that does not exists
         if ('\\' !== \DIRECTORY_SEPARATOR) {
@@ -44,6 +45,7 @@ class ProcessRunnerTest extends TestCase
         $exitCode = $p->getExitCode();
 
         $this->assertNotEquals($exitCode, 0, 'Expect the exit code to be non-zero: ' . $exitCode);
+        $this->assertEquals($p->getOutput(), null, 'Expect a null output');
         $this->assertTrue((\stripos($p->getStderr(), $expectedErr) !== false), "Expect '{$expectedErr}' to be in the stderr");
     }
 }


### PR DESCRIPTION
to address PhpPact\Standalone\Runner\ProcessRunner\setStderr() method issue #110