### PR TITLE
fix: GuzzleHttp\Psr7\Uri invalid path modification

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -152,7 +152,7 @@ class Verifier
      */
     public function verify(string $consumerName, string $tag = null, string $consumerVersion = null): self
     {
-        $path = "pacts/provider/{$this->config->getProviderName()}/consumer/{$consumerName}/";
+        $path = "/pacts/provider/{$this->config->getProviderName()}/consumer/{$consumerName}/";
 
         if ($tag) {
             $path .= "latest/{$tag}/";

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -150,10 +150,10 @@ class VerifierTest extends TestCase
         $version      = '11111';
 
         return [
-            [$consumerName, $providerName, null, $version, "pacts/provider/$providerName/consumer/$consumerName/version/$version/"],
-            [$consumerName, $providerName, $tag, null, "pacts/provider/$providerName/consumer/$consumerName/latest/$tag/"],
-            [$consumerName, $providerName, $tag, $version, "pacts/provider/$providerName/consumer/$consumerName/latest/$tag/"],
-            [$consumerName, $providerName, null, null, "pacts/provider/$providerName/consumer/$consumerName/latest/"],
+            [$consumerName, $providerName, null, $version, "/pacts/provider/$providerName/consumer/$consumerName/version/$version/"],
+            [$consumerName, $providerName, $tag, null, "/pacts/provider/$providerName/consumer/$consumerName/latest/$tag/"],
+            [$consumerName, $providerName, $tag, $version, "/pacts/provider/$providerName/consumer/$consumerName/latest/$tag/"],
+            [$consumerName, $providerName, null, null, "/pacts/provider/$providerName/consumer/$consumerName/latest/"],
         ];
     }
 


### PR DESCRIPTION
This PR fixes `InvalidArgumentException` exception (with message 'The path of a URI with an authority must start with a slash "/" or be empty') during provider verification from pact broker.

E.g. `(new \GuzzleHttp\Psr7\Uri)->withPath('foo/bar')` throws an exception because the path of a URI with an authority must start with a slash "/" or be empty (See [change log](https://github.com/guzzle/psr7/blob/master/CHANGELOG.md#changed-5)).

Fixes #207 