### PR TITLE
feat: Support matchers in headers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,13 @@ jobs:
         with:
           dependency-versions: 'locked'
 
-      - name: Static Code Analysis
-        run: composer lint
+      - name: Code Style Analysis
+        uses: docker://oskarstark/php-cs-fixer-ga:2.19.0
+        with:
+          args: --config=.php_cs --diff --dry-run
 
-      - uses: docker://oskarstark/phpstan-ga
+      - name: Static Code Analysis
+        uses: docker://oskarstark/phpstan-ga
         env:
           REQUIRE_DEV: true
         with:

--- a/src/PhpPact/Consumer/Model/ConsumerRequest.php
+++ b/src/PhpPact/Consumer/Model/ConsumerRequest.php
@@ -95,11 +95,11 @@ class ConsumerRequest implements \JsonSerializable
 
     /**
      * @param string $header
-     * @param string $value
+     * @param array | string $value
      *
      * @return ConsumerRequest
      */
-    public function addHeader(string $header, string $value): self
+    public function addHeader(string $header, $value): self
     {
         $this->headers[$header] = $value;
 

--- a/src/PhpPact/Consumer/Model/ProviderResponse.php
+++ b/src/PhpPact/Consumer/Model/ProviderResponse.php
@@ -65,11 +65,11 @@ class ProviderResponse implements \JsonSerializable
 
     /**
      * @param string $header
-     * @param string $value
+     * @param array | string $value
      *
      * @return ProviderResponse
      */
-    public function addHeader(string $header, string $value): self
+    public function addHeader(string $header, $value): self
     {
         $this->headers[$header] = $value;
 

--- a/src/PhpPact/Standalone/MockService/MockServer.php
+++ b/src/PhpPact/Standalone/MockService/MockServer.php
@@ -164,6 +164,7 @@ class MockServer
             }
         } while ($tries <= $maxTries);
 
+        // @phpstan-ignore-next-line
         throw new HealthCheckFailedException("Failed to make connection to Mock Server in {$maxTries} attempts.");
     }
 }


### PR DESCRIPTION
The `string` was to strict and prevented the headers from being matchable.

With this fix you can use matcher in headers like this:
```php
$request = new ConsumerRequest()
    ->setMethod('POST')
    ->setPath('/api/call')
    ->addHeader('Content-Type', 'application/json')
    ->addHeader('X-Auth-Token', $matcher->like('auth-token'));
```