### PR TITLE
refactor: Add ArrayContains matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/ArrayContains.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/ArrayContains.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * Checks if all the variants are present in an array.
+ */
+class ArrayContains implements MatcherInterface
+{
+    /**
+     * @param array<mixed> $variants
+     */
+    public function __construct(private array $variants)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+            'variants' => array_values($this->variants),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'arrayContains';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/ArrayContainsTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/ArrayContainsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\ArrayContains;
+use PhpPact\Consumer\Matcher\Matchers\Integer;
+use PhpPact\Consumer\Matcher\Matchers\Type;
+use PHPUnit\Framework\TestCase;
+
+class ArrayContainsTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $variants = [
+            new Type('string'),
+            new Integer(),
+        ];
+        $array = new ArrayContains($variants);
+        $this->assertSame(
+            '{"pact:matcher:type":"arrayContains","variants":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"integer","pact:generator:type":"RandomInt","min":0,"max":10}]}',
+            json_encode($array)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules

Depend on:
* https://github.com/pact-foundation/pact-php/pull/404
* https://github.com/pact-foundation/pact-php/pull/414