### PR TITLE
refactor: Remove @return tag from jsonSerialize()

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Generators/AbstractDateTime.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/AbstractDateTime.php
@@ -10,10 +10,7 @@ abstract class AbstractDateTime implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
         $data = ['pact:generator:type' => $this->getType()];
 
@@ -25,7 +22,7 @@ abstract class AbstractDateTime implements GeneratorInterface
             $data['expression'] = $this->expression;
         }
 
-        return $data;
+        return (object) $data;
     }
 
     abstract protected function getType(): string;

--- a/src/PhpPact/Consumer/Matcher/Generators/MockServerURL.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/MockServerURL.php
@@ -16,12 +16,9 @@ class MockServerURL implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'regex'               => $this->regex,
             'example'             => $this->example,
             'pact:generator:type' => 'MockServerURL',

--- a/src/PhpPact/Consumer/Matcher/Generators/ProviderState.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/ProviderState.php
@@ -15,12 +15,9 @@ class ProviderState implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'expression'          => $this->expression,
             'pact:generator:type' => 'ProviderState',
         ];

--- a/src/PhpPact/Consumer/Matcher/Generators/RandomBoolean.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/RandomBoolean.php
@@ -9,12 +9,9 @@ use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
  */
 class RandomBoolean implements GeneratorInterface
 {
-    /**
-     * @return array<string, string>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'pact:generator:type' => 'RandomBoolean',
         ];
     }

--- a/src/PhpPact/Consumer/Matcher/Generators/RandomDecimal.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/RandomDecimal.php
@@ -13,12 +13,9 @@ class RandomDecimal implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string|int>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'digits'              => $this->digits,
             'pact:generator:type' => 'RandomDecimal',
         ];

--- a/src/PhpPact/Consumer/Matcher/Generators/RandomHexadecimal.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/RandomHexadecimal.php
@@ -13,12 +13,9 @@ class RandomHexadecimal implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string|int>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'digits'              => $this->digits,
             'pact:generator:type' => 'RandomHexadecimal',
         ];

--- a/src/PhpPact/Consumer/Matcher/Generators/RandomInt.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/RandomInt.php
@@ -13,12 +13,9 @@ class RandomInt implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string|int>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'min'                 => $this->min,
             'max'                 => $this->max,
             'pact:generator:type' => 'RandomInt',

--- a/src/PhpPact/Consumer/Matcher/Generators/RandomString.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/RandomString.php
@@ -13,12 +13,9 @@ class RandomString implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string|int>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'size'                => $this->size,
             'pact:generator:type' => 'RandomString',
         ];

--- a/src/PhpPact/Consumer/Matcher/Generators/Regex.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/Regex.php
@@ -13,12 +13,9 @@ class Regex implements GeneratorInterface
     {
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
-        return [
+        return (object) [
             'regex'               => $this->regex,
             'pact:generator:type' => 'Regex',
         ];

--- a/src/PhpPact/Consumer/Matcher/Generators/Uuid.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/Uuid.php
@@ -34,10 +34,7 @@ class Uuid implements GeneratorInterface
         }
     }
 
-    /**
-     * @return array<string, string>
-     */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): object
     {
         $data = ['pact:generator:type' => 'Uuid'];
 
@@ -45,6 +42,6 @@ class Uuid implements GeneratorInterface
             $data['format'] = $this->format;
         }
 
-        return $data;
+        return (object) $data;
     }
 }


### PR DESCRIPTION
Replace return type from `array` to `object` so no need to add `@return` annotation to explain the return value to make PHPStan happy.