### PR TITLE
fix: Address PHP 8.1 deprecations

### DIFF
--- a/src/PhpPact/Consumer/Model/ConsumerRequest.php
+++ b/src/PhpPact/Consumer/Model/ConsumerRequest.php
@@ -166,6 +166,7 @@ class ConsumerRequest implements \JsonSerializable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $results = [];

--- a/src/PhpPact/Consumer/Model/Interaction.php
+++ b/src/PhpPact/Consumer/Model/Interaction.php
@@ -111,6 +111,7 @@ class Interaction implements \JsonSerializable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         if ($this->getProviderState()) {

--- a/src/PhpPact/Consumer/Model/Message.php
+++ b/src/PhpPact/Consumer/Model/Message.php
@@ -133,6 +133,7 @@ class Message implements \JsonSerializable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $out                = [];

--- a/src/PhpPact/Consumer/Model/ProviderResponse.php
+++ b/src/PhpPact/Consumer/Model/ProviderResponse.php
@@ -99,6 +99,7 @@ class ProviderResponse implements \JsonSerializable
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $results = [

--- a/src/PhpPact/Standalone/MockService/MockServerConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfig.php
@@ -212,6 +212,10 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
      */
     public function setPactDir($pactDir): PactConfigInterface
     {
+        if ($pactDir === null) {
+            return $this;
+        }
+
         if ('\\' !== \DIRECTORY_SEPARATOR) {
             $pactDir = \str_replace('\\', \DIRECTORY_SEPARATOR, $pactDir);
         }

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectors.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectors.php
@@ -28,31 +28,37 @@ class ConsumerVersionSelectors implements Iterator, Countable
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->selectors[$this->position];
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->position;
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->position;
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return isset($this->selectors[$this->position]);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->position = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return \count($this->selectors);


### PR DESCRIPTION
Most of them were related to the change of type of PHP Core interfaces, and to maintain compatibility with PHP 7.3, the attribute `#[\ReturnTypeWillChange]` is used, which before PHP 8.0 is interpreted as a comment.

Another change is related with a deprecation when passing `null` in the 3rd argument of `str_replace`.