### PR TITLE
chore: Add generators example

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,10 @@
             "XmlProvider\\Tests\\": "example/xml/provider/tests",
             "MatchersConsumer\\": "example/matchers/consumer/src",
             "MatchersConsumer\\Tests\\": "example/matchers/consumer/tests",
-            "MatchersProvider\\Tests\\": "example/matchers/provider/tests"
+            "MatchersProvider\\Tests\\": "example/matchers/provider/tests",
+            "GeneratorsConsumer\\": "example/generators/consumer/src",
+            "GeneratorsConsumer\\Tests\\": "example/generators/consumer/tests",
+            "GeneratorsProvider\\Tests\\": "example/generators/provider/tests"
         }
     },
     "scripts": {

--- a/example/generators/consumer/phpunit.xml
+++ b/example/generators/consumer/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../../../vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="PhpPact Example Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="PACT_LOGLEVEL" value="DEBUG"/>
+    </php>
+</phpunit>

--- a/example/generators/consumer/src/Service/HttpClientService.php
+++ b/example/generators/consumer/src/Service/HttpClientService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace GeneratorsConsumer\Service;
+
+use GuzzleHttp\Client;
+use Psr\Http\Message\ResponseInterface;
+
+class HttpClientService
+{
+    private Client $httpClient;
+
+    private string $baseUri;
+
+    public function __construct(string $baseUri)
+    {
+        $this->httpClient = new Client();
+        $this->baseUri    = $baseUri;
+    }
+
+    public function sendRequest(): ResponseInterface
+    {
+        return $this->httpClient->get("{$this->baseUri}/generators", [
+            'headers' => ['Accept' => 'application/json'],
+            'json' => ['id' => 112],
+            'http_errors' => false,
+        ]);
+    }
+}

--- a/example/generators/consumer/tests/Service/GeneratorsTest.php
+++ b/example/generators/consumer/tests/Service/GeneratorsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace GeneratorsConsumer\Tests\Service;
+
+use DateTime;
+use GeneratorsConsumer\Service\HttpClientService;
+use PhpPact\Consumer\InteractionBuilder;
+use PhpPact\Consumer\Matcher\HttpStatus;
+use PhpPact\Consumer\Matcher\Matcher;
+use PhpPact\Consumer\Model\ConsumerRequest;
+use PhpPact\Consumer\Model\ProviderResponse;
+use PhpPact\Standalone\MockService\MockServerConfig;
+use PHPUnit\Framework\TestCase;
+
+class GeneratorsTest extends TestCase
+{
+    private Matcher $matcher;
+
+    public function setUp(): void
+    {
+        $this->matcher = new Matcher();
+    }
+
+    public function testGetMatchers()
+    {
+        $request = new ConsumerRequest();
+        $request
+            ->setMethod('GET')
+            ->setPath('/generators')
+            ->addHeader('Accept', 'application/json')
+            ->setBody([
+                'id' => $this->matcher->fromProviderState($this->matcher->integer(), '${id}')
+            ]);
+
+        $response = new ProviderResponse();
+        $response
+            ->setStatus($this->matcher->statusCode(HttpStatus::CLIENT_ERROR))
+            ->addHeader('Content-Type', 'application/json')
+            ->setBody([
+                'regex' => $this->matcher->regex(null, $regexWithoutAnchors = '\d+ (miles|kilometers)'),
+                'boolean' => $this->matcher->booleanV3(null),
+                'integer' => $this->matcher->integerV3(null),
+                'decimal' => $this->matcher->decimalV3(null),
+                'hexadecimal' => $this->matcher->hexadecimal(null),
+                'uuid' => $this->matcher->uuid(null),
+                'date' => $this->matcher->date('yyyy-MM-dd', null),
+                'time' => $this->matcher->time('HH:mm::ss', null),
+                'datetime' => $this->matcher->datetime("YYYY-MM-D'T'HH:mm:ss", null),
+                'string' => $this->matcher->string(null),
+                'number' => $this->matcher->number(null),
+                'requestId' => 222,
+            ]);
+
+        $config = new MockServerConfig();
+        $config
+            ->setConsumer('generatorsConsumer')
+            ->setProvider('generatorsProvider')
+            ->setPactDir(__DIR__.'/../../../pacts')
+            ->setPactSpecificationVersion('4.0.0');
+        if ($logLevel = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($logLevel);
+        }
+        $builder = new InteractionBuilder($config);
+        $builder
+            ->given('Get Generators')
+            ->uponReceiving('A get request to /generators')
+            ->with($request)
+            ->willRespondWith($response);
+
+        $service = new HttpClientService($config->getBaseUri());
+        $response = $service->sendRequest();
+        $verifyResult = $builder->verify();
+
+        $statusCode = $response->getStatusCode();
+        $body = \json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertTrue($verifyResult);
+        $this->assertThat(
+            $statusCode,
+            $this->logicalAnd(
+                $this->greaterThanOrEqual(400),
+                $this->lessThanOrEqual(499)
+            )
+        );
+        $this->assertRegExp('/^' . $regexWithoutAnchors . '$/', $body['regex']);
+        $this->assertIsBool($body['boolean']);
+        $this->assertIsInt($body['integer']);
+        $this->assertIsFloat($body['decimal'] + 0);
+        $this->assertRegExp('/' . Matcher::HEX_FORMAT . '/', $body['hexadecimal']);
+        $this->assertRegExp('/' . Matcher::UUID_V4_FORMAT . '/', $body['uuid']);
+        $this->assertTrue($this->validateDateTime($body['date'], 'Y-m-d'));
+        $this->assertTrue($this->validateDateTime($body['time'], 'H:i::s'));
+        $this->assertTrue($this->validateDateTime($body['datetime'], "Y-m-z\TH:i:s"));
+        $this->assertIsString($body['string']);
+        $this->assertIsNumeric($body['number']);
+        $this->assertSame(222, $body['requestId']);
+    }
+
+    private function validateDateTime(string $datetime, string $format): bool
+    {
+        $value = DateTime::createFromFormat($format, $datetime);
+
+        return $value && $value->format($format) === $datetime;
+    }
+}

--- a/example/generators/pacts/generatorsConsumer-generatorsProvider.json
+++ b/example/generators/pacts/generatorsConsumer-generatorsProvider.json
@@ -1,0 +1,260 @@
+{
+  "consumer": {
+    "name": "generatorsConsumer"
+  },
+  "interactions": [
+    {
+      "description": "A get request to /generators",
+      "pending": false,
+      "providerStates": [
+        {
+          "name": "Get Generators"
+        }
+      ],
+      "request": {
+        "body": {
+          "content": {
+            "id": 13
+          },
+          "contentType": "application/json",
+          "encoded": false
+        },
+        "generators": {
+          "body": {
+            "$.id": {
+              "expression": "${id}",
+              "type": "ProviderState"
+            }
+          }
+        },
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
+          "header": {}
+        },
+        "method": "GET",
+        "path": "/generators"
+      },
+      "response": {
+        "body": {
+          "content": {
+            "boolean": null,
+            "date": null,
+            "datetime": null,
+            "decimal": null,
+            "hexadecimal": null,
+            "integer": null,
+            "number": null,
+            "regex": null,
+            "requestId": 222,
+            "string": "some string",
+            "time": null,
+            "uuid": null
+          },
+          "contentType": "application/json",
+          "encoded": false
+        },
+        "generators": {
+          "body": {
+            "$.boolean": {
+              "type": "RandomBoolean"
+            },
+            "$.date": {
+              "format": "yyyy-MM-dd",
+              "type": "Date"
+            },
+            "$.datetime": {
+              "format": "YYYY-MM-D'T'HH:mm:ss",
+              "type": "DateTime"
+            },
+            "$.decimal": {
+              "digits": 10,
+              "type": "RandomDecimal"
+            },
+            "$.hexadecimal": {
+              "digits": 10,
+              "type": "RandomHexadecimal"
+            },
+            "$.integer": {
+              "max": 10,
+              "min": 0,
+              "type": "RandomInt"
+            },
+            "$.number": {
+              "max": 10,
+              "min": 0,
+              "type": "RandomInt"
+            },
+            "$.regex": {
+              "regex": "\\d+ (miles|kilometers)",
+              "type": "Regex"
+            },
+            "$.string": {
+              "size": 10,
+              "type": "RandomString"
+            },
+            "$.time": {
+              "format": "HH:mm::ss",
+              "type": "Time"
+            },
+            "$.uuid": {
+              "type": "Uuid"
+            }
+          },
+          "status": {
+            "max": 499,
+            "min": 400,
+            "type": "RandomInt"
+          }
+        },
+        "headers": {
+          "Content-Type": [
+            "application/json"
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.boolean": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "boolean"
+                }
+              ]
+            },
+            "$.date": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "format": "yyyy-MM-dd",
+                  "match": "date"
+                }
+              ]
+            },
+            "$.datetime": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "format": "YYYY-MM-D'T'HH:mm:ss",
+                  "match": "datetime"
+                }
+              ]
+            },
+            "$.decimal": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "decimal"
+                }
+              ]
+            },
+            "$.hexadecimal": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^[0-9a-fA-F]+$"
+                }
+              ]
+            },
+            "$.integer": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.number": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "number"
+                }
+              ]
+            },
+            "$.regex": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "\\d+ (miles|kilometers)"
+                }
+              ]
+            },
+            "$.string": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "$.time": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "format": "HH:mm::ss",
+                  "match": "time"
+                }
+              ]
+            },
+            "$.uuid": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$"
+                }
+              ]
+            }
+          },
+          "header": {},
+          "status": {
+            "$": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "statusCode",
+                  "status": "clientError"
+                }
+              ]
+            }
+          }
+        },
+        "status": 0
+      },
+      "transport": "http",
+      "type": "Synchronous/HTTP"
+    }
+  ],
+  "metadata": {
+    "pactRust": {
+      "ffi": "0.4.11",
+      "mockserver": "1.2.4",
+      "models": "1.1.12"
+    },
+    "pactSpecification": {
+      "version": "4.0"
+    }
+  },
+  "provider": {
+    "name": "generatorsProvider"
+  }
+}

--- a/example/generators/provider/phpunit.xml
+++ b/example/generators/provider/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../../../vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="PhpPact Example Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="PACT_LOGLEVEL" value="DEBUG"/>
+    </php>
+</phpunit>

--- a/example/generators/provider/public/index.php
+++ b/example/generators/provider/public/index.php
@@ -1,0 +1,44 @@
+<?php
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+$app = AppFactory::create();
+$app->addBodyParsingMiddleware();
+
+$app->get('/generators', function (Request $request, Response $response) {
+    $body = $request->getParsedBody();
+    $response->getBody()->write(\json_encode([
+        'regex' => '800 kilometers',
+        'boolean' => true,
+        'integer' => 11,
+        'decimal' => 25.1,
+        'hexadecimal' => '20AC',
+        'uuid' => 'e9d2f3a5-6ecc-4bff-8935-84bb6141325a',
+        'date' => '1997-12-11',
+        'time' => '11:01::02',
+        'datetime' => '1997-07-16T19:20:30',
+        'string' => 'another string',
+        'number' => 112.3,
+        'requestId' => $body['id'],
+    ]));
+
+    return $response
+        ->withHeader('Content-Type', 'application/json')
+        ->withStatus(400);
+});
+
+$app->post('/pact-change-state', function (Request $request, Response $response) {
+    $response->getBody()->write(\json_encode([
+        'id' => 222,
+    ]));
+
+    return $response
+        ->withHeader('Content-Type', 'application/json')
+        ->withStatus(200);
+});
+
+$app->run();

--- a/example/generators/provider/tests/PactVerifyTest.php
+++ b/example/generators/provider/tests/PactVerifyTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace GeneratorsProvider\Tests;
+
+use GuzzleHttp\Psr7\Uri;
+use PhpPact\Standalone\ProviderVerifier\Model\VerifierConfig;
+use PhpPact\Standalone\ProviderVerifier\Verifier;
+use PhpPactTest\Helper\ProviderProcess;
+use PHPUnit\Framework\TestCase;
+
+class PactVerifyTest extends TestCase
+{
+    private ProviderProcess $process;
+
+    protected function setUp(): void
+    {
+        $this->process = new ProviderProcess(__DIR__ . '/../public/');
+        $this->process->start();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->process->stop();
+    }
+
+    public function testPactVerifyConsumer()
+    {
+        $config = new VerifierConfig();
+        $config->getProviderInfo()
+            ->setName('generatorsProvider')
+            ->setHost('localhost')
+            ->setPort(7202);
+        $config->getProviderState()
+            ->setStateChangeUrl(new Uri('http://localhost:7202/pact-change-state'))
+        ;
+        if ($level = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($level);
+        }
+
+        $verifier = new Verifier($config);
+        $verifier->addFile(__DIR__ . '/../../pacts/generatorsConsumer-generatorsProvider.json');
+
+        $verifyResult = $verifier->verify();
+
+        $this->assertTrue($verifyResult);
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -49,6 +49,12 @@
     <testsuite name="PhpPact Matchers Provider Example Tests">
         <directory>./example/matchers/provider/tests</directory>
     </testsuite>
+    <testsuite name="PhpPact Generators Consumer Example Tests">
+        <directory>./example/generators/consumer/tests</directory>
+    </testsuite>
+    <testsuite name="PhpPact Generators Provider Example Tests">
+        <directory>./example/generators/provider/tests</directory>
+    </testsuite>
   </testsuites>
   <logging>
     <junit outputFile="./test_results/reports/unit_test_results.xml"/>


### PR DESCRIPTION
There is no example for `MockServerURL`  yet, because the `url` matcher is not available in pact-php (yet)