### PR TITLE
feat: Add installer for system pact binaries if preinstalled on posix systems

### DIFF
--- a/src/PhpPact/Standalone/Installer/InstallManager.php
+++ b/src/PhpPact/Standalone/Installer/InstallManager.php
@@ -7,6 +7,7 @@ use PhpPact\Standalone\Installer\Model\Scripts;
 use PhpPact\Standalone\Installer\Service\InstallerInterface;
 use PhpPact\Standalone\Installer\Service\InstallerLinux;
 use PhpPact\Standalone\Installer\Service\InstallerMac;
+use PhpPact\Standalone\Installer\Service\InstallerPosixPreinstalled;
 use PhpPact\Standalone\Installer\Service\InstallerWindows;
 
 /**
@@ -30,7 +31,8 @@ class InstallManager
         $this
             ->registerInstaller(new InstallerWindows())
             ->registerInstaller(new InstallerMac())
-            ->registerInstaller(new InstallerLinux());
+            ->registerInstaller(new InstallerLinux())
+            ->registerInstaller(new InstallerPosixPreinstalled());
     }
 
     /**

--- a/src/PhpPact/Standalone/Installer/Service/InstallerPosixPreinstalled.php
+++ b/src/PhpPact/Standalone/Installer/Service/InstallerPosixPreinstalled.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PhpPact\Standalone\Installer\Service;
+
+use PhpPact\Standalone\Installer\Model\Scripts;
+
+class InstallerPosixPreinstalled implements InstallerInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function isEligible(): bool
+    {
+        return in_array(PHP_OS, ['Linux', 'Darwin']) && !empty($this->getBinaryPath('pact-provider-verifier'));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function install(string $destinationDir): Scripts
+    {
+        $scripts = new Scripts(
+            'pact-mock-service',
+            'pact-stub-service',
+            'pact-provider-verifier',
+            'pact-message',
+            'pact-broker'
+        );
+
+        return $scripts;
+    }
+
+    private function getBinaryPath($binary)
+    {
+        return trim(shell_exec('command -v ' . escapeshellarg($binary)));
+    }
+}

--- a/src/PhpPact/Standalone/Installer/Service/InstallerPosixPreinstalled.php
+++ b/src/PhpPact/Standalone/Installer/Service/InstallerPosixPreinstalled.php
@@ -30,7 +30,7 @@ class InstallerPosixPreinstalled implements InstallerInterface
         return $scripts;
     }
 
-    private function getBinaryPath($binary)
+    private function getBinaryPath(string $binary): string
     {
         return trim(shell_exec('command -v ' . escapeshellarg($binary)));
     }


### PR DESCRIPTION
Its necessary to use a different ruby vendor for arm64 architectures, so this gives the ability to use gem packages pre-installed on a system ruby, such as docker `linux/arm64` images when `linux/amd64` emulation is too unstable