### PR TITLE
refactor: Add ContentType matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/ContentType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/ContentType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * Match binary data by its content type (magic file check)
+ */
+class ContentType implements MatcherInterface
+{
+    public function __construct(private string $contentType)
+    {
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'value'             => $this->contentType,
+            'pact:matcher:type' => $this->getType(),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'contentType';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/ContentTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/ContentTypeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\ContentType;
+use PHPUnit\Framework\TestCase;
+
+class ContentTypeTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $contentType = new ContentType('text/csv');
+        $this->assertSame(
+            '{"value":"text\/csv","pact:matcher:type":"contentType"}',
+            json_encode($contentType)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules