### PR TITLE
feat: Allow broker token to be set

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfig.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfig.php
@@ -31,6 +31,9 @@ class VerifierConfig implements VerifierConfigInterface
     private $brokerUri;
 
     /** @var null|string */
+    private $brokerToken;
+
+    /** @var null|string */
     private $brokerUsername;
 
     /** @var null|string */
@@ -179,6 +182,24 @@ class VerifierConfig implements VerifierConfigInterface
     public function setBrokerUri(UriInterface $brokerUri): VerifierConfigInterface
     {
         $this->brokerUri = $brokerUri;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}}
+     */
+    public function getBrokerToken(): ?string
+    {
+        return $this->brokerToken;
+    }
+
+    /**
+     * {@inheritdoc }
+     */
+    public function setBrokerToken(?string $brokerToken): VerifierConfigInterface
+    {
+        $this->brokerToken = $brokerToken;
 
         return $this;
     }

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigInterface.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigInterface.php
@@ -95,6 +95,18 @@ interface VerifierConfigInterface
     public function setBrokerUri(UriInterface $brokerUri): self;
 
     /**
+     * @return null|string token for the pact broker
+     */
+    public function getBrokerToken(): ?string;
+
+    /**
+     * @param null|string $brokerToken token for the pact broker
+     *
+     * @return VerifierConfigInterface
+     */
+    public function setBrokerToken(?string $brokerToken): self;
+
+    /**
      * @return null|string username for the pact broker if secured
      */
     public function getBrokerUsername();

--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -76,6 +76,10 @@ class Verifier
             $parameters[] = '--publish-verification-results';
         }
 
+        if ($this->config->getBrokerToken() !== null) {
+            $parameters[] = "--broker-token={$this->config->getBrokerToken()}";
+        }
+
         if ($this->config->getBrokerUsername() !== null) {
             $parameters[] = "--broker-username={$this->config->getBrokerUsername()}";
         }

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -24,6 +24,7 @@ class VerifierTest extends TestCase
             ->setProviderBaseUrl(new Uri('http://myprovider:1234'))
             ->setProviderStatesSetupUrl(new Uri('http://someurl:1234'))
             ->setPublishResults(true)
+            ->setBrokerToken('someToken')
             ->setBrokerUsername('someusername')
             ->setBrokerPassword('somepassword')
             ->addCustomProviderHeader('key1', 'value1')
@@ -42,6 +43,7 @@ class VerifierTest extends TestCase
         $this->assertContains('--provider-base-url=http://myprovider:1234', $arguments);
         $this->assertContains('--provider-states-setup-url=http://someurl:1234', $arguments);
         $this->assertContains('--publish-verification-results', $arguments);
+        $this->assertContains('--broker-token=someToken', $arguments);
         $this->assertContains('--broker-username=someusername', $arguments);
         $this->assertContains('--broker-password=somepassword', $arguments);
         $this->assertContains('--custom-provider-header="key1: value1"', $arguments);


### PR DESCRIPTION
Some brokers require the use of a broker token. This adds the ability for a user to set their broker token for verification.