### PR TITLE
broker: Fix broker describe pacticipant argument passing

### DIFF
--- a/src/PhpPact/Standalone/Broker/Broker.php
+++ b/src/PhpPact/Standalone/Broker/Broker.php
@@ -36,7 +36,7 @@ class Broker
             \array_merge(
                 [
                     'can-i-deploy',
-                    '--pacticipant=' . $this->config->getPacticipant(),
+                    '--pacticipant=\'' . $this->config->getPacticipant().'\'',
                     '--version=' . $this->config->getVersion()
                 ],
                 $this->getArguments()
@@ -135,7 +135,7 @@ class Broker
             \array_merge(
                 [
                     'create-version-tag',
-                    '--pacticipant=' . $this->config->getPacticipant(),
+                    '--pacticipant=\'' . $this->config->getPacticipant().'\'',
                     '--version=' . $this->config->getVersion(),
                     '--tag=' . $this->config->getTag(),
                 ],
@@ -186,7 +186,7 @@ class Broker
             \array_merge(
                 [
                     'describe-version',
-                    '--pacticipant=' . $this->config->getPacticipant(),
+                    '--pacticipant=\'' . $this->config->getPacticipant().'\'',
                     '--output=json',
                 ],
                 $this->getArguments()

--- a/tests/PhpPact/Standalone/Broker/BrokerTest.php
+++ b/tests/PhpPact/Standalone/Broker/BrokerTest.php
@@ -50,7 +50,7 @@ class BrokerTest extends TestCase
     public function describeVersion(): void
     {
         $config = new BrokerConfig();
-        $config->setPacticipant("\"Animal Profile Service\"")
+        $config->setPacticipant('Animal Profile Service')
             ->setBrokerUri(new Uri('https://test.pactflow.io'))
             ->setBrokerUsername('dXfltyFMgNOFZAxr8io9wJ37iUpY42M')
             ->setBrokerPassword('O5AIZWxelWbLvqMd8PkAVycBJh2Psyg1');


### PR DESCRIPTION
In reference to https://github.com/pact-foundation/pact-php/pull/304 
Config class end-user should not be aware of correct passing data with them usage in mind (e.g. quotes).
I think `PhpPact\Standalone\Broker\Broker` class should get correct use of config data and pass them to CLI command in right way. 