### PR TITLE
Allow future releases of composer/semver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.1",
         "ext-openssl": "*",
-        "composer/semver": "1.4.2",
+        "composer/semver": "^1.4.2",
         "guzzlehttp/guzzle": "^6.3",
         "amphp/socket": "^0.10.9",
         "amphp/process": "^1.1.0",


### PR DESCRIPTION
In composer.json, the composer/semver package was locked to version 1.4.2, which disallow current v1.5 for that package.