### PR TITLE
chore: Add status code matcher example

### DIFF
--- a/example/matchers/consumer/src/Service/HttpClientService.php
+++ b/example/matchers/consumer/src/Service/HttpClientService.php
@@ -3,6 +3,7 @@
 namespace MatchersConsumer\Service;
 
 use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
 
 class HttpClientService
 {
@@ -16,13 +17,12 @@ class HttpClientService
         $this->baseUri    = $baseUri;
     }
 
-    public function getMatchers(): array
+    public function sendRequest(): ResponseInterface
     {
-        $response = $this->httpClient->get("{$this->baseUri}/matchers", [
+        return $this->httpClient->get("{$this->baseUri}/matchers", [
             'headers' => ['Accept' => 'application/json'],
-            'query' => 'ignore=statusCode&pages=2&pages=3&locales[]=fr-BE&locales[]=ru-RU',
+            'query' => 'pages=2&pages=3&locales[]=fr-BE&locales[]=ru-RU',
+            'http_errors' => false,
         ]);
-
-        return \json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
     }
 }

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -52,9 +52,6 @@
         "method": "GET",
         "path": "/matchers",
         "query": {
-          "ignore": [
-            "statusCode"
-          ],
           "locales[]": [
             "en-US",
             "en-AU"
@@ -132,7 +129,6 @@
             "nullValue": null,
             "number": 123,
             "query": {
-              "ignore": "statusCode",
               "locales": [
                 "en-US",
                 "en-AU"
@@ -564,9 +560,20 @@
               ]
             }
           },
-          "header": {}
+          "header": {},
+          "status": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "statusCode",
+                  "status": "serverError"
+                }
+              ]
+            }
+          }
         },
-        "status": 200
+        "status": 512
       },
       "transport": "http",
       "type": "Synchronous/HTTP"
@@ -574,9 +581,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.10",
+      "ffi": "0.4.11",
       "mockserver": "1.2.4",
-      "models": "1.1.11"
+      "models": "1.1.12"
     },
     "pactSpecification": {
       "version": "4.0"

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -88,7 +88,9 @@ $app->get('/matchers', function (Request $request, Response $response) {
         'query' => $request->getQueryParams(),
     ]));
 
-    return $response->withHeader('Content-Type', 'application/json');
+    return $response
+        ->withHeader('Content-Type', 'application/json')
+        ->withStatus(503);
 });
 
 $app->post('/pact-change-state', function (Request $request, Response $response) {

--- a/src/PhpPact/Consumer/Model/Interaction/StatusTrait.php
+++ b/src/PhpPact/Consumer/Model/Interaction/StatusTrait.php
@@ -2,18 +2,25 @@
 
 namespace PhpPact\Consumer\Model\Interaction;
 
+use JsonException;
+
 trait StatusTrait
 {
-    private int $status = 200;
+    private string $status = '200';
 
-    public function getStatus(): int
+    public function getStatus(): string
     {
         return $this->status;
     }
 
-    public function setStatus(int $status): self
+    /**
+     * @param int|array<string, mixed> $status
+     *
+     * @throws JsonException
+     */
+    public function setStatus(int|array $status): self
     {
-        $this->status = $status;
+        $this->status = is_array($status) ? json_encode($status, JSON_THROW_ON_ERROR) : (string) $status;
 
         return $this;
     }

--- a/src/PhpPact/Consumer/Registry/Interaction/Part/ResponseRegistry.php
+++ b/src/PhpPact/Consumer/Registry/Interaction/Part/ResponseRegistry.php
@@ -19,9 +19,9 @@ class ResponseRegistry extends AbstractPartRegistry implements ResponseRegistryI
         parent::__construct($client, $interactionRegistry, $responseBodyRegistry ?? new ResponseBodyRegistry($client, $interactionRegistry));
     }
 
-    public function withResponse(int $status): self
+    public function withResponse(string $status): self
     {
-        $this->client->call('pactffi_response_status', $this->getInteractionId(), $status);
+        $this->client->call('pactffi_response_status_v2', $this->getInteractionId(), $status);
 
         return $this;
     }

--- a/src/PhpPact/Consumer/Registry/Interaction/Part/ResponseRegistryInterface.php
+++ b/src/PhpPact/Consumer/Registry/Interaction/Part/ResponseRegistryInterface.php
@@ -4,5 +4,5 @@ namespace PhpPact\Consumer\Registry\Interaction\Part;
 
 interface ResponseRegistryInterface extends PartRegistryInterface
 {
-    public function withResponse(int $status): self;
+    public function withResponse(string $status): self;
 }

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -851,8 +851,11 @@ class MatcherTest extends TestCase
     public function testValidStatusCode()
     {
         $expected = [
-            'status'            => 'success',
-            'pact:matcher:type' => 'statusCode',
+            'pact:generator:type' => 'RandomInt',
+            'min'                 => 200,
+            'max'                 => 299,
+            'status'              => 'success',
+            'pact:matcher:type'   => 'statusCode',
         ];
         $actual = $this->matcher->statusCode(HttpStatus::SUCCESS);
 


### PR DESCRIPTION
This matcher can't be used to match the response code unfortunately, because currently `pactffi_response_status` only allow integer status.

But it can be useful to match a value in body (like this example), query parameter or header.