### PR TITLE
MockServerConfig improvements

### DIFF
--- a/src/PhpPact/Standalone/MockService/MockServerConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfig.php
@@ -62,12 +62,12 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
     /**
      * The max allowed attempts the mock server has to be available in. Otherwise it is considered as sick.
      */
-    private int $healthCheckTimeout;
+    private int $healthCheckTimeout = 10;
 
     /**
      * The seconds between health checks of mock server
      */
-    private int $healthCheckRetrySec;
+    private int $healthCheckRetrySec = 1;
 
     private ?string $logLevel = null;
 
@@ -118,7 +118,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function setSecure(bool $secure): MockServerConfigInterface
+    public function setSecure(bool $secure): self
     {
         $this->secure = $secure;
 
@@ -274,7 +274,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         return $this->logLevel;
     }
 
-    public function setLogLevel(string $logLevel): PactConfigInterface
+    public function setLogLevel(string $logLevel): self
     {
         $logLevel = \strtoupper($logLevel);
         if (!\in_array($logLevel, ['DEBUG', 'INFO', 'WARN', 'ERROR'])) {
@@ -303,7 +303,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         return $this;
     }
 
-    public function setHealthCheckTimeout(int $timeout): MockServerConfigInterface
+    public function setHealthCheckTimeout(int $timeout): self
     {
         $this->healthCheckTimeout = $timeout;
 
@@ -315,7 +315,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         return $this->healthCheckTimeout;
     }
 
-    public function setHealthCheckRetrySec(int $seconds): MockServerConfigInterface
+    public function setHealthCheckRetrySec(int $seconds): self
     {
         $this->healthCheckRetrySec = $seconds;
 

--- a/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
@@ -15,21 +15,30 @@ class MockServerConfigTest extends TestCase
         $consumer                 = 'test-consumer';
         $pactDir                  = 'test-pact-dir/';
         $pactFileWriteMode        = 'merge';
+        $logLevel                 = 'INFO';
         $log                      = 'test-log-dir/';
         $cors                     = true;
         $pactSpecificationVersion = '2.0';
+        $healthCheckTimeout       = 20;
+        $healthCheckRetrySec      = 2;
+        $secure                   = false;
 
         $subject = (new MockServerConfig())
+            ->setSecure(false)
             ->setHost($host)
             ->setPort($port)
             ->setProvider($provider)
             ->setConsumer($consumer)
             ->setPactDir($pactDir)
             ->setPactFileWriteMode($pactFileWriteMode)
+            ->setLogLevel($logLevel)
             ->setLog($log)
             ->setPactSpecificationVersion($pactSpecificationVersion)
-            ->setCors($cors);
+            ->setCors($cors)
+            ->setHealthCheckTimeout(20)
+            ->setHealthCheckRetrySec(2);
 
+        static::assertSame($secure, $subject->isSecure());
         static::assertSame($host, $subject->getHost());
         static::assertSame($port, $subject->getPort());
         static::assertSame($provider, $subject->getProvider());
@@ -37,7 +46,10 @@ class MockServerConfigTest extends TestCase
         static::assertSame($pactDir, $subject->getPactDir());
         static::assertSame($pactFileWriteMode, $subject->getPactFileWriteMode());
         static::assertSame($log, $subject->getLog());
+        static::assertSame($logLevel, $subject->getLogLevel());
         static::assertSame($pactSpecificationVersion, $subject->getPactSpecificationVersion());
         static::assertSame($cors, $subject->hasCors());
+        static::assertSame($healthCheckTimeout, $subject->getHealthCheckTimeout());
+        static::assertSame($healthCheckRetrySec, $subject->getHealthCheckRetrySec());
     }
 }


### PR DESCRIPTION
* Fix config setters returning a interface which prevents chaining when static analysis tools are in use as the interfaces are only a subset of what the class can do.

* Set defaults similar to MockServerEnvConfig for timeouts as these are typed but not set to a value by default, forcing you to set them to avoid an error.