### PR TITLE
Add bearer token authentication

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,6 +22,7 @@
         <env name="PACT_CONSUMER_VERSION" value="1.0.0"/>
         <env name="PACT_PROVIDER_NAME" value="someProvider"/>
         <env name="PACT_BROKER_URI" value="http://localhost"/>
+        <!-- <env name="PACT_BROKER_BEARER_TOKEN" value="someToken"/> -->
         <env name="PACT_CORS" value="true"/>
     </php>
 </phpunit>

--- a/src/PhpPact/Broker/Service/BrokerHttpClient.php
+++ b/src/PhpPact/Broker/Service/BrokerHttpClient.php
@@ -17,13 +17,21 @@ class BrokerHttpClient implements BrokerHttpClientInterface
     /** @var UriInterface */
     private $baseUri;
 
+    /** @var array */
+    private $headers;
+
     /**
      * {@inheritdoc}
      */
-    public function __construct(ClientInterface $httpClient, UriInterface $baseUri)
+    public function __construct(ClientInterface $httpClient, UriInterface $baseUri, array $headers = array())
     {
         $this->httpClient = $httpClient;
         $this->baseUri    = $baseUri;
+        $this->headers    = $headers;
+
+        if(! array_key_exists('Content-Type', $headers)){
+            $this->headers['Content-Type'] = 'application/json';
+        }
     }
 
     /**
@@ -39,9 +47,7 @@ class BrokerHttpClient implements BrokerHttpClientInterface
         $uri = $this->baseUri->withPath("/pacts/provider/{$provider}/consumer/{$consumer}/version/{$version}");
 
         $this->httpClient->put($uri, [
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
+            'headers' => $this->headers,
             'body' => $json,
         ]);
     }
@@ -53,11 +59,8 @@ class BrokerHttpClient implements BrokerHttpClientInterface
     {
         /** @var UriInterface $uri */
         $uri = $this->baseUri->withPath("/pacticipants/{$consumer}/versions/{$version}/tags/{$tag}");
-
         $this->httpClient->put($uri, [
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
+            'headers' => $this->headers,
         ]);
     }
 
@@ -73,9 +76,7 @@ class BrokerHttpClient implements BrokerHttpClientInterface
         $uri = $this->baseUri->withPath("/pacts/provider/{$provider}/latest");
 
         $response = $this->httpClient->get($uri, [
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
+            'headers' => $this->headers,
         ]);
 
         $json = \json_decode($response->getBody()->getContents(), true);
@@ -96,9 +97,7 @@ class BrokerHttpClient implements BrokerHttpClientInterface
         $uri = $this->baseUri->withPath("/pacts/provider/{$provider}/latest/{$tag}");
 
         $response = $this->httpClient->get($uri, [
-            'headers' => [
-                'Content-Type' => 'application/json',
-            ],
+            'headers' => $this->headers,
         ]);
 
         $json = \json_decode($response->getBody()->getContents(), true);

--- a/src/PhpPact/Broker/Service/BrokerHttpClientInterface.php
+++ b/src/PhpPact/Broker/Service/BrokerHttpClientInterface.php
@@ -14,10 +14,11 @@ interface BrokerHttpClientInterface
     /**
      * HttpServiceInterface constructor.
      *
-     * @param ClientInterface $client  Http Client
-     * @param UriInterface    $baseUri Base URI for the PhpPact Broker
+     * @param ClientInterface $client Http Client
+     * @param UriInterface $baseUri Base URI for the PhpPact Broker
+     * @param array $headers additional headers
      */
-    public function __construct(ClientInterface $client, UriInterface $baseUri);
+    public function __construct(ClientInterface $client, UriInterface $baseUri, array $headers);
 
     /**
      * Publish JSON.

--- a/src/PhpPact/Consumer/Listener/PactTestListener.php
+++ b/src/PhpPact/Consumer/Listener/PactTestListener.php
@@ -115,9 +115,14 @@ class PactTestListener implements TestListener
                     $clientConfig['verify'] = $sslVerify !== 'no';
                 }
 
+                $headers = array();
+                if ($bearerToken = \getenv('PACT_BROKER_BEARER_TOKEN')) {
+                    $headers['Authorization'] = 'Bearer ' . $bearerToken;
+                }
+
                 $client = new GuzzleClient($clientConfig);
 
-                $brokerHttpService = new BrokerHttpClient($client, new Uri($pactBrokerUri));
+                $brokerHttpService = new BrokerHttpClient($client, new Uri($pactBrokerUri), $headers);
                 $brokerHttpService->tag($this->mockServerConfig->getConsumer(), $consumerVersion, $tag);
                 $brokerHttpService->publishJson($json, $consumerVersion);
                 print 'Pact file has been uploaded to the Broker successfully.';


### PR DESCRIPTION
This PR adds bearer token authentication option in BrokerHttpClient(as used in service https://pactflow.io for example).