### PR TITLE
refactor: Add Uuid generator class

### DIFF
--- a/src/PhpPact/Consumer/Exception/ConsumerException.php
+++ b/src/PhpPact/Consumer/Exception/ConsumerException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Consumer\Exception;
+
+use PhpPact\Exception\BaseException;
+
+class ConsumerException extends BaseException
+{
+}

--- a/src/PhpPact/Consumer/Matcher/Exception/InvalidUuidFormatException.php
+++ b/src/PhpPact/Consumer/Matcher/Exception/InvalidUuidFormatException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Exception;
+
+class InvalidUuidFormatException extends MatcherException
+{
+}

--- a/src/PhpPact/Consumer/Matcher/Exception/MatcherException.php
+++ b/src/PhpPact/Consumer/Matcher/Exception/MatcherException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Exception;
+
+use PhpPact\Consumer\Exception\ConsumerException;
+
+class MatcherException extends ConsumerException
+{
+}

--- a/src/PhpPact/Consumer/Matcher/Generators/Uuid.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/Uuid.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Generators;
+
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
+use PhpPact\Consumer\Matcher\Exception\InvalidUuidFormatException;
+
+/**
+ * Generates a random UUID.
+ * V4 supports specifying the format:
+ * - simple (e.g 936DA01f9abd4d9d80c702af85c822a8)
+ * - lower-case-hyphenated (e.g 936da01f-9abd-4d9d-80c7-02af85c822a8)
+ * - upper-case-hyphenated (e.g 936DA01F-9ABD-4D9D-80C7-02AF85C822A8)
+ * - URN (e.g. urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8)
+ */
+class Uuid implements GeneratorInterface
+{
+    public const SIMPLE_FORMAT = 'simple';
+    public const LOWER_CASE_HYPHENATED_FORMAT = 'lower-case-hyphenated';
+    public const UPPER_CASE_HYPHENATED_FORMAT = 'upper-case-hyphenated';
+    public const URN_FORMAT = 'URN';
+
+    public const FORMATS = [
+        self::SIMPLE_FORMAT,
+        self::LOWER_CASE_HYPHENATED_FORMAT,
+        self::UPPER_CASE_HYPHENATED_FORMAT,
+        self::URN_FORMAT,
+    ];
+
+    public function __construct(private ?string $format = null)
+    {
+        if ($format && !in_array($format, self::FORMATS, true)) {
+            throw new InvalidUuidFormatException(sprintf('Format %s is not supported. Supported formats are: %s', $format, implode(', ', self::FORMATS)));
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = ['pact:generator:type' => 'Uuid'];
+
+        if ($this->format !== null) {
+            $data['format'] = $this->format;
+        }
+
+        return $data;
+    }
+}

--- a/src/PhpPact/Exception/BaseException.php
+++ b/src/PhpPact/Exception/BaseException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Exception;
+
+use Exception;
+
+class BaseException extends Exception
+{
+}

--- a/tests/PhpPact/Consumer/Matcher/Generators/UuidTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Generators/UuidTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Generators;
+
+use PhpPact\Consumer\Matcher\Exception\InvalidUuidFormatException;
+use PhpPact\Consumer\Matcher\Generators\Uuid;
+use PHPUnit\Framework\TestCase;
+
+class UuidTest extends TestCase
+{
+    /**
+     * @testWith [null,                    "{\"pact:generator:type\":\"Uuid\"}"]
+     *           ["simple",                "{\"pact:generator:type\":\"Uuid\",\"format\":\"simple\"}"]
+     *           ["lower-case-hyphenated", "{\"pact:generator:type\":\"Uuid\",\"format\":\"lower-case-hyphenated\"}"]
+     *           ["upper-case-hyphenated", "{\"pact:generator:type\":\"Uuid\",\"format\":\"upper-case-hyphenated\"}"]
+     *           ["URN",                   "{\"pact:generator:type\":\"Uuid\",\"format\":\"URN\"}"]
+     *           ["invalid",               null]
+     */
+    public function testSerialize(?string $format, ?string $json): void
+    {
+        if (!$json) {
+            $this->expectException(InvalidUuidFormatException::class);
+            $this->expectExceptionMessage('Format invalid is not supported. Supported formats are: simple, lower-case-hyphenated, upper-case-hyphenated, URN');
+        }
+        $uuid = new Uuid($format);
+        $this->assertSame($json, json_encode($uuid));
+    }
+}


### PR DESCRIPTION
The generator is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-generators