### PR TITLE
Gotta go fast

### DIFF
--- a/src/PhpPact/Standalone/MockService/MockServer.php
+++ b/src/PhpPact/Standalone/MockService/MockServer.php
@@ -42,10 +42,6 @@ class MockServer
         $processId =  $this->processRunner->run();
 
         $result = $this->verifyHealthCheck();
-        if ($result) {
-            $retrySec = $this->config->getHealthCheckRetrySec();
-            \sleep($retrySec);
-        }
 
         return $processId;
     }
@@ -122,7 +118,7 @@ class MockServer
             try {
                 return $service->healthCheck();
             } catch (ConnectionException $e) {
-                \sleep($retrySec);
+                \usleep(round($retrySec * 1000000));
             }
         } while ($tries <= $maxTries);
 

--- a/src/PhpPact/Standalone/MockService/MockServerConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfig.php
@@ -62,12 +62,12 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
     /**
      * The max allowed attempts the mock server has to be available in. Otherwise it is considered as sick.
      */
-    private int $healthCheckTimeout;
+    private int $healthCheckTimeout = 10;
 
     /**
      * The seconds between health checks of mock server
      */
-    private int $healthCheckRetrySec;
+    private int $healthCheckRetrySec = 1;
 
     private ?string $logLevel = null;
 
@@ -118,7 +118,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function setSecure(bool $secure): MockServerConfigInterface
+    public function setSecure(bool $secure): self
     {
         $this->secure = $secure;
 
@@ -274,7 +274,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         return $this->logLevel;
     }
 
-    public function setLogLevel(string $logLevel): PactConfigInterface
+    public function setLogLevel(string $logLevel): self
     {
         $logLevel = \strtoupper($logLevel);
         if (!\in_array($logLevel, ['DEBUG', 'INFO', 'WARN', 'ERROR'])) {
@@ -303,7 +303,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         return $this;
     }
 
-    public function setHealthCheckTimeout(int $timeout): MockServerConfigInterface
+    public function setHealthCheckTimeout(int $timeout): self
     {
         $this->healthCheckTimeout = $timeout;
 
@@ -315,7 +315,7 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         return $this->healthCheckTimeout;
     }
 
-    public function setHealthCheckRetrySec(int $seconds): MockServerConfigInterface
+    public function setHealthCheckRetrySec(int $seconds): self
     {
         $this->healthCheckRetrySec = $seconds;
 

--- a/src/PhpPact/Standalone/MockService/MockServerConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfig.php
@@ -62,12 +62,12 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
     /**
      * The max allowed attempts the mock server has to be available in. Otherwise it is considered as sick.
      */
-    private int $healthCheckTimeout = 10;
+    private int $healthCheckTimeout = 100;
 
     /**
      * The seconds between health checks of mock server
      */
-    private int $healthCheckRetrySec = 1;
+    private float $healthCheckRetrySec = 0.1;
 
     private ?string $logLevel = null;
 
@@ -315,14 +315,14 @@ class MockServerConfig implements MockServerConfigInterface, PactConfigInterface
         return $this->healthCheckTimeout;
     }
 
-    public function setHealthCheckRetrySec(int $seconds): self
+    public function setHealthCheckRetrySec(float $seconds): self
     {
         $this->healthCheckRetrySec = $seconds;
 
         return $this;
     }
 
-    public function getHealthCheckRetrySec(): int
+    public function getHealthCheckRetrySec(): float
     {
         return $this->healthCheckRetrySec;
     }

--- a/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
+++ b/src/PhpPact/Standalone/MockService/MockServerConfigInterface.php
@@ -59,7 +59,7 @@ interface MockServerConfigInterface
 
     public function getHealthCheckTimeout(): int;
 
-    public function setHealthCheckRetrySec(int $seconds): self;
+    public function setHealthCheckRetrySec(float $seconds): self;
 
-    public function getHealthCheckRetrySec(): int;
+    public function getHealthCheckRetrySec(): float;
 }

--- a/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
+++ b/src/PhpPact/Standalone/MockService/MockServerEnvConfig.php
@@ -33,13 +33,13 @@ class MockServerEnvConfig extends MockServerConfig
 
         $timeout = $this->parseEnv('PACT_MOCK_SERVER_HEALTH_CHECK_TIMEOUT', false);
         if (!$timeout) {
-            $timeout = 10;
+            $timeout = 100;
         }
         $this->setHealthCheckTimeout($timeout);
 
         $seconds = $this->parseEnv('PACT_MOCK_SERVER_HEALTH_CHECK_RETRY_SEC', false);
         if (!$seconds) {
-            $seconds = 1;
+            $seconds = 0.1;
         }
         $this->setHealthCheckRetrySec($seconds);
 

--- a/src/PhpPact/Standalone/PactMessage/PactMessage.php
+++ b/src/PhpPact/Standalone/PactMessage/PactMessage.php
@@ -40,8 +40,6 @@ class PactMessage
         $process = new ProcessRunner(Scripts::getPactMessage(), $arguments);
         $process->runBlocking();
 
-        \sleep(1);
-
         return true;
     }
 }

--- a/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
@@ -15,21 +15,30 @@ class MockServerConfigTest extends TestCase
         $consumer                 = 'test-consumer';
         $pactDir                  = 'test-pact-dir/';
         $pactFileWriteMode        = 'merge';
+        $logLevel                 = 'INFO';
         $log                      = 'test-log-dir/';
         $cors                     = true;
         $pactSpecificationVersion = '2.0';
+        $healthCheckTimeout       = 20;
+        $healthCheckRetrySec      = 2;
+        $secure                   = false;
 
         $subject = (new MockServerConfig())
+            ->setSecure(false)
             ->setHost($host)
             ->setPort($port)
             ->setProvider($provider)
             ->setConsumer($consumer)
             ->setPactDir($pactDir)
             ->setPactFileWriteMode($pactFileWriteMode)
+            ->setLogLevel($logLevel)
             ->setLog($log)
             ->setPactSpecificationVersion($pactSpecificationVersion)
-            ->setCors($cors);
+            ->setCors($cors)
+            ->setHealthCheckTimeout(20)
+            ->setHealthCheckRetrySec(2);
 
+        static::assertSame($secure, $subject->isSecure());
         static::assertSame($host, $subject->getHost());
         static::assertSame($port, $subject->getPort());
         static::assertSame($provider, $subject->getProvider());
@@ -37,7 +46,10 @@ class MockServerConfigTest extends TestCase
         static::assertSame($pactDir, $subject->getPactDir());
         static::assertSame($pactFileWriteMode, $subject->getPactFileWriteMode());
         static::assertSame($log, $subject->getLog());
+        static::assertSame($logLevel, $subject->getLogLevel());
         static::assertSame($pactSpecificationVersion, $subject->getPactSpecificationVersion());
         static::assertSame($cors, $subject->hasCors());
+        static::assertSame($healthCheckTimeout, $subject->getHealthCheckTimeout());
+        static::assertSame($healthCheckRetrySec, $subject->getHealthCheckRetrySec());
     }
 }

--- a/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
@@ -20,7 +20,7 @@ class MockServerConfigTest extends TestCase
         $cors                     = true;
         $pactSpecificationVersion = '2.0';
         $healthCheckTimeout       = 20;
-        $healthCheckRetrySec      = 2;
+        $healthCheckRetrySec      = 2.0;
         $secure                   = false;
 
         $subject = (new MockServerConfig())


### PR DESCRIPTION
Pact consumer tests are supposed to be like unit tests but mine were taking 2 seconds+ each, the majority of which was php sleep()

* Allow SetHealthCheckRetrySec / PACT_MOCK_SERVER_HEALTH_CHECK_RETRY_SEC
  to be a float so it can be set to 0.1 instead of 1.

* Use usleep instead of sleep so that the retry seconds can be a < 1 second.

* Increase the total number of attempts so it still tries for ~10 seconds.

* Remove sleeps in PactMessage which do not appear to be needed.

Results in my environment 

3 pact consumer tests
Before - 00:06.577s
After  - 00:01.603s

32 pact message tests
Before - 00:55.202s
After  - 00:21.900s



