### PR TITLE
chore: Closing socket connection after opening it

### DIFF
--- a/example/tests/Provider/PactVerifyTest.php
+++ b/example/tests/Provider/PactVerifyTest.php
@@ -28,7 +28,15 @@ class PactVerifyTest extends TestCase
         $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath], null, null, null, null);
 
         $this->process->start();
-        $this->process->waitUntil(fn () => is_resource(@fsockopen('127.0.0.1', 7202)));
+        $this->process->waitUntil(function (): bool {
+            $fp = @fsockopen('127.0.0.1', 7202);
+            $isOpen = is_resource($fp);
+            if ($isOpen) {
+                fclose($fp);
+            }
+
+            return $isOpen;
+        });
     }
 
     /**

--- a/example/tests/Provider/PactVerifyTest.php
+++ b/example/tests/Provider/PactVerifyTest.php
@@ -25,7 +25,7 @@ class PactVerifyTest extends TestCase
     {
         $publicPath    =  __DIR__ . '/../../src/Provider/public/';
 
-        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath], null, null, null, null);
+        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath]);
 
         $this->process->start();
         $this->process->waitUntil(function (): bool {

--- a/example/tests/Provider/PactVerifyTest.php
+++ b/example/tests/Provider/PactVerifyTest.php
@@ -25,7 +25,7 @@ class PactVerifyTest extends TestCase
     {
         $publicPath    =  __DIR__ . '/../../src/Provider/public/';
 
-        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath]);
+        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath], null, null, null, null);
 
         $this->process->start();
         $this->process->waitUntil(fn () => is_resource(@fsockopen('127.0.0.1', 7202)));

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -22,7 +22,15 @@ class VerifierTest extends TestCase
         $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath], null, null, null, null);
 
         $this->process->start();
-        $this->process->waitUntil(fn () => is_resource(@fsockopen('127.0.0.1', 7202)));
+        $this->process->waitUntil(function (): bool {
+            $fp = @fsockopen('127.0.0.1', 7202);
+            $isOpen = is_resource($fp);
+            if ($isOpen) {
+                fclose($fp);
+            }
+
+            return $isOpen;
+        });
     }
 
     /**

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -19,7 +19,7 @@ class VerifierTest extends TestCase
     {
         $publicPath    =  __DIR__ . '/../../../_public/';
 
-        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath]);
+        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath], null, null, null, null);
 
         $this->process->start();
         $this->process->waitUntil(fn () => is_resource(@fsockopen('127.0.0.1', 7202)));

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -19,7 +19,7 @@ class VerifierTest extends TestCase
     {
         $publicPath    =  __DIR__ . '/../../../_public/';
 
-        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath], null, null, null, null);
+        $this->process = new Process(['php', '-S', '127.0.0.1:7202', '-t', $publicPath]);
 
         $this->process->start();
         $this->process->waitUntil(function (): bool {


### PR DESCRIPTION
Attempt to fix the timeout error like this:

```
 There was 1 error:

1) PhpPactTest\Standalone\ProviderVerifier\VerifierTest::testVerify
Symfony\Component\Process\Exception\ProcessTimedOutException: The process "php -S 127.0.0.1:7202 -t "D:\a\pact-php\pact-php\tests\PhpPact\Standalone\ProviderVerifier/../../../_public/"" exceeded the timeout of 60 seconds.

D:\a\pact-php\pact-php\vendor\symfony\process\Process.php:1263
D:\a\pact-php\pact-php\vendor\symfony\process\Process.php:468
D:\a\pact-php\pact-php\tests\PhpPact\Standalone\ProviderVerifier\VerifierTest.php:25
```

Link to [failed job](https://github.com/pact-foundation/pact-php/actions/runs/5694624383/job/15436171774?pr=327)