### PR TITLE
fix: arrayContains matcher doesn't work if variants is array with keys

### DIFF
--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -67,9 +67,9 @@ class MatchersTest extends TestCase
                 'includes' => $this->matcher->includes('lazy dog'),
                 'number' => $this->matcher->number(123),
                 'arrayContaining' => $this->matcher->arrayContaining([
-                    $this->matcher->string('some text'),
-                    $this->matcher->number(111),
-                    $this->matcher->uuid('2fbd41cc-4bbc-44ea-a419-67f767691407'),
+                    'text' => $this->matcher->string('some text'),
+                    'number' => $this->matcher->number(111),
+                    'uuid' => $this->matcher->uuid('2fbd41cc-4bbc-44ea-a419-67f767691407'),
                 ]),
                 'notEmpty' => $this->matcher->notEmpty(['1','2','3']),
                 'semver' => $this->matcher->semver('10.0.0-alpha4'),

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -586,7 +586,7 @@ class Matcher
     {
         return [
             'pact:matcher:type' => 'arrayContains',
-            'variants'          => $variants,
+            'variants'          => array_values($variants),
         ];
     }
 

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -786,6 +786,23 @@ class MatcherTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testArrayContainingWithKeys()
+    {
+        $expected = [
+            'pact:matcher:type' => 'arrayContains',
+            'variants'          => [
+                'item 1',
+                'item 2'
+            ],
+        ];
+        $actual = $this->matcher->arrayContaining([
+            'key 1' => 'item 1',
+            'key 2' => 'item 2'
+        ]);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testNotEmpty()
     {
         $expected = [


### PR DESCRIPTION
* On consumer: the example value become `null`
* On provider: because example value become `null`, we got this error on verification:

```
Failures:

1) Verifying a pact between matchersConsumer and matchersProvider Given Get Matchers - A get request to /matchers
    1.1) has a matching body
           $.arrayContaining -> Expected [102.3,"eb375cad-48cc-4f7f-981b-ea4f1af90bf2"] (Array) to be equal to null (Null)



```