### PR TITLE
Fix windows tests

### DIFF
--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -193,7 +193,6 @@ class ProcessRunner
      */
     public function stop(): bool
     {
-
         $pid = $this->process->getPid();
 
         print "\nStopping Process Id: {$pid}\n";

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -193,26 +193,16 @@ class ProcessRunner
      */
     public function stop(): bool
     {
-        if (!$this->process->isRunning()) {
-            return true;
-        }
 
         $pid = $this->process->getPid();
 
         print "\nStopping Process Id: {$pid}\n";
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            \exec(\sprintf('taskkill /F /T /PID %d /fi "STATUS eq RUNNING" 2>&1', $pid), $output, $exitCode);
-            if ($exitCode) {
-                throw new ProcessException(\sprintf('Unable to kill the process (%s).', \implode(' ', $output)));
-            }
+            \exec(\sprintf('taskkill /F /T /PID %d 2>&1', $pid), $output, $exitCode);
         }
 
         $this->process->kill();
-
-        if ($this->process->isRunning()) {
-            throw new ProcessException(\sprintf('Error while killing process "%s".', $pid));
-        }
 
         return true;
     }

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -202,7 +202,7 @@ class ProcessRunner
         print "\nStopping Process Id: {$pid}\n";
 
         if ('\\' === \DIRECTORY_SEPARATOR) {
-            \exec(\sprintf('taskkill /F /T /PID %d 2>&1', $pid), $output, $exitCode);
+            \exec(\sprintf('taskkill /F /T /PID %d /fi "STATUS eq RUNNING" 2>&1', $pid), $output, $exitCode);
             if ($exitCode) {
                 throw new ProcessException(\sprintf('Unable to kill the process (%s).', \implode(' ', $output)));
             }

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -144,10 +144,7 @@ class ProcessRunner
      */
     public function runNonBlocking(): int
     {
-        $logHandler = new StreamHandler(new ResourceOutputStream(\STDOUT));
-        $logHandler->setFormatter(new ConsoleFormatter(null, null, true));
-        $logger = new Logger('server');
-        $logger->pushHandler($logHandler);
+        $logger     = $this->getLogger();
 
         $pid        = null;
 

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -203,7 +203,6 @@ class ProcessRunner
 
         $this->process->kill();
 
-
         if ($this->process->isRunning()) {
             throw new ProcessException(\sprintf('Error while killing process "%s".', $pid));
         }

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -203,6 +203,11 @@ class ProcessRunner
 
         $this->process->kill();
 
+
+        if ($this->process->isRunning()) {
+            throw new ProcessException(\sprintf('Error while killing process "%s".', $pid));
+        }
+
         return true;
     }
 


### PR DESCRIPTION
simplifies ProcessRunner:stop in order to make it work properly on windows systems

fixes #124 