### PR TITLE
chore: Change default datetime format

### DIFF
--- a/example/generators/consumer/tests/Service/GeneratorsTest.php
+++ b/example/generators/consumer/tests/Service/GeneratorsTest.php
@@ -44,8 +44,8 @@ class GeneratorsTest extends TestCase
                 'hexadecimal' => $this->matcher->hexadecimal(null),
                 'uuid' => $this->matcher->uuid(null),
                 'date' => $this->matcher->date('yyyy-MM-dd', null),
-                'time' => $this->matcher->time('HH:mm::ss', null),
-                'datetime' => $this->matcher->datetime("YYYY-MM-D'T'HH:mm:ss", null),
+                'time' => $this->matcher->time('HH:mm:ss', null),
+                'datetime' => $this->matcher->datetime("yyyy-MM-dd'T'HH:mm:ss", null),
                 'string' => $this->matcher->string(null),
                 'number' => $this->matcher->number(null),
                 'requestId' => 222,
@@ -89,8 +89,8 @@ class GeneratorsTest extends TestCase
         $this->assertRegExp('/' . Matcher::HEX_FORMAT . '/', $body['hexadecimal']);
         $this->assertRegExp('/' . Matcher::UUID_V4_FORMAT . '/', $body['uuid']);
         $this->assertTrue($this->validateDateTime($body['date'], 'Y-m-d'));
-        $this->assertTrue($this->validateDateTime($body['time'], 'H:i::s'));
-        $this->assertTrue($this->validateDateTime($body['datetime'], "Y-m-z\TH:i:s"));
+        $this->assertTrue($this->validateDateTime($body['time'], 'H:i:s'));
+        $this->assertTrue($this->validateDateTime($body['datetime'], "Y-m-d\TH:i:s"));
         $this->assertIsString($body['string']);
         $this->assertIsNumeric($body['number']);
         $this->assertSame(222, $body['requestId']);

--- a/example/generators/pacts/generatorsConsumer-generatorsProvider.json
+++ b/example/generators/pacts/generatorsConsumer-generatorsProvider.json
@@ -80,7 +80,7 @@
               "type": "Date"
             },
             "$.datetime": {
-              "format": "YYYY-MM-D'T'HH:mm:ss",
+              "format": "yyyy-MM-dd'T'HH:mm:ss",
               "type": "DateTime"
             },
             "$.decimal": {
@@ -110,7 +110,7 @@
               "type": "RandomString"
             },
             "$.time": {
-              "format": "HH:mm::ss",
+              "format": "HH:mm:ss",
               "type": "Time"
             },
             "$.uuid": {
@@ -151,7 +151,7 @@
               "combine": "AND",
               "matchers": [
                 {
-                  "format": "YYYY-MM-D'T'HH:mm:ss",
+                  "format": "yyyy-MM-dd'T'HH:mm:ss",
                   "match": "datetime"
                 }
               ]
@@ -210,7 +210,7 @@
               "combine": "AND",
               "matchers": [
                 {
-                  "format": "HH:mm::ss",
+                  "format": "HH:mm:ss",
                   "match": "time"
                 }
               ]

--- a/example/generators/provider/public/index.php
+++ b/example/generators/provider/public/index.php
@@ -19,7 +19,7 @@ $app->get('/generators', function (Request $request, Response $response) {
         'hexadecimal' => '20AC',
         'uuid' => 'e9d2f3a5-6ecc-4bff-8935-84bb6141325a',
         'date' => '1997-12-11',
-        'time' => '11:01::02',
+        'time' => '11:01:02',
         'datetime' => '1997-07-16T19:20:30',
         'string' => 'another string',
         'number' => 112.3,

--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -66,8 +66,8 @@ class MatchersTest extends TestCase
                 'email' => $this->matcher->email(),
                 'nullValue' => $this->matcher->nullValue(),
                 'date' => $this->matcher->date('yyyy-MM-dd', '2015-05-16'),
-                'time' => $this->matcher->time('HH:mm::ss', '23:59::58'),
-                'datetime' => $this->matcher->datetime("YYYY-mm-DD'T'HH:mm:ss", '2000-10-31T01:30:00'),
+                'time' => $this->matcher->time('HH:mm:ss', '23:59::58'),
+                'datetime' => $this->matcher->datetime("yyyy-MM-dd'T'HH:mm:ss", '2000-10-31T01:30:00'),
                 'likeString' => $this->matcher->string('some string'),
                 'equal' => $this->matcher->equal('exact this value'),
                 'equalArray' => $this->matcher->equal([

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -297,7 +297,7 @@
               "combine": "AND",
               "matchers": [
                 {
-                  "format": "YYYY-mm-DD'T'HH:mm:ss",
+                  "format": "yyyy-MM-dd'T'HH:mm:ss",
                   "match": "datetime"
                 }
               ]
@@ -511,7 +511,7 @@
               "combine": "AND",
               "matchers": [
                 {
-                  "format": "HH:mm::ss",
+                  "format": "HH:mm:ss",
                   "match": "time"
                 }
               ]

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -36,7 +36,7 @@ $app->get('/matchers', function (Request $request, Response $response) {
         'email' => 'pact@example.com',
         'nullValue' => null,
         'date' => '1997-12-11',
-        'time' => '11:01::02',
+        'time' => '11:01:02',
         'datetime' => '1997-07-16T19:20:30',
         'likeString' => 'another string',
         'equal' => 'exact this value',

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -466,7 +466,7 @@ class Matcher
     /**
      * @return array<string, mixed>
      */
-    public function time(string $format = 'HH:mm::ss', ?string $value = null): array
+    public function time(string $format = 'HH:mm:ss', ?string $value = null): array
     {
         if (null === $value) {
             return [
@@ -486,7 +486,7 @@ class Matcher
     /**
      * @return array<string, mixed>
      */
-    public function datetime(string $format = "YYYY-mm-DD'T'HH:mm:ss", ?string $value = null): array
+    public function datetime(string $format = "yyyy-MM-dd'T'HH:mm:ss", ?string $value = null): array
     {
         if (null === $value) {
             return [

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -661,9 +661,9 @@ class MatcherTest extends TestCase
         $expected = [
             'value'             => '21:45::31',
             'pact:matcher:type' => 'time',
-            'format'            => 'HH:mm::ss',
+            'format'            => 'HH:mm:ss',
         ];
-        $actual = $this->matcher->time('HH:mm::ss', '21:45::31');
+        $actual = $this->matcher->time('HH:mm:ss', '21:45::31');
 
         $this->assertEquals($expected, $actual);
     }
@@ -673,7 +673,7 @@ class MatcherTest extends TestCase
         $expected = [
             'pact:generator:type' => 'Time',
             'pact:matcher:type'   => 'time',
-            'format'              => 'HH:mm::ss',
+            'format'              => 'HH:mm:ss',
         ];
         $actual = $this->matcher->time();
 
@@ -685,9 +685,9 @@ class MatcherTest extends TestCase
         $expected = [
             'value'             => '2015-08-06T16:53:10',
             'pact:matcher:type' => 'datetime',
-            'format'            => "YYYY-mm-DD'T'HH:mm:ss",
+            'format'            => "yyyy-MM-dd'T'HH:mm:ss",
         ];
-        $actual = $this->matcher->datetime("YYYY-mm-DD'T'HH:mm:ss", '2015-08-06T16:53:10');
+        $actual = $this->matcher->datetime("yyyy-MM-dd'T'HH:mm:ss", '2015-08-06T16:53:10');
 
         $this->assertEquals($expected, $actual);
     }
@@ -697,7 +697,7 @@ class MatcherTest extends TestCase
         $expected = [
             'pact:generator:type' => 'DateTime',
             'pact:matcher:type'   => 'datetime',
-            'format'              => "YYYY-mm-DD'T'HH:mm:ss",
+            'format'              => "yyyy-MM-dd'T'HH:mm:ss",
         ];
         $actual = $this->matcher->datetime();
 


### PR DESCRIPTION
* Change the default formats. The previous **default** formats I copied them from https://github.com/pact-foundation/pact-specification/tree/version-4#supported-generators. I think the **new** formats make more sense to end-user.
* Doing so also fixed a failed test: on this specific day `2023-11-30`,  the value become `"2023-12-334T17:15:07"`, not `"2023-11-334T17:15:07"` as expected. I'm not sure what is the problem here.