### PR TITLE
refactor: Add MockServerURL generator class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Generators/MockServerURL.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/MockServerURL.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Generators;
+
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
+
+/**
+ * Generates a URL with the mock server as the base URL.
+ *
+ * Example regex: .*(/path)$
+ * Example example: http://localhost:1234/path
+ */
+class MockServerURL implements GeneratorInterface
+{
+    public function __construct(private string $regex, private string $example)
+    {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'regex'               => $this->regex,
+            'example'             => $this->example,
+            'pact:generator:type' => 'MockServerURL',
+        ];
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Generators/MockServerURLTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Generators/MockServerURLTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Generators;
+
+use PhpPact\Consumer\Matcher\Generators\MockServerURL;
+use PHPUnit\Framework\TestCase;
+
+class MockServerURLTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $url = new MockServerURL('.*(/path)$', 'http://localhost:1234/path');
+        $this->assertSame(
+            '{"regex":".*(\/path)$","example":"http:\/\/localhost:1234\/path","pact:generator:type":"MockServerURL"}',
+            json_encode($url)
+        );
+    }
+}


### PR DESCRIPTION
The generator is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-generators