### PR TITLE
Fixing Bug #120 By Handling the RequestException

### DIFF
--- a/src/PhpPact/Standalone/MockService/Service/MockServerHttpService.php
+++ b/src/PhpPact/Standalone/MockService/Service/MockServerHttpService.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Standalone\MockService\Service;
 
+use GuzzleHttp\Exception\RequestException;
 use PhpPact\Consumer\Model\Interaction;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\Exception\ConnectionException;
@@ -134,12 +135,18 @@ class MockServerHttpService implements MockServerHttpServiceInterface
     {
         $uri = $this->config->getBaseUri()->withPath('/interactions/verification');
 
-        $this->client->get($uri, [
-            'headers' => [
-                'Content-Type'        => 'application/json',
-                'X-Pact-Mock-Service' => true,
-            ],
-        ]);
+        try {
+            $this->client->get(
+                $uri, [
+                'headers' => [
+                    'Content-Type'        => 'application/json',
+                    'X-Pact-Mock-Service' => true,
+                ],
+            ]
+            );
+        } catch (RequestException $e) {
+            return false;
+        }
 
         return true;
     }

--- a/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
+++ b/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
@@ -95,7 +95,7 @@ class MockServerHttpServiceTest extends TestCase
             ->setMethod('GET');
 
         $response = new ProviderResponse();
-        $response->setStatus(200);
+        $response->setStatus(500);
 
         $interaction = new Interaction();
         $interaction


### PR DESCRIPTION
The Mock Server returns a 500 when /interactions/verification is called and there were invalid interactions.
The HTTP 500 causes Guzzle to throw a RequestException which needs to be caught and handled.