### PR TITLE
Fix custom provider headers enclosing

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -86,7 +86,7 @@ class Verifier
 
         if ($this->config->getCustomProviderHeaders() !== null) {
             foreach ($this->config->getCustomProviderHeaders() as $customProviderHeader) {
-                $parameters[] = "--custom-provider-header={$customProviderHeader}";
+                $parameters[] = "--custom-provider-header=\"{$customProviderHeader}\"";
             }
         }
 

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -42,8 +42,8 @@ class VerifierTest extends TestCase
         $this->assertContains('--publish-verification-results', $arguments);
         $this->assertContains('--broker-username=someusername', $arguments);
         $this->assertContains('--broker-password=somepassword', $arguments);
-        $this->assertContains('--custom-provider-header=key1: value1', $arguments);
-        $this->assertContains('--custom-provider-header=key2: value2', $arguments);
+        $this->assertContains('--custom-provider-header="key1: value1"', $arguments);
+        $this->assertContains('--custom-provider-header="key2: value2"', $arguments);
         $this->assertContains('--verbose', $arguments);
         $this->assertContains('--format=someformat', $arguments);
         $this->assertContains('--provider-version-tag=prod', $arguments);


### PR DESCRIPTION
Currently custom provider headers are not being enclosed in quotes when passed to `pact-provider-verifier`.

For example, setting: `--custom-provider-header=Authorization: Bearer MyToken`, causes the header to be cut at the first space resulting in the `Authorization` header to have an empty value when parsed by `pact-provider-verifier`. 