### PR TITLE
Disable jit on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,7 @@ jobs:
           extensions: sockets, curl, zip, ffi
           php-version: ${{ matrix.php }}
           coverage: none
+          ini-values: ${{ matrix.operating-system == 'windows-latest' && 'opcache.enable=0 opcache.enable_cli=0' || '' }}
 
       - name: Composer install
         uses: ramsey/composer-install@v2


### PR DESCRIPTION
The error I am trying to fix is:

```
[Fri Sep 22 04:21:58 2023] 127.0.0.1:65468 [500]: POST /pact-change-state - Uncaught UnexpectedValueException: JIT on Windows is not currently supported in D:\a\pact-php\pact-php\vendor\phpseclib\phpseclib\phpseclib\bootstrap.php:28
```

You need this [PR](https://github.com/pact-foundation/pact-php/pull/339) to see the error clearly.

* phpseclib doesn't support [JIT on Windows](https://github.com/phpseclib/phpseclib/blob/master/phpseclib/bootstrap.php#L17), so I need to disable it.
* I tried to set env `PHPSECLIB_ALLOW_JIT` but it seems does not work
