### PR TITLE
revert: Values matcher accept keys again

### DIFF
--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -70,6 +70,11 @@ class MatchersTest extends TestCase
                 'datetime' => $this->matcher->datetime("YYYY-mm-DD'T'HH:mm:ss", '2000-10-31T01:30:00'),
                 'likeString' => $this->matcher->string('some string'),
                 'equal' => $this->matcher->equal('exact this value'),
+                'equalArray' => $this->matcher->equal([
+                    'a',
+                    'bb',
+                    'ccc',
+                ]),
                 'includes' => $this->matcher->includes('lazy dog'),
                 'number' => $this->matcher->number(123),
                 'arrayContaining' => $this->matcher->arrayContaining([
@@ -80,6 +85,11 @@ class MatchersTest extends TestCase
                 'notEmpty' => $this->matcher->notEmpty(['1','2','3']),
                 'semver' => $this->matcher->semver('10.0.0-alpha4'),
                 'values' => $this->matcher->values([
+                    'a',
+                    'bb',
+                    'ccc',
+                ]),
+                'valuesWithKeys' => $this->matcher->values([
                     'a' => 'a',
                     'b' => 'bb',
                     'c' => 'ccc',
@@ -151,6 +161,11 @@ class MatchersTest extends TestCase
             'datetime' => '2000-10-31T01:30:00',
             'likeString' => 'some string',
             'equal' => 'exact this value',
+            'equalArray' => [
+                'a',
+                'bb',
+                'ccc',
+            ],
             'includes' => 'lazy dog',
             'number' => 123,
             'arrayContaining' => [
@@ -164,6 +179,11 @@ class MatchersTest extends TestCase
                 'a',
                 'bb',
                 'ccc',
+            ],
+            'valuesWithKeys' => [
+                'a' => 'a',
+                'b' => 'bb',
+                'c' => 'ccc',
             ],
             'contentType' => 'text/html',
             'eachKey' => [

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -106,6 +106,11 @@
             },
             "email": "hello@pact.io",
             "equal": "exact this value",
+            "equalArray": [
+              "a",
+              "bb",
+              "ccc"
+            ],
             "hexadecimal": "F7A16",
             "includes": "lazy dog",
             "integer": 9,
@@ -144,7 +149,12 @@
               "a",
               "bb",
               "ccc"
-            ]
+            ],
+            "valuesWithKeys": {
+              "a": "a",
+              "b": "bb",
+              "c": "ccc"
+            }
           },
           "contentType": "application/json",
           "encoded": false
@@ -360,6 +370,14 @@
                 }
               ]
             },
+            "$.equalArray": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "equality"
+                }
+              ]
+            },
             "$.hexadecimal": {
               "combine": "AND",
               "matchers": [
@@ -530,6 +548,14 @@
               ]
             },
             "$.values": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "values"
+                }
+              ]
+            },
+            "$.valuesWithKeys": {
               "combine": "AND",
               "matchers": [
                 {

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -40,6 +40,11 @@ $app->get('/matchers', function (Request $request, Response $response) {
         'datetime' => '1997-07-16T19:20:30',
         'likeString' => 'another string',
         'equal' => 'exact this value',
+        'equalArray' => [
+            'a',
+            'bb',
+            'ccc',
+        ],
         'includes' => 'The quick brown fox jumps over the lazy dog',
         'number' => 112.3,
         'arrayContaining' => [
@@ -48,10 +53,17 @@ $app->get('/matchers', function (Request $request, Response $response) {
         ],
         'notEmpty' => [111],
         'semver' => '0.27.1-beta2',
-        'values' => [
+        'values' => [ // Missing ending values are OK, additional values are NOT OK
             'a',
             'bb',
-            'ccc',
+            //'ccc',
+            //'dddd',
+        ],
+        'valuesWithKeys' => [ // Missing keys are OK, additional keys are NOT OK
+            //'a' => 'a',
+            'b' => 'bb',
+            //'c' => 'ccc',
+            //'d' => 'dddd',
         ],
         'contentType' =>
             <<<HTML

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -647,7 +647,7 @@ class Matcher
     public function values(array $values): array
     {
         return [
-            'value'             => array_values($values),
+            'value'             => $values,
             'pact:matcher:type' => 'values',
         ];
     }

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -881,8 +881,8 @@ class MatcherTest extends TestCase
         $expected = [
             'pact:matcher:type' => 'values',
             'value'             => [
-                'item 1',
-                'item 2'
+                'key 1' => 'item 1',
+                'key 2' => 'item 2'
             ],
         ];
         $actual = $this->matcher->values([


### PR DESCRIPTION
Revert https://github.com/pact-foundation/pact-php/pull/356

I was wrong #356 is a feature, not a bug.

* When you pass array without keys to `values` matcher, it compare values using its index (i.e. starting with 0) in the array.
* When you pass array with keys to `values` matcher, it compare values using those keys.
* Missing keys/indexes are OK.
* Additional keys/indexes are NOT OK.
  * I'm not sure about this behavior.
  * Pact complain that the value of additional keys/indexes must equals to the first value (e.g. `a`) ???
  * Probably because I'm testing this `values` matcher on `Response`?
  * If using this `values` matcher on `Request`, additional keys/indexes are OK. See this behavior on [compatibility suite](https://github.com/pact-foundation/pact-compatibility-suite/blob/main/features/V3/matching_rules.feature#L238-L257)

I'm not really understand the behavior of missing/additional keys/indexes. Look like it's the [Postel's law](https://docs.pact.io/getting_started/matching/gotchas), but in revert?