### PR TITLE
fix: values matcher doesn't work if values is array with keys

### DIFF
--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -73,6 +73,11 @@ class MatchersTest extends TestCase
                 ]),
                 'notEmpty' => $this->matcher->notEmpty(['1','2','3']),
                 'semver' => $this->matcher->semver('10.0.0-alpha4'),
+                'values' => $this->matcher->values([
+                    'a' => 'a',
+                    'b' => 'bb',
+                    'c' => 'ccc',
+                ]),
                 'contentType' => $this->matcher->contentType('text/html'),
             ]);
 
@@ -136,6 +141,11 @@ class MatchersTest extends TestCase
             ],
             'notEmpty' => ['1', '2', '3'],
             'semver' => '10.0.0-alpha4',
+            'values' => [
+                'a',
+                'bb',
+                'ccc',
+            ],
             'contentType' => 'text/html',
         ], $matchersResult);
     }

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -98,7 +98,12 @@
             "time": "23:59::58",
             "timeISO8601": "T22:44:30.652Z",
             "timestampRFC3339": "Mon, 31 Oct 2016 15:21:41 -0400",
-            "uuid": "52c9585e-f345-4964-aa28-a45c64b2b2eb"
+            "uuid": "52c9585e-f345-4964-aa28-a45c64b2b2eb",
+            "values": [
+              "a",
+              "bb",
+              "ccc"
+            ]
           },
           "contentType": "application/json",
           "encoded": false
@@ -450,6 +455,14 @@
                 {
                   "match": "regex",
                   "regex": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$"
+                }
+              ]
+            },
+            "$.values": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "values"
                 }
               ]
             }

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -48,6 +48,11 @@ $app->get('/matchers', function (Request $request, Response $response) {
         ],
         'notEmpty' => [111],
         'semver' => '0.27.1-beta2',
+        'values' => [
+            'a',
+            'bb',
+            'ccc',
+        ],
         'contentType' =>
             <<<HTML
             <!DOCTYPE html>

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -643,7 +643,7 @@ class Matcher
     public function values(array $values): array
     {
         return [
-            'value'             => $values,
+            'value'             => array_values($values),
             'pact:matcher:type' => 'values',
         ];
     }

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -843,6 +843,23 @@ class MatcherTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
+    public function testValuesWithKeys()
+    {
+        $expected = [
+            'pact:matcher:type' => 'values',
+            'value'             => [
+                'item 1',
+                'item 2'
+            ],
+        ];
+        $actual = $this->matcher->values([
+            'key 1' => 'item 1',
+            'key 2' => 'item 2'
+        ]);
+
+        $this->assertEquals($expected, $actual);
+    }
+
     public function testContentType()
     {
         $expected = [


### PR DESCRIPTION
* On consumer: example values will be array with keys:

```
     'values' => Array (
-        0 => 'a'
-        1 => 'bb'
-        2 => 'ccc'
+        'a' => 'a'
+        'b' => 'bb'
+        'c' => 'ccc'
     )
```

* On provider: got this error on verification:

```
Failures:

1) Verifying a pact between matchersConsumer and matchersProvider Given Get Matchers - A get request to /matchers
    1.1) has a matching body
           $.values -> Type mismatch: Expected ["a","bb","ccc"] (Array) to be the same type as {"a":"a","b":"bb","c":"ccc"} (Object)


```