### PR TITLE
Unlock amphp/cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "amphp/serialization": "^1.0",
         "amphp/socket": "^1.1.3",
         "amphp/sync": "^1.4.0",
-        "amphp/cache": "v1.4.0",
+        "amphp/cache": "^1.4.0",
         "amphp/windows-registry": "v0.3.3",
         "guzzlehttp/guzzle": "^6.5.8|^7.4.5",
         "phpunit/phpunit": ">=8.5.23"


### PR DESCRIPTION
It has been locked to v1.4.0 in
0aafa78ed78b7e05597e9bba9cc9aad415352def, without an explanation and probably by mistake.