### PR TITLE
chore: Replace atLeastAndMostLike by arrayLike

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -93,23 +93,24 @@ class Matcher
     }
 
     /**
-     * @param mixed $value example of what the expected data would be
-     * @param int   $min   minimum number of objects to verify against
+     * @param array $values example of what the expected data would be
+     * @param int   $min    minimum number of objects to verify against
+     * @param int   $min    maximum number of objects to verify against
      *
      * @return array<string, mixed>
      */
-    public function atLeastAndMostLike(mixed $value, int $min, int $max): array
+    public function arrayLike(array $values, ?int $min = null, ?int $max = null): array
     {
-        if ($min <= 0 || $min > $max) {
+        if (($min !== null && $min <= 0) || ($min !== null && $max !== null && $min > $max)) {
             throw new Exception('Invalid minimum number of elements');
         }
 
         return [
-            'value' => array_fill(0, $min, $value),
+            'value' => $values,
             'pact:matcher:type' => 'type',
-            'min' => $min,
-            'max' => $max,
-        ];
+        ] +
+        ($min === null ? [] : ['min' => $min]) +
+        ($max === null ? [] : ['max' => $max]);
     }
 
     /**

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -134,36 +134,45 @@ class MatcherTest extends TestCase
     /**
      * @throws Exception
      */
-    public function testAtLeastAndMostLikeInvalidMin()
+    public function testArrayLikeNegativeMin()
     {
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Invalid minimum number of elements');
-        $this->matcher->atLeastAndMostLike('text', 10, 1);
+        $this->matcher->arrayLike(['text'], -2, 9);
     }
 
     /**
-     * @dataProvider dataProviderForEachLikeTest
+     * @throws Exception
      */
-    public function testAtLeastAndMostLike(object|array $value)
+    public function testArrayLikeMinLargerThanMax()
     {
-        $eachValueMatcher = [
-            'value1' => [
-                'value'             => 1,
-                'pact:matcher:type' => 'type',
-            ],
-            'value2' => 2,
-        ];
-        $expected = \json_encode([
-            'value' => [
-                $eachValueMatcher,
-                $eachValueMatcher,
-            ],
-            'pact:matcher:type' => 'type',
-            'min'               => 2,
-            'max'               => 4,
-        ]);
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid minimum number of elements');
+        $this->matcher->arrayLike(['text'], 10, 1);
+    }
 
-        $actual = \json_encode($this->matcher->atLeastAndMostLike($value, 2, 4));
+    public function dataProviderForArrayLikeTest()
+    {
+        return [
+            [null, null, []],
+            [2, null, ['min' => 2]],
+            [null, 5, ['max' => 5]],
+            [3, 8, ['min' => 3, 'max' => 8]],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForArrayLikeTest
+     */
+    public function testArrayLike(?int $min, ?int $max, array $expectedMinMax)
+    {
+        $values = ['test1', 'test2'];
+        $expected = \json_encode([
+            'value'             => $values,
+            'pact:matcher:type' => 'type',
+        ] + $expectedMinMax);
+
+        $actual = \json_encode($this->matcher->arrayLike($values, $min, $max));
 
         $this->assertEquals($expected, $actual);
     }


### PR DESCRIPTION
`atLeastAndMostLike` is my invention, and I don't think it's useful. Instead, I replace it with `arrayLike` (which is also my invention).

`arrayLike` do what `atLeastAndMostLike` do, which is checking both `min` and `max`, but it also:

* Allow any array as example value (so example value doesn't need to be a value appear multiple times)
* Allow min = 0 (in this case example value doesn't need to be empty array)
* Min can be null
* Max can be null
* Min and max can be both null (now it become `$matcher->like()`)
* Min and max are not null (`atLeastAndMostLike` above)

for example:

```php
$user = [
    'gender' => $matcher->regex('male', 'male|female|other'),
    'firstName' => $macher->like('Bettye'),
    'lastName' => $macher->like('Johnston'),
    'birthday' => $matcher->date('yyyy-MM-dd', '2022-11-21')
];
$father = [
    'gender' => 'male',
    'firstName' => 'Deonte',
    'lastName' => 'Zulauf',
    'birthday' =>  '1970-11-21'
];
$mother = [
    'gender' => 'female',
    'firstName' => 'Delpha',
    'lastName' => 'Ryan',
    'birthday' =>  '1986-11-21'
];
$users = $matcher->arrayLike([
    $user,
    $father,
    $mother
], 0)
```