### PR TITLE
feat: update phpstan/phpstan analyze tool

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "amphp/cache": "^1.4.0",
         "amphp/windows-registry": "v0.3.3",
         "guzzlehttp/guzzle": "^6.5.8|^7.4.5",
-        "phpunit/phpunit": "^8.5|^9.0",
+        "phpunit/phpunit": ">=8.5.23 <10",
         "tienvx/composer-downloads-plugin": "^1.1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "amphp/cache": "^1.4.0",
         "amphp/windows-registry": "v0.3.3",
         "guzzlehttp/guzzle": "^6.5.8|^7.4.5",
-        "phpunit/phpunit": ">=8.5.23",
+        "phpunit/phpunit": "^8.5|^9.0",
         "tienvx/composer-downloads-plugin": "^1.1.0"
     },
     "require-dev": {
@@ -45,7 +45,7 @@
         "slim/psr7": "^1.2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
-        "phpstan/phpstan": "^0.12.90"
+        "phpstan/phpstan": "^1.9"
     },
     "autoload": {
         "psr-4": {

--- a/src/PhpPact/Exception/ConnectionException.php
+++ b/src/PhpPact/Exception/ConnectionException.php
@@ -10,8 +10,8 @@ use Exception;
  */
 class ConnectionException extends Exception
 {
-    public function __construct(string $message)
+    public function __construct(string $message, \Exception $previous = null)
     {
-        parent::__construct($message, 0, null);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/src/PhpPact/Standalone/MockService/MockServer.php
+++ b/src/PhpPact/Standalone/MockService/MockServer.php
@@ -3,12 +3,12 @@
 namespace PhpPact\Standalone\MockService;
 
 use Exception;
-use GuzzleHttp\Exception\ConnectException;
 use PhpPact\Http\GuzzleClient;
 use PhpPact\Standalone\Exception\HealthCheckFailedException;
 use PhpPact\Standalone\Installer\Model\Scripts;
 use PhpPact\Standalone\MockService\Service\MockServerHttpService;
 use PhpPact\Standalone\Runner\ProcessRunner;
+use PhpPact\Exception\ConnectionException;
 
 /**
  * Ruby Standalone Mock Server Wrapper
@@ -135,15 +135,12 @@ class MockServer
             ++$tries;
 
             try {
-                $status = $service->healthCheck();
-
-                return $status;
-            } catch (ConnectException $e) {
+                return $service->healthCheck();
+            } catch (ConnectionException $e) {
                 \sleep($retrySec);
             }
         } while ($tries <= $maxTries);
 
-        // @phpstan-ignore-next-line
         throw new HealthCheckFailedException("Failed to make connection to Mock Server in {$maxTries} attempts.");
     }
 }

--- a/src/PhpPact/Standalone/MockService/Service/MockServerHttpService.php
+++ b/src/PhpPact/Standalone/MockService/Service/MockServerHttpService.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Standalone\MockService\Service;
 
+use GuzzleHttp\Exception\RequestException;
 use PhpPact\Consumer\Model\Interaction;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\Exception\ConnectionException;
@@ -60,6 +61,8 @@ class MockServerHttpService implements MockServerHttpServiceInterface
                 || $body !== "Mock service running\n") {
                 throw new ConnectionException('Failed to receive a successful response from the Mock Server.');
             }
+        } catch (RequestException $e) {
+            throw new ConnectionException('Failed to receive a successful response from the Mock Server.', $e);
         } catch (GuzzleConnectionException $e) {
             throw new ConnectionException('Failed to receive a successful response from the Mock Server.', $e);
         }

--- a/src/PhpPact/Standalone/MockService/Service/MockServerHttpService.php
+++ b/src/PhpPact/Standalone/MockService/Service/MockServerHttpService.php
@@ -7,6 +7,7 @@ use PhpPact\Consumer\Model\Message;
 use PhpPact\Exception\ConnectionException;
 use PhpPact\Http\ClientInterface;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;
+use GuzzleHttp\Exception\ConnectException as GuzzleConnectionException;
 
 /**
  * Http Service that interacts with the Ruby Standalone Mock Server.
@@ -45,18 +46,22 @@ class MockServerHttpService implements MockServerHttpServiceInterface
     {
         $uri = $this->config->getBaseUri()->withPath('/');
 
-        $response = $this->client->get($uri, [
-            'headers' => [
-                'Content-Type'        => 'application/json',
-                'X-Pact-Mock-Service' => true,
-            ],
-        ]);
+        try {
+            $response = $this->client->get($uri, [
+                'headers' => [
+                    'Content-Type'        => 'application/json',
+                    'X-Pact-Mock-Service' => true,
+                ],
+            ]);
 
-        $body = $response->getBody()->getContents();
+            $body = $response->getBody()->getContents();
 
-        if ($response->getStatusCode() !== 200
-            || $body !== "Mock service running\n") {
-            throw new ConnectionException('Failed to receive a successful response from the Mock Server.');
+            if ($response->getStatusCode() !== 200
+                || $body !== "Mock service running\n") {
+                throw new ConnectionException('Failed to receive a successful response from the Mock Server.');
+            }
+        } catch (GuzzleConnectionException $e) {
+            throw new ConnectionException('Failed to receive a successful response from the Mock Server.', $e);
         }
 
         return true;

--- a/tests/PhpPact/Consumer/InteractionBuilderTest.php
+++ b/tests/PhpPact/Consumer/InteractionBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer;
+namespace PhpPactTest\Consumer;
 
 use PhpPact\Consumer\Matcher\Matcher;
 use PhpPact\Consumer\Model\ConsumerRequest;

--- a/tests/PhpPact/Consumer/InteractionBuilderTest.php
+++ b/tests/PhpPact/Consumer/InteractionBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpPactTest\Consumer;
 
+use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Matcher\Matcher;
 use PhpPact\Consumer\Model\ConsumerRequest;
 use PhpPact\Consumer\Model\ProviderResponse;

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace PhpPact\Consumer\Matcher;
+namespace PhpPactTest\Consumer\Matcher;
 
 use Exception;
+use PhpPact\Consumer\Matcher\Matcher;
 use PHPUnit\Framework\TestCase;
 
 class MatcherTest extends TestCase

--- a/tests/PhpPact/Consumer/Model/ConsumerRequestTest.php
+++ b/tests/PhpPact/Consumer/Model/ConsumerRequestTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace PhpPact\Consumer\Model;
+namespace PhpPactTest\Consumer\Model;
 
 use PhpPact\Consumer\Matcher\Matcher;
+use PhpPact\Consumer\Model\ConsumerRequest;
 use PHPUnit\Framework\TestCase;
 
 class ConsumerRequestTest extends TestCase

--- a/tests/PhpPact/Consumer/Model/ProviderResponseTest.php
+++ b/tests/PhpPact/Consumer/Model/ProviderResponseTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace PhpPact\Consumer\Model;
+namespace PhpPactTest\Consumer\Model;
 
+use PhpPact\Consumer\Model\ProviderResponse;
 use PHPUnit\Framework\TestCase;
 
 class ProviderResponseTest extends TestCase

--- a/tests/PhpPact/Standalone/Broker/BrokerConfigTest.php
+++ b/tests/PhpPact/Standalone/Broker/BrokerConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer;
+namespace PhpPactTest\Standalone\Broker;
 
 use PhpPact\Standalone\MockService\MockServerConfig;
 use PHPUnit\Framework\TestCase;

--- a/tests/PhpPact/Standalone/Broker/BrokerTest.php
+++ b/tests/PhpPact/Standalone/Broker/BrokerTest.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace PhpPact\Standalone\Broker;
+namespace PhpPactTest\Standalone\Broker;
 
 use GuzzleHttp\Psr7\Uri;
+use PhpPact\Standalone\Broker\Broker;
+use PhpPact\Standalone\Broker\BrokerConfig;
 use PHPUnit\Framework\TestCase;
 
 class BrokerTest extends TestCase

--- a/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer;
+namespace PhpPactTest\Standalone\MockServer;
 
 use PhpPact\Standalone\MockService\MockServerConfig;
 use PHPUnit\Framework\TestCase;

--- a/tests/PhpPact/Standalone/MockServer/MockServerTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer;
+namespace PhpPactTest\Standalone\MockServer;
 
 use GuzzleHttp\Exception\ConnectException;
 use PhpPact\Standalone\Exception\HealthCheckFailedException;

--- a/tests/PhpPact/Standalone/MockServer/MockServerTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerTest.php
@@ -2,7 +2,7 @@
 
 namespace PhpPactTest\Standalone\MockServer;
 
-use GuzzleHttp\Exception\ConnectException;
+use PhpPact\Exception\ConnectionException;
 use PhpPact\Standalone\Exception\HealthCheckFailedException;
 use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Standalone\MockService\MockServer;
@@ -43,7 +43,7 @@ class MockServerTest extends TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $connectionException = $this->getMockBuilder(ConnectException::class)
+        $connectionException = $this->getMockBuilder(ConnectionException::class)
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
+++ b/tests/PhpPact/Standalone/MockServer/Service/MockServerHttpServiceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Standalone\MockService\Service;
+namespace PhpPactTest\Standalone\MockServer\Service;
 
 use GuzzleHttp\Exception\ServerException;
 use PhpPact\Consumer\InteractionBuilder;
@@ -14,6 +14,8 @@ use PhpPact\Standalone\Exception\MissingEnvVariableException;
 use PhpPact\Standalone\MockService\MockServer;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;
 use PhpPact\Standalone\MockService\MockServerEnvConfig;
+use PhpPact\Standalone\MockService\Service\MockServerHttpService;
+use PhpPact\Standalone\MockService\Service\MockServerHttpServiceInterface;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Standalone\ProviderVerifier;
+namespace PhpPactTest\Standalone\ProviderVerifier;
 
 use GuzzleHttp\Psr7\Uri;
 use Monolog\Handler\TestHandler;
@@ -9,6 +9,9 @@ use PhpPact\Broker\Service\BrokerHttpClient;
 use PhpPact\Broker\Service\BrokerHttpClientInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\ConsumerVersionSelectors;
 use PhpPact\Standalone\ProviderVerifier\Model\VerifierConfig;
+use PhpPact\Standalone\ProviderVerifier\ProcessRunnerFactory;
+use PhpPact\Standalone\ProviderVerifier\Verifier;
+use PhpPact\Standalone\ProviderVerifier\VerifierProcess;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 

--- a/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
+++ b/tests/PhpPact/Standalone/Runner/ProcessRunnerTest.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace PhpPact\Standalone\Runner;
+namespace PhpPactTest\Standalone\Runner;
 
+use PhpPact\Standalone\Runner\ProcessRunner;
 use PHPUnit\Framework\TestCase;
 
 class ProcessRunnerTest extends TestCase

--- a/tests/PhpPact/Standalone/StubServer/Service/StubServerHttpServiceTest.php
+++ b/tests/PhpPact/Standalone/StubServer/Service/StubServerHttpServiceTest.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace PhpPact\Standalone\StubService\Service;
+namespace PhpPactTest\Standalone\StubServer\Service;
 
 use PhpPact\Http\GuzzleClient;
 use PhpPact\Standalone\Exception\MissingEnvVariableException;
+use PhpPact\Standalone\StubService\Service\StubServerHttpService;
+use PhpPact\Standalone\StubService\Service\StubServerHttpServiceInterface;
 use PhpPact\Standalone\StubService\StubServer;
 use PhpPact\Standalone\StubService\StubServerConfig;
 use PhpPact\Standalone\StubService\StubServerConfigInterface;

--- a/tests/PhpPact/Standalone/StubServer/StubServerConfigTest.php
+++ b/tests/PhpPact/Standalone/StubServer/StubServerConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer;
+namespace PhpPactTest\Standalone\StubServer;
 
 use PhpPact\Standalone\StubService\StubServerConfig;
 use PHPUnit\Framework\TestCase;

--- a/tests/PhpPact/Standalone/StubServer/StubServerTest.php
+++ b/tests/PhpPact/Standalone/StubServer/StubServerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PhpPact\Consumer;
+namespace PhpPactTest\Standalone\StubServer;
 
 use PhpPact\Standalone\StubService\StubServer;
 use PhpPact\Standalone\StubService\StubServerConfig;


### PR DESCRIPTION
* Update phpstan/phpstan to actual version to resolve tons of deprecation warnings.
* specify phpunit versions to avoid install phpunit 10, since they removed some stuff and pact-php not working with it.
* Fix tests namespace to match psr-4 autoloader and avoid additional warnings.