### PR TITLE
Verifier output

### DIFF
--- a/example/src/Provider/public/index.php
+++ b/example/src/Provider/public/index.php
@@ -10,13 +10,17 @@ $app = new \Slim\App();
 $app->get('/hello/{name}', function (Request $request, Response $response) {
     $name = $request->getAttribute('name');
 
-    return $response->withJson(['message' => "Hello, {$name}"]);
+    return $response
+            ->withJson(['message' => "Hello, {$name}"])
+            ->withHeader('Content-Type', 'application/json');
 });
 
 $app->get('/goodbye/{name}', function (Request $request, Response $response) {
     $name = $request->getAttribute('name');
 
-    return $response->withJson(['message' => "Goodbye, {$name}"]);
+    return $response
+        ->withJson(['message' => "Goodbye, {$name}"])
+        ->withHeader('Content-Type', 'application/json');
 });
 
 $app->run();

--- a/example/tests/Consumer/Service/ConsumerServiceGoodbyeTest.php
+++ b/example/tests/Consumer/Service/ConsumerServiceGoodbyeTest.php
@@ -25,7 +25,7 @@ class ConsumerServiceGoodbyeTest extends TestCase
         $response = new ProviderResponse();
         $response
             ->setStatus(200)
-            ->addHeader('Content-Type', 'application/json;charset=utf-8')
+            ->addHeader('Content-Type', 'application/json')
             ->setBody([
                 'message' => 'Goodbye, Bob'
             ]);

--- a/example/tests/Consumer/Service/ConsumerServiceHelloTest.php
+++ b/example/tests/Consumer/Service/ConsumerServiceHelloTest.php
@@ -31,7 +31,7 @@ class ConsumerServiceHelloTest extends TestCase
         $response = new ProviderResponse();
         $response
             ->setStatus(200)
-            ->addHeader('Content-Type', 'application/json;charset=utf-8')
+            ->addHeader('Content-Type', 'application/json')
             ->setBody([
                 'message' => $matcher->term('Hello, Bob', '(Hello, )[A-Za-z]')
             ]);

--- a/src/PhpPact/Standalone/ProviderVerifier/VerifierProcess.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/VerifierProcess.php
@@ -33,11 +33,13 @@ class VerifierProcess
 
     /**
      * @param Logger $logger
+     *
      * @return VerifierProcess
      */
-    public function setLogger(Logger $logger): VerifierProcess
+    public function setLogger(Logger $logger): self
     {
         $this->logger = $logger;
+
         return $this;
     }
 
@@ -60,6 +62,7 @@ class VerifierProcess
         $logger = $this->getLogger();
 
         $logger->addInfo("Verifying PACT with script:\n{$processRunner->getCommand()}\n\n");
+
         try {
             $processRunner->runBlocking();
 

--- a/src/PhpPact/Standalone/ProviderVerifier/VerifierProcess.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/VerifierProcess.php
@@ -83,7 +83,7 @@ class VerifierProcess
     {
         if (null === $this->logger) {
             $logHandler = new StreamHandler(new ResourceOutputStream(\STDOUT));
-            $logHandler->setFormatter(new ConsoleFormatter);
+            $logHandler->setFormatter(new ConsoleFormatter(null, null, true));
             $this->logger = new Logger('console');
             $this->logger->pushHandler($logHandler);
         }

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -128,15 +128,12 @@ class ProcessRunner
 
             $pid = yield $this->process->getPid();
 
-            $stream = $this->process->getStdout();
-            while (null !== $chunk = yield $stream->read()) {
-                $this->output .= $chunk;
-            }
-
-            $stream = $this->process->getStderr();
-            while (null !== $chunk = yield $stream->read()) {
-                $this->stderr .= $chunk;
-            }
+            $this->process->getStdout()->read()->onResolve(function (\Throwable $reason = null, $value) {
+                $this->output .= $value;
+            });
+            $this->process->getStderr()->read()->onResolve(function (\Throwable $reason = null, $value) {
+                $this->stderr .= $value;
+            });
 
             if ($blocking) {
                 if ($this->getExitCode() !== 0) {

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -131,10 +131,10 @@ class ProcessRunner
                     $this->stderr .= $chunk;
                 }
             } else {
-                $this->process->getStdout()->read()->onResolve(function (\Throwable $reason = null, $value = null) {
+                $this->process->getStdout()->read()->onResolve(function (\Throwable $reason = null, $value) {
                     $this->output .= $value;
                 });
-                $this->process->getStderr()->read()->onResolve(function (\Throwable $reason = null, $value = null) {
+                $this->process->getStderr()->read()->onResolve(function (\Throwable $reason = null, $value) {
                     $this->stderr .= $value;
                 });
             }

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -110,7 +110,7 @@ class ProcessRunner
     public function run($blocking = false): int
     {
         $logHandler = new StreamHandler(new ResourceOutputStream(\STDOUT));
-        $logHandler->setFormatter(new ConsoleFormatter);
+        $logHandler->setFormatter(new ConsoleFormatter(null, null, true));
         $logger = new Logger('server');
         $logger->pushHandler($logHandler);
 

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -120,14 +120,6 @@ class ProcessRunner
 
             $this->process->start();
 
-            $this->process->getStdout()->read()->onResolve(function (\Throwable $reason = null, $value) {
-                $this->output .= $value;
-            });
-
-            $this->process->getStderr()->read()->onResolve(function (\Throwable $reason = null, $value) {
-                $this->stderr .= $value;
-            });
-
             if ($blocking) {
                 $exitCode = yield $this->process->join();
                 $this->setExitCode($exitCode);
@@ -135,6 +127,16 @@ class ProcessRunner
             }
 
             $pid = yield $this->process->getPid();
+
+            $stream = $this->process->getStdout();
+            while (null !== $chunk = yield $stream->read()) {
+                $this->output .= $chunk;
+            }
+
+            $stream = $this->process->getStderr();
+            while (null !== $chunk = yield $stream->read()) {
+                $this->stderr .= $chunk;
+            }
 
             if ($blocking) {
                 if ($this->getExitCode() !== 0) {

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -198,8 +198,8 @@ class VerifierTest extends TestCase
         $logMessages = $handler->getRecords();
 
         $this->assertCount(3, $logMessages);
-        $this->assertContains("out > first line", $logMessages[1]['message']);
-        $this->assertContains("err > second line", $logMessages[2]['message']);
+        $this->assertContains('out > first line', $logMessages[1]['message']);
+        $this->assertContains('err > second line', $logMessages[2]['message']);
 
         $this->assertNotNull($exception);
     }

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -69,6 +69,7 @@ class VerifierTest extends TestCase
     {
         $expectedUrltoBroker = 'http://mock/' . $path;
 
+        /** @var Uri $uriMock */
         $uriMock = $this->createMock(Uri::class);
         $uriMock->expects($this->once())
             ->method('withPath')
@@ -170,7 +171,11 @@ class VerifierTest extends TestCase
 
     public function testRunShouldLogOutputIfCmdFails()
     {
-        $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
+        } else {
+            $cmd = 'start cmd /c' . __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.bat';
+        }
 
         $scriptsMock = $this->createMock(Scripts::class);
         $scriptsMock->method('getProviderVerifier')->willReturn($cmd);

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -198,8 +198,8 @@ class VerifierTest extends TestCase
         $logMessages = $handler->getRecords();
 
         $this->assertCount(3, $logMessages);
-        $this->assertContains('out > first line', $logMessages[1]['message']);
-        $this->assertContains('err > second line', $logMessages[2]['message']);
+        $this->assertContains('first line', $logMessages[1]['message']);
+        $this->assertContains('second line', $logMessages[2]['message']);
 
         $this->assertNotNull($exception);
     }

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -174,7 +174,7 @@ class VerifierTest extends TestCase
         if ('\\' !== \DIRECTORY_SEPARATOR) {
             $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
         } else {
-            $cmd = 'start cmd /c' . __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.bat';
+            $cmd = 'cmd /c' . __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.bat';
         }
 
         $scriptsMock = $this->createMock(Scripts::class);

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -198,8 +198,8 @@ class VerifierTest extends TestCase
         $logMessages = $handler->getRecords();
 
         $this->assertCount(3, $logMessages);
-        $this->assertEquals("out > first line\n", $logMessages[1]['message']);
-        $this->assertEquals("err > second line\n", $logMessages[2]['message']);
+        $this->assertContains("out > first line", $logMessages[1]['message']);
+        $this->assertContains("err > second line", $logMessages[2]['message']);
 
         $this->assertNotNull($exception);
     }

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -3,9 +3,12 @@
 namespace PhpPact\Standalone\ProviderVerifier;
 
 use GuzzleHttp\Psr7\Uri;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PhpPact\Broker\Service\BrokerHttpClient;
 use PhpPact\Broker\Service\BrokerHttpClientInterface;
 use PhpPact\Standalone\Installer\InstallManager;
+use PhpPact\Standalone\Installer\Model\Scripts;
 use PhpPact\Standalone\ProviderVerifier\Model\VerifierConfig;
 use PHPUnit\Framework\TestCase;
 
@@ -163,5 +166,36 @@ class VerifierTest extends TestCase
           ['someProvider', '1.0.0'],
           ['someProvider', '1.2.3'],
         ];
+    }
+
+    public function testRunShouldLogOutputIfCmdFails()
+    {
+        $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
+
+        $scriptsMock = $this->createMock(Scripts::class);
+        $scriptsMock->method('getProviderVerifier')->willReturn($cmd);
+
+        $installerMock = $this->createMock(InstallManager::class);
+        $installerMock->method('install')->willReturn($scriptsMock);
+
+        $process = new VerifierProcess($installerMock);
+
+        $logger = new Logger('console', [$handler = new TestHandler()]);
+        $process->setLogger($logger);
+
+        try {
+            $exception = null;
+            $process->run([], 60, 10);
+        } catch (\Exception $e) {
+            $exception = $e;
+        }
+
+        $logMessages = $handler->getRecords();
+
+        $this->assertCount(3, $logMessages);
+        $this->assertEquals("out > first line\n", $logMessages[1]['message']);
+        $this->assertEquals("err > second line\n", $logMessages[2]['message']);
+
+        $this->assertNotNull($exception);
     }
 }

--- a/tests/PhpPact/Standalone/ProviderVerifier/verifier.bat
+++ b/tests/PhpPact/Standalone/ProviderVerifier/verifier.bat
@@ -1,0 +1,8 @@
+@ECHO OFF
+
+REM this script simulates a command (like pact-verifier) which prints several lines to stdout and stderr
+
+ECHO "first line"
+ECHO "second line" 1>&2
+
+exit 42

--- a/tests/PhpPact/Standalone/ProviderVerifier/verifier.sh
+++ b/tests/PhpPact/Standalone/ProviderVerifier/verifier.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# this script simulates a command (like pact-verifier) which prints several lines to stdout and stderr
+
+echoerr() { echo "$@" 1>&2; }
+
+echo "first line"
+echoerr "second line"
+
+exit 1

--- a/tests/PhpPact/Standalone/ProviderVerifier/verifier.sh
+++ b/tests/PhpPact/Standalone/ProviderVerifier/verifier.sh
@@ -7,4 +7,4 @@ echoerr() { echo "$@" 1>&2; }
 echo "first line"
 echoerr "second line"
 
-exit 1
+exit 42

--- a/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
+++ b/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
@@ -14,11 +14,9 @@ class ProcessRunnerTest extends TestCase
         if ('\\' !== \DIRECTORY_SEPARATOR) {
             $p              = new ProcessRunner('ls', ['-alt']);
             $expectedOutput = 'total';
-            $expectedErr    = 'failedApp';
         } else {
             $p              = new ProcessRunner('dir', []);
             $expectedOutput = 'pact';
-            $expectedErr    = 'failedApp';
         }
 
         $p->runBlocking();
@@ -47,5 +45,27 @@ class ProcessRunnerTest extends TestCase
         $this->assertNotEquals($exitCode, 0, 'Expect the exit code to be non-zero: ' . $exitCode);
         $this->assertEquals($p->getOutput(), null, 'Expect a null output');
         $this->assertTrue((\stripos($p->getStderr(), $expectedErr) !== false), "Expect '{$expectedErr}' to be in the stderr");
+    }
+
+    /**
+     * @throws \Exception
+     */
+    public function testProcessRunnerShouldReturnCompleteOutput()
+    {
+        $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
+
+        $p              = new ProcessRunner($cmd, []);
+        $expectedOutput = 'third line';
+        $expectedErr = 'fourth line';
+
+        try {
+            $p->runBlocking();
+        } catch(\Exception $e) {
+
+        }
+
+        $this->assertTrue((\stripos($p->getOutput(), $expectedOutput) !== false), "Expect '{$expectedOutput}' to be in the output:");
+        $this->assertTrue((\stripos($p->getStderr(), $expectedErr) !== false), "Expect '{$expectedErr}' to be in the stderr");
+
     }
 }

--- a/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
+++ b/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
@@ -55,7 +55,7 @@ class ProcessRunnerTest extends TestCase
         if ('\\' !== \DIRECTORY_SEPARATOR) {
             $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
         } else {
-            $cmd = 'start cmd /c' . __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.bat';
+            $cmd = 'cmd /c' . __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.bat';
         }
 
         $p              = new ProcessRunner($cmd, []);

--- a/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
+++ b/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
@@ -56,16 +56,14 @@ class ProcessRunnerTest extends TestCase
 
         $p              = new ProcessRunner($cmd, []);
         $expectedOutput = 'third line';
-        $expectedErr = 'fourth line';
+        $expectedErr    = 'fourth line';
 
         try {
             $p->runBlocking();
-        } catch(\Exception $e) {
-
+        } catch (\Exception $e) {
         }
 
         $this->assertTrue((\stripos($p->getOutput(), $expectedOutput) !== false), "Expect '{$expectedOutput}' to be in the output:");
         $this->assertTrue((\stripos($p->getStderr(), $expectedErr) !== false), "Expect '{$expectedErr}' to be in the stderr");
-
     }
 }

--- a/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
+++ b/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
@@ -52,7 +52,11 @@ class ProcessRunnerTest extends TestCase
      */
     public function testProcessRunnerShouldReturnCompleteOutput()
     {
-        $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
+        if ('\\' !== \DIRECTORY_SEPARATOR) {
+            $cmd = __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.sh';
+        } else {
+            $cmd = 'start cmd /c' . __DIR__ . \DIRECTORY_SEPARATOR . 'verifier.bat';
+        }
 
         $p              = new ProcessRunner($cmd, []);
         $expectedOutput = 'third line';

--- a/tests/PhpPact/Standalone/Runner/verifier.bat
+++ b/tests/PhpPact/Standalone/Runner/verifier.bat
@@ -1,0 +1,11 @@
+@ECHO OFF
+
+REM this script simulates a command (like pact-verifier) which prints several lines to stdout and stderr
+
+ECHO "first line"
+ECHO "second line" 1>&2
+ECHO "third line"
+ECHO "fourth line" 1>&2
+ECHO "fifth line"
+
+exit 42

--- a/tests/PhpPact/Standalone/Runner/verifier.sh
+++ b/tests/PhpPact/Standalone/Runner/verifier.sh
@@ -10,4 +10,4 @@ echo "third line"
 echoerr "fourth line"
 echo "fifth line"
 
-exit 1
+exit 42

--- a/tests/PhpPact/Standalone/Runner/verifier.sh
+++ b/tests/PhpPact/Standalone/Runner/verifier.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# this script simulates a command (like pact-verifier) which prints several lines to stdout and stderr
+
+echoerr() { echo "$@" 1>&2; }
+
+echo "first line"
+echoerr "second line"
+echo "third line"
+echoerr "fourth line"
+echo "fifth line"
+
+exit 1


### PR DESCRIPTION
This pull request ensures that all output is captured, if `VerifierProcess:run()` executes any command that fails (exit code >0)

There are two problems currently:

1. The output is not passed to the logger, if `$processRunner->runBlocking()` throws an exception
2. `ProcessRunner:run()` does not capture the complete output, if stdout and stderr are used alternating (see verifier.sh script in UnitTest)