### PR TITLE
feat: Support all variations of ISO 8601 time zone designators

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -9,9 +9,9 @@ namespace PhpPact\Consumer\Matcher;
 class Matcher
 {
     public const ISO8601_DATE_FORMAT                 = '^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))?)$';
-    public const ISO8601_DATETIME_FORMAT             = '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$';
-    public const ISO8601_DATETIME_WITH_MILLIS_FORMAT = '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3}([+-][0-2]\\d:[0-5]\\d|Z)$';
-    public const ISO8601_TIME_FORMAT                 = '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$';
+    public const ISO8601_DATETIME_FORMAT             = '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d(?:|:?[0-5]\\d)|Z)?$';
+    public const ISO8601_DATETIME_WITH_MILLIS_FORMAT = '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3}([+-][0-2]\\d(?:|:?[0-5]\\d)|Z)?$';
+    public const ISO8601_TIME_FORMAT                 = '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?([+-][0-2]\\d(?:|:?[0-5]\\d)|Z)?)$';
     public const RFC3339_TIMESTAMP_FORMAT            = '^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s\\d{2}\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s(\\+|-)\\d{4}$';
     public const UUID_V4_FORMAT                      = '^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$';
     public const IPV4_FORMAT                         = '^(\\d{1,3}\\.)+\\d{1,3}$';

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -141,69 +141,119 @@ class MatcherTest extends TestCase
     }
 
     /**
+     * @dataProvider dataProviderForTimeTest
+     *
      * @throws Exception
      */
-    public function testTime()
+    public function testTime($time)
     {
         $expected = [
             'data' => [
-                'generate' => 'T22:44:30.652Z',
+                'generate' => $time,
                 'matcher'  => [
                     'json_class' => 'Regexp',
                     'o'          => 0,
-                    's'          => '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?(([+-]\\d\\d:\\d\\d)|Z)?)?$',
+                    's'          => '^(T\\d\\d:\\d\\d(:\\d\\d)?(\\.\\d+)?([+-][0-2]\\d(?:|:?[0-5]\\d)|Z)?)$',
                 ],
             ],
             'json_class' => 'Pact::Term',
         ];
 
-        $actual = $this->matcher->timeISO8601('T22:44:30.652Z');
+        $actual = $this->matcher->timeISO8601($time);
 
         $this->assertEquals($expected, $actual);
     }
 
+    public function dataProviderForTimeTest()
+    {
+        return [
+            ['T22:44:30.652Z'],
+            ['T22:44:30Z'],
+            ['T22:44Z'],
+            ['T22:44:30+01:00'],
+            ['T22:44:30+0100'],
+            ['T22:44:30+01'],
+            ['T22:44:30'],
+            ['T22:44:30-12:00'],
+            ['T22:44:30+0545'],
+            ['T22:44:30+14'],
+        ];
+    }
+
     /**
+     * @dataProvider dataProviderForDateTimeTest
+     *
      * @throws Exception
      */
-    public function testDateTime()
+    public function testDateTime($dateTime)
     {
         $expected = [
             'data' => [
-                'generate' => '2015-08-06T16:53:10+01:00',
+                'generate' => $dateTime,
                 'matcher'  => [
                     'json_class' => 'Regexp',
                     'o'          => 0,
-                    's'          => '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d:[0-5]\\d|Z)$',
+                    's'          => '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d([+-][0-2]\\d(?:|:?[0-5]\\d)|Z)?$',
                 ],
             ],
             'json_class' => 'Pact::Term',
         ];
 
-        $actual = $this->matcher->dateTimeISO8601('2015-08-06T16:53:10+01:00');
+        $actual = $this->matcher->dateTimeISO8601($dateTime);
 
         $this->assertEquals($expected, $actual);
     }
 
+    public function dataProviderForDateTimeTest()
+    {
+        return [
+            ['2015-08-06T16:53:10+01:00'],
+            ['2015-08-06T16:53:10+0100'],
+            ['2015-08-06T16:53:10+01'],
+            ['2015-08-06T16:53:10Z'],
+            ['2015-08-06T16:53:10'],
+            ['2015-08-06T16:53:10-12:00'],
+            ['2015-08-06T16:53:10+0545'],
+            ['2015-08-06T16:53:10+14'],
+        ];
+    }
+
     /**
+     * @dataProvider dataProviderForDateTimeWithMillisTest
+     *
      * @throws Exception
      */
-    public function testDateTimeWithMillis()
+    public function testDateTimeWithMillis($dateTime)
     {
         $expected = [
             'data' => [
-                'generate' => '2015-08-06T16:53:10.123+01:00',
+                'generate' => $dateTime,
                 'matcher'  => [
                     'json_class' => 'Regexp',
                     'o'          => 0,
-                    's'          => '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3}([+-][0-2]\\d:[0-5]\\d|Z)$',
+                    's'          => '^\\d{4}-[01]\\d-[0-3]\\dT[0-2]\\d:[0-5]\\d:[0-5]\\d\\.\\d{3}([+-][0-2]\\d(?:|:?[0-5]\\d)|Z)?$',
                 ],
             ],
             'json_class' => 'Pact::Term',
         ];
 
-        $actual = $this->matcher->dateTimeWithMillisISO8601('2015-08-06T16:53:10.123+01:00');
+        $actual = $this->matcher->dateTimeWithMillisISO8601($dateTime);
 
         $this->assertEquals($expected, $actual);
+    }
+
+    public function dataProviderForDateTimeWithMillisTest()
+    {
+        return [
+            ['2015-08-06T16:53:10.123+01:00'],
+            ['2015-08-06T16:53:10.123+0100'],
+            ['2015-08-06T16:53:10.123+01'],
+            ['2015-08-06T16:53:10.123Z'],
+            ['2015-08-06T16:53:10.123'],
+            ['2015-08-06T16:53:10.123-12:00'],
+            ['2015-08-06T16:53:10.123+0545'],
+            ['2015-08-06T16:53:10.123+14'],
+        ];
     }
 
     /**


### PR DESCRIPTION
Especially important for us is the support of the +/-hhmm format  (e.g. `2015-08-06T16:53:10.123+0100`) as it's used in our Java services.