### PR TITLE
fix: Allow whitespace in the provider name

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -64,7 +64,7 @@ class Verifier
         $parameters = [];
 
         if (!empty($this->config->getProviderName())) {
-            $parameters[] = "--provider={$this->config->getProviderName()}";
+            $parameters[] = "--provider='{$this->config->getProviderName()}'";
         }
 
         if ($this->config->getProviderBaseUrl() !== null) {

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -24,7 +24,7 @@ class VerifierTest extends TestCase
 
         $config = new VerifierConfig();
         $config
-            ->setProviderName('someProvider')
+            ->setProviderName('some provider with whitespace')
             ->setProviderVersion('1.0.0')
             ->addProviderVersionTag('prod')
             ->addProviderVersionTag('dev')
@@ -72,7 +72,7 @@ class VerifierTest extends TestCase
         $this->assertContains('--include-wip-pacts-since=2020-01-30', $arguments);
         $this->assertContains('--consumer-version-selector=\'{"tag":"foo","latest":true}\'', $this->stripSpaces($arguments));
         $this->assertContains('--consumer-version-selector=\'{"tag":"bar","latest":true}\'', $this->stripSpaces($arguments));
-        $this->assertContains('--provider=someProvider', $arguments);
+        $this->assertContains('--provider=\'some provider with whitespace\'', $arguments);
     }
 
     /**


### PR DESCRIPTION
As reported yesterday in https://github.com/pact-foundation/pact-php/issues/218, but now with a fix :-).

Here's the original reported issue text:

> Hi,
> 
> First off, thanks for providing and maintaining this package. We are getting much use out of it.
> 
> Unfortunately, when switching to PHP 8.0 (and therefor pact-php 7.1.0), we found that having a whitespace in the provider name (or more specifically, in the value that is used in the --provider= command line argument) breaks our Pact run. That's because on this line: https://github.com/pact-foundation/pact-php/blame/7.1.0/src/PhpPact/Standalone/ProviderVerifier/Verifier.php#L66, the value is not quoted before putting it into the argument list. Another value, for example this one: https://github.com/pact-foundation/pact-php/blame/7.1.0/src/PhpPact/Standalone/ProviderVerifier/Verifier.php#L118, is quoted in the way I would assume the provider name could be quoted as well.
> 
> Is this backward compatibility break (compared to 7.0.1, where it worked because the --provider was not used yet, and the provider name was only used in a URL where it was urlencoded) intentional? If not, this might be a bug sweat_smile
> 
> Thanks for any reply in advance,
> Jelrik