### PR TITLE
Run php cs fixer on PHP 8.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1' ]
+        php: [ '8.0', '8.1', '8.2' ]
 
     steps:
       - name: 🛑 Cancel Previous Runs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.0', '8.1', '8.2' ]
+        php: [ '8.2' ]
 
     steps:
       - name: 🛑 Cancel Previous Runs


### PR DESCRIPTION
PHP-CS-FIXER released version 3.15 with PHP 8.2 support