### PR TITLE
feat: allow multi values for regex matcher

### DIFF
--- a/example/matchers/consumer/src/Service/HttpClientService.php
+++ b/example/matchers/consumer/src/Service/HttpClientService.php
@@ -20,7 +20,7 @@ class HttpClientService
     {
         $response = $this->httpClient->get("{$this->baseUri}/matchers", [
             'headers' => ['Accept' => 'application/json'],
-            'query' => 'ignore=statusCode&pages=2&pages=3',
+            'query' => 'ignore=statusCode&pages=2&pages=3&locales[]=fr-BE&locales[]=ru-RU',
         ]);
 
         return \json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);

--- a/example/matchers/consumer/src/Service/HttpClientService.php
+++ b/example/matchers/consumer/src/Service/HttpClientService.php
@@ -20,7 +20,7 @@ class HttpClientService
     {
         $response = $this->httpClient->get("{$this->baseUri}/matchers", [
             'headers' => ['Accept' => 'application/json'],
-            'query' => ['ignore' => 'statusCode'],
+            'query' => 'ignore=statusCode&pages=2&pages=3',
         ]);
 
         return \json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);

--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -27,6 +27,9 @@ class MatchersTest extends TestCase
             ->setPath($this->matcher->regex('/matchers', '^\/matchers$'))
             ->setQuery([
                 'ignore' => 'statusCode',
+                'pages' => [
+                    json_encode($this->matcher->regex([1], '\d+')),
+                ],
             ])
             ->addHeader('Accept', 'application/json');
 

--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -27,8 +27,11 @@ class MatchersTest extends TestCase
             ->setPath($this->matcher->regex('/matchers', '^\/matchers$'))
             ->setQuery([
                 'ignore' => 'statusCode',
-                'pages' => [
-                    json_encode($this->matcher->regex([1], '\d+')),
+                'pages' => [ // Consumer send multiple values, but provider receive single (last) value
+                    json_encode($this->matcher->regex([1, 22], '\d+')),
+                ],
+                'locales[]' => [ // Consumer send multiple values, provider receive all values
+                    json_encode($this->matcher->regex(['en-US', 'en-AU'], '^[a-z]{2}-[A-Z]{2}$')),
                 ],
             ])
             ->addHeader('Accept', 'application/json');
@@ -90,6 +93,11 @@ class MatchersTest extends TestCase
                     ['vehicle 1' => 'car'],
                     [$this->matcher->regex(null, 'car|bike|motorbike')]
                 ),
+                'query' => [
+                    'ignore' => 'statusCode',
+                    'pages' => '22',
+                    'locales' => ['en-US', 'en-AU'],
+                ],
             ]);
 
         $config = new MockServerConfig();
@@ -163,6 +171,11 @@ class MatchersTest extends TestCase
             ],
             'eachValue' => [
                 'vehicle 1' => 'car',
+            ],
+            'query' => [
+                'ignore' => 'statusCode',
+                'pages' => '22',
+                'locales' => ['en-US', 'en-AU'],
             ],
         ], $matchersResult);
     }

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -28,13 +28,26 @@
               }
             ]
           },
-          "query": {}
+          "query": {
+            "$.pages": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "\\d+"
+                }
+              ]
+            }
+          }
         },
         "method": "GET",
         "path": "/matchers",
         "query": {
           "ignore": [
             "statusCode"
+          ],
+          "pages": [
+            "1"
           ]
         }
       },

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -37,6 +37,15 @@
                   "regex": "\\d+"
                 }
               ]
+            },
+            "$['locales[]']": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^[a-z]{2}-[A-Z]{2}$"
+                }
+              ]
             }
           }
         },
@@ -46,8 +55,13 @@
           "ignore": [
             "statusCode"
           ],
+          "locales[]": [
+            "en-US",
+            "en-AU"
+          ],
           "pages": [
-            "1"
+            "1",
+            "22"
           ]
         }
       },
@@ -112,6 +126,14 @@
             ],
             "nullValue": null,
             "number": 123,
+            "query": {
+              "ignore": "statusCode",
+              "locales": [
+                "en-US",
+                "en-AU"
+              ],
+              "pages": "22"
+            },
             "regex": "500 miles",
             "semver": "10.0.0-alpha4",
             "time": "23:59::58",

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -73,6 +73,7 @@ $app->get('/matchers', function (Request $request, Response $response) {
             'item 1' => 'bike',
             'item 2' => 'motorbike',
         ],
+        'query' => $request->getQueryParams(),
     ]));
 
     return $response->withHeader('Content-Type', 'application/json');

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -124,16 +124,16 @@ class Matcher
     /**
      * Validate that a value will match a regex pattern.
      *
-     * @param string|null $value   example of what the expected data would be
+     * @param string|string[]|null $values   example of what the expected data would be
      * @param string $pattern valid Ruby regex pattern
      *
      * @return array<string, mixed>
      *
      * @throws Exception
      */
-    public function term(?string $value, string $pattern): array
+    public function term(string|array|null $values, string $pattern): array
     {
-        if (null === $value) {
+        if (null === $values) {
             return [
                 'regex'               => $pattern,
                 'pact:matcher:type'   => 'regex',
@@ -141,16 +141,18 @@ class Matcher
             ];
         }
 
-        $result = preg_match("/$pattern/", $value);
+        foreach ((array) $values as $value) {
+            $result = preg_match("/$pattern/", $value);
 
-        if ($result === false || $result === 0) {
-            $errorCode = preg_last_error();
+            if ($result === false || $result === 0) {
+                $errorCode = preg_last_error();
 
-            throw new Exception("The pattern {$pattern} is not valid for value {$value}. Failed with error code {$errorCode}.");
+                throw new Exception("The pattern {$pattern} is not valid for value {$value}. Failed with error code {$errorCode}.");
+            }
         }
 
         return [
-            'value'             => $value,
+            'value'             => $values,
             'regex'             => $pattern,
             'pact:matcher:type' => 'regex',
         ];
@@ -159,13 +161,15 @@ class Matcher
     /**
      * Alias for the term matcher.
      *
+     * @param string|string[]|null $values
+     *
      * @return array<string, mixed>
      *
      * @throws Exception
      */
-    public function regex(?string $value, string $pattern): array
+    public function regex(string|array|null $values, string $pattern): array
     {
-        return $this->term($value, $pattern);
+        return $this->term($values, $pattern);
     }
 
     /**

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -211,6 +211,22 @@ class MatcherTest extends TestCase
     /**
      * @throws Exception
      */
+    public function testRegexMultiValues()
+    {
+        $expected = [
+            'value'             => [1, 23],
+            'regex'             => '\d+',
+            'pact:matcher:type' => 'regex',
+        ];
+
+        $actual = $this->matcher->regex([1, 23], '\d+');
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @throws Exception
+     */
     public function testDateISO8601()
     {
         $expected = [


### PR DESCRIPTION
This feature allow to use `regex` matcher to match multiple values for query parameter and header. See https://github.com/pact-foundation/pact-reference/issues/332

This feature is mostly for **compatibility suite**, in [v2/http_consumer](https://github.com/pact-foundation/pact-compatibility-suite/blob/main/features/V2/http_consumer.feature) feature, with these scenarios:
* Supports matchers for repeated request query parameters (positive case)
* Supports matchers for repeated request query parameters (negative case)