### PR TITLE
fix: broken animal profile service URL

### DIFF
--- a/tests/PhpPact/Standalone/Broker/BrokerTest.php
+++ b/tests/PhpPact/Standalone/Broker/BrokerTest.php
@@ -48,7 +48,7 @@ class BrokerTest extends TestCase
     public function describeVersion(): void
     {
         $config = new BrokerConfig();
-        $config->setPacticipant(\rawurlencode('Animal Profile Service'))
+        $config->setPacticipant(\rawurlencode('Animal Profile Service V3'))
             ->setBrokerUri(new Uri('https://test.pactflow.io'))
             ->setBrokerUsername('dXfltyFMgNOFZAxr8io9wJ37iUpY42M')
             ->setBrokerPassword('O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1');
@@ -67,7 +67,7 @@ class BrokerTest extends TestCase
     public function listLatestPactVersions(): void
     {
         $config = new BrokerConfig();
-        $config->setPacticipant(\rawurlencode('Animal Profile Service'))
+        $config->setPacticipant(\rawurlencode('Animal Profile Service V3'))
             ->setBrokerUri(new Uri('https://test.pactflow.io'))
             ->setBrokerUsername('dXfltyFMgNOFZAxr8io9wJ37iUpY42M')
             ->setBrokerPassword('O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1');


### PR DESCRIPTION
Honestly I'm so mad I'm needing to sumbit another PR to an API testing product that isn't managing it's tests or API's.

Please put in place some process. Earlier this year it was changed credentials (which are hard-coded); now it's a rename of a service that this downstream relies on.

I Don't care if this merges as I don't use pactflow. Honestly every interaction upsets me because of this basic, preventable nonsense. This doesn't need to merge if someone renames `Animal Profile Service V3` back to `Animal Profile Service`.

Maybe a better pattern might be having a canned broker that lives in this repo, so does not need credentials, and won't flake based on network level changes. You never want to try to contribute and have network resource effects give false positives.

The actual test seems to be checking the broker command has received good arguments; so could a `--test` flag be added to sub-processes, so that they don't actually hit the network?

This was causing flakes in updating https://github.com/pact-foundation/pact-php/pull/257