### PR TITLE
Indicate language to enable syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,7 @@ a particular message callback on the provider side.  See example\tests\MessagePr
 
 If you would like to test with fixtures, you can use the `pact-stub-service` like this:
 
-```
+```php
 $pactLocation             = __DIR__ . '/someconsumer-someprovider.json';
 $host                     = 'localhost';
 $port                     = 7201;


### PR DESCRIPTION
Add missing language indication within the `pact-stub-service` example.