### PR TITLE
Download contract from pact mock server hook

### DIFF
--- a/src/PhpPact/Consumer/Hook/ContractDownloader.php
+++ b/src/PhpPact/Consumer/Hook/ContractDownloader.php
@@ -2,14 +2,13 @@
 
 namespace PhpPact\Consumer\Hook;
 
-use PHPUnit\Runner\AfterLastTestHook;
+use Exception;
+use PhpPact\Http\GuzzleClient;
 use PhpPact\Standalone\MockService\MockServerEnvConfig;
 use PhpPact\Standalone\MockService\Service\MockServerHttpService;
-use PhpPact\Http\GuzzleClient;
-use RuntimeException;
 use PHPUnit\Framework\AssertionFailedError;
-use Exception;
-
+use PHPUnit\Runner\AfterLastTestHook;
+use RuntimeException;
 
 class ContractDownloader implements AfterLastTestHook
 {
@@ -32,16 +31,14 @@ class ContractDownloader implements AfterLastTestHook
      */
     public function executeAfterLastTest(): void
     {
-        try
-        {
+        try {
             $this->getMockServerService()->verifyInteractions();
         } catch (Exception $e) {
             throw new AssertionFailedError('Pact interaction verification failed', $e);
         }
 
-        try
-        {
-            file_put_contents($this->getPactFilename(), $this->getPactJson());
+        try {
+            \file_put_contents($this->getPactFilename(), $this->getPactJson());
         } catch (Exception $e) {
             throw new RuntimeException('Pact contract generation failed', $e);
         }
@@ -55,7 +52,7 @@ class ContractDownloader implements AfterLastTestHook
         );
     }
 
-    private function getPactFilename() : string
+    private function getPactFilename(): string
     {
         return $this->mockServerConfig->getPactDir()
         . DIRECTORY_SEPARATOR
@@ -64,7 +61,7 @@ class ContractDownloader implements AfterLastTestHook
         . $this->mockServerConfig->getProvider() . '.json';
     }
 
-    private function getPactJson() : string
+    private function getPactJson(): string
     {
         $uri      = $this->mockServerConfig->getBaseUri()->withPath('/pact');
         $response = $this->client->post(
@@ -74,7 +71,7 @@ class ContractDownloader implements AfterLastTestHook
                     'Content-Type'        => 'application/json',
                     'X-Pact-Mock-Service' => true,
                 ],
-                'body' => json_encode([
+                'body' => \json_encode([
                     'consumer' => ['name' => $this->mockServerConfig->getConsumer()],
                     'provider' => ['name' => $this->mockServerConfig->getProvider()]
                 ])

--- a/src/PhpPact/Consumer/Hook/ContractDownloader.php
+++ b/src/PhpPact/Consumer/Hook/ContractDownloader.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace PhpPact\Consumer\Hook;
+
+use PHPUnit\Runner\AfterLastTestHook;
+use PhpPact\Standalone\MockService\MockServerEnvConfig;
+use PhpPact\Standalone\MockService\Service\MockServerHttpService;
+use PhpPact\Http\GuzzleClient;
+use RuntimeException;
+use PHPUnit\Framework\AssertionFailedError;
+use Exception;
+
+
+class ContractDownloader implements AfterLastTestHook
+{
+    /** @var MockServerConfigInterface */
+    private $mockServerConfig;
+
+    /**
+     * ContractDownloader constructor.
+     *
+     * @throws MissingEnvVariableException
+     */
+    public function __construct()
+    {
+        $this->mockServerConfig = new MockServerEnvConfig();
+    }
+
+    /**
+     * @throws AssertionFailedError
+     * @throws RuntimeException
+     */
+    public function executeAfterLastTest(): void
+    {
+        try
+        {
+            $this->getMockServerService()->verifyInteractions();
+        } catch (Exception $e) {
+            throw new AssertionFailedError('Pact interaction verification failed', $e);
+        }
+
+        try
+        {
+            file_put_contents($this->getPactFilename(), $this->getPactJson());
+        } catch (Exception $e) {
+            throw new RuntimeException('Pact contract generation failed', $e);
+        }
+    }
+
+    private function getMockServerService(): MockServerHttpService
+    {
+        return new MockServerHttpService(
+            new GuzzleClient(),
+            $this->mockServerConfig
+        );
+    }
+
+    private function getPactFilename() : string
+    {
+        return $this->mockServerConfig->getPactDir()
+        . DIRECTORY_SEPARATOR
+        . $this->mockServerConfig->getConsumer()
+        . '-'
+        . $this->mockServerConfig->getProvider() . '.json';
+    }
+
+    private function getPactJson() : string
+    {
+        $uri      = $this->mockServerConfig->getBaseUri()->withPath('/pact');
+        $response = $this->client->post(
+            $uri,
+            [
+                'headers' => [
+                    'Content-Type'        => 'application/json',
+                    'X-Pact-Mock-Service' => true,
+                ],
+                'body' => json_encode([
+                    'consumer' => ['name' => $this->mockServerConfig->getConsumer()],
+                    'provider' => ['name' => $this->mockServerConfig->getProvider()]
+                ])
+            ]
+        );
+
+        return \json_encode(\json_decode($response->getBody()->getContents()));
+    }
+}


### PR DESCRIPTION
We are not able to use an included pact-mock server in our CI pipeline (our php images are based on php alpine) due to the following issues:
- https://github.com/pact-foundation/pact-mock-service-npm/issues/18
- https://github.com/pact-foundation/pact-js/issues/305

In order to overcome this problem, we use a separate standalone pact-mock server. Unfortunately, the existing Consumer\Listener\PactTestListener is not designed to fetch the contract from the pact-mock server. I created this PHPUnit hook to fetch and store contract in the configured location, so that the file can be used as an artifact.
