### PR TITLE
fix logging during verification

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/ProcessRunnerFactory.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/ProcessRunnerFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier;
+
+use PhpPact\Standalone\Runner\ProcessRunner;
+use Psr\Log\LoggerInterface;
+
+class ProcessRunnerFactory
+{
+    /**
+     * @param string $providerVerifier
+     * @param array  $arguments
+     *
+     * @return ProcessRunner
+     */
+    public function createRunner(string $providerVerifier, array $arguments, LoggerInterface $logger = null)
+    {
+        $processRunner = new ProcessRunner($providerVerifier, $arguments);
+        if ($logger) {
+            $processRunner->setLogger($logger);
+        }
+
+        return $processRunner;
+    }
+}

--- a/src/PhpPact/Standalone/Runner/ProcessRunner.php
+++ b/src/PhpPact/Standalone/Runner/ProcessRunner.php
@@ -10,6 +10,7 @@ use Amp\Loop;
 use Amp\Process\Process;
 use Amp\Process\ProcessException;
 use Monolog\Logger;
+use Psr\Log\LoggerInterface;
 
 /**
  * Wrapper around Process with Amp
@@ -29,7 +30,7 @@ class ProcessRunner
     private $stderr;
 
     /**
-     * @var Logger
+     * @var LoggerInterface
      */
     private $logger;
 
@@ -44,11 +45,11 @@ class ProcessRunner
     }
 
     /**
-     * @param Logger $logger
+     * @param LoggerInterface $logger
      *
      * @return ProcessRunner
      */
-    public function setLogger(Logger $logger): self
+    public function setLogger(LoggerInterface $logger): self
     {
         $this->logger = $logger;
 
@@ -211,7 +212,7 @@ class ProcessRunner
     }
 
     /**
-     * @return Logger
+     * @return LoggerInterface
      */
     private function getLogger()
     {

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierProcessTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierProcessTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace PhpPactTest\Standalone\ProviderVerifier;
+
+use PhpPact\Standalone\Installer\InstallManager;
+use PhpPact\Standalone\Installer\Model\Scripts;
+use PhpPact\Standalone\ProviderVerifier\ProcessRunnerFactory;
+use PhpPact\Standalone\ProviderVerifier\VerifierProcess;
+use PhpPact\Standalone\Runner\ProcessRunner;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+class VerifierProcessTest extends TestCase
+{
+    public function testRun()
+    {
+        $verifier  = 'foo';
+        $arguments = ['foo' => 'bar'];
+
+        $scripts = $this->createMock(Scripts::class);
+        $scripts->expects($this->once())
+            ->method('getProviderVerifier')
+            ->will($this->returnValue($verifier));
+
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $processRunner = $this->createMock(ProcessRunner::class);
+
+        $installManager = $this->createMock(InstallManager::class);
+        $installManager->expects($this->once())
+            ->method('install')
+            ->will($this->returnValue($scripts));
+
+        $processRunnerFactory = $this->createMock(ProcessRunnerFactory::class);
+        $processRunnerFactory->expects($this->once())
+            ->method('createRunner')
+            ->with($this->equalTo($verifier), $this->equalTo($arguments), $this->equalTo($logger))
+            ->will($this->returnValue($processRunner));
+
+        $process = new VerifierProcess($installManager, $processRunnerFactory);
+        $process->setLogger($logger);
+        $process->run($arguments, 42, 23);
+    }
+
+    public function testRunWithDefaultLogger()
+    {
+        $verifier  = 'foo';
+        $arguments = ['foo' => 'bar'];
+
+        $scripts = $this->createMock(Scripts::class);
+        $scripts->expects($this->once())
+            ->method('getProviderVerifier')
+            ->will($this->returnValue($verifier));
+
+        $processRunner = $this->createMock(ProcessRunner::class);
+
+        $installManager = $this->createMock(InstallManager::class);
+        $installManager->expects($this->once())
+            ->method('install')
+            ->will($this->returnValue($scripts));
+
+        $processRunnerFactory = $this->createMock(ProcessRunnerFactory::class);
+        $processRunnerFactory->expects($this->once())
+            ->method('createRunner')
+            ->with($this->equalTo($verifier), $this->equalTo($arguments))
+            ->will($this->returnValue($processRunner));
+
+        $process = new VerifierProcess($installManager, $processRunnerFactory);
+        $process->run($arguments, 42, 23);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage foo
+     */
+    public function testRunForwardsException()
+    {
+        $verifier  = 'foo';
+        $arguments = ['foo' => 'bar'];
+
+        $expectedException = new \RuntimeException('foo');
+
+        $scripts = $this->createMock(Scripts::class);
+        $scripts->expects($this->once())
+            ->method('getProviderVerifier')
+            ->will($this->returnValue($verifier));
+
+        $processRunner = $this->createMock(ProcessRunner::class);
+        $processRunner->expects($this->once())
+            ->method('runBlocking')
+            ->will(
+                $this->returnCallback(
+                    function () use ($expectedException) {
+                        throw $expectedException;
+                    }
+                )
+            );
+
+        $installManager = $this->createMock(InstallManager::class);
+        $installManager->expects($this->once())
+            ->method('install')
+            ->will($this->returnValue($scripts));
+
+        $processRunnerFactory = $this->createMock(ProcessRunnerFactory::class);
+        $processRunnerFactory->expects($this->once())
+            ->method('createRunner')
+            ->with($this->equalTo($verifier), $this->equalTo($arguments))
+            ->will($this->returnValue($processRunner));
+
+        $process = new VerifierProcess($installManager, $processRunnerFactory);
+        $process->run($arguments, 42, 23);
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/pact-foundation/pact-php/issues/135.

The logger methods used during the verification are not included in the standardized LoggerInterface. These methods (addInfo, addError) are contained in Monolith v1 but not in Monolog v2. Thus the verification will break in any fresh installed Symfony 4.3 project.

I changed the usage of the logger to use the interface. It is always a bad practice to rely on concrete classes.

I also introduced ProcessRunnerFactory for better unit testing possibilities.