### PR TITLE
fix: Fix fatal error when reponse's status is not set

### DIFF
--- a/src/PhpPact/Consumer/Model/Interaction/StatusTrait.php
+++ b/src/PhpPact/Consumer/Model/Interaction/StatusTrait.php
@@ -4,7 +4,7 @@ namespace PhpPact\Consumer\Model\Interaction;
 
 trait StatusTrait
 {
-    private int $status;
+    private int $status = 200;
 
     public function getStatus(): int
     {


### PR DESCRIPTION
Fix `Fatal error: Typed property PhpPact\Consumer\Model\ProviderResponse::$status must not be accessed before initialization (Behat\Testwork\Call\Exception\FatalThrowableError)`

* This is mainly for compatibility suite
* For end-user, this change will save them a line of code:

```php
        $request = new ConsumerRequest();
        $request
            ->setMethod('GET')
            ->setPath('/goodbye/Bob')
            ->addHeader('Content-Type', 'application/json');

        $response = new ProviderResponse(); // still need to define an object like this, but it's future improvement, not right now
        // $response->setStatus(200); // no need to do this

        $config = new MockServerConfig();
        $config
            ->setConsumer('jsonConsumer')
            ->setProvider('jsonProvider')
            ->setPactDir(__DIR__.'/../../../pacts');
        $builder = new InteractionBuilder($config);
        $builder
            ->given('Get Goodbye')
            ->uponReceiving('A get request to /goodbye/{name}')
            ->with($request)
            ->willRespondWith($response); // need to call this, but it's future improvement, not right now
```