### PR TITLE
feat: pass pact-broker-base-url argument to verifier process

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -144,7 +144,7 @@ class Verifier
         }
 
         if ($this->config->getBrokerUri() !== null) {
-            $parameters[] = "--pact-broker-base-url={$this->config->getBrokerUri()}";
+            $parameters[] = "--pact-broker-base-url={$this->config->getBrokerUri()->__toString()}";
         }
 
         return $parameters;

--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -143,6 +143,10 @@ class Verifier
             $parameters[] = "--include-wip-pacts-since={$this->config->getIncludeWipPactSince()}";
         }
 
+        if ($this->config->getBrokerUri() !== null) {
+            $parameters[] = "--pact-broker-base-url={$this->config->getBrokerUri()}";
+        }
+
         return $parameters;
     }
 

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -36,6 +36,7 @@ class VerifierTest extends TestCase
             ->setBrokerToken('someToken')
             ->setBrokerUsername('someusername')
             ->setBrokerPassword('somepassword')
+            ->setBrokerUri(new Uri('https://example.broker/'))
             ->addCustomProviderHeader('key1', 'value1')
             ->addCustomProviderHeader('key2', 'value2')
             ->setVerbose(true)
@@ -77,6 +78,7 @@ class VerifierTest extends TestCase
         $this->assertContains('--consumer-version-selector=\'{"tag":"foo","latest":true}\'', $this->stripSpaces($arguments));
         $this->assertContains('--consumer-version-selector=\'{"tag":"bar","latest":true}\'', $this->stripSpaces($arguments));
         $this->assertContains('--provider=\'some provider with whitespace\'', $arguments);
+        $this->assertContains('--pact-broker-base-url=https://example.broker/', $arguments);
     }
 
     /**

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -121,7 +121,7 @@ class VerifierTest extends TestCase
             ->with($path)
             ->willReturn($uriMock);
 
-        $uriMock->expects($this->once())
+        $uriMock->expects($this->any())
             ->method('__toString')
             ->willReturn($expectedUrltoBroker);
 


### PR DESCRIPTION
With this change it's possible to fetch pacts directly from broker.
