### PR TITLE
Open the PactTestListener

### DIFF
--- a/src/PhpPact/Consumer/Listener/PactTestListener.php
+++ b/src/PhpPact/Consumer/Listener/PactTestListener.php
@@ -24,20 +24,20 @@ class PactTestListener implements TestListener
     use TestListenerDefaultImplementation;
 
     /** @var MockServer */
-    private $server;
+    protected $server;
 
     /**
      * Name of the test suite configured in your phpunit config.
      *
      * @var string[]
      */
-    private $testSuiteNames;
+    protected $testSuiteNames;
 
     /** @var MockServerEnvConfig */
-    private $mockServerConfig;
+    protected $mockServerConfig;
 
     /** @var bool */
-    private $failed;
+    protected $failed;
 
     /**
      * PactTestListener constructor.


### PR DESCRIPTION
It is hard to extend the PactTestListener therefore i have made the fields "protected"

This way we can start our own `MockServer` using a dockerized version of the ruby standone version