### PR TITLE
fix: provider-verifier bad arguments naming

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -124,11 +124,11 @@ class Verifier
         }
 
         if ($this->config->isVerbose() === true) {
-            $parameters[] = '--verbose';
+            $parameters[] = '--verbose=VERBOSE';
         }
 
         if ($this->config->getLogDirectory() !== null) {
-            $parameters[] = "--log={$this->config->getLogDirectory()}";
+            $parameters[] = "--log-dir={$this->config->getLogDirectory()}";
         }
 
         if ($this->config->getFormat() !== null) {

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -65,8 +65,8 @@ class VerifierTest extends TestCase
         $this->assertContains('--broker-password=somepassword', $arguments);
         $this->assertContains('--custom-provider-header="key1: value1"', $arguments);
         $this->assertContains('--custom-provider-header="key2: value2"', $arguments);
-        $this->assertContains('--verbose', $arguments);
-        $this->assertContains('--log=my/log/directory', $arguments);
+        $this->assertContains('--verbose=VERBOSE', $arguments);
+        $this->assertContains('--log-dir=my/log/directory', $arguments);
         $this->assertContains('--format=someformat', $arguments);
         $this->assertContains('--provider-version-tag=prod', $arguments);
         $this->assertContains('--provider-version-tag=dev', $arguments);


### PR DESCRIPTION
closes #271 

I've also change the `--verbose` argument to `--verbose=VERBOSE`