### PR TITLE
refactor: Add EachKey matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/EachKey.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/EachKey.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * Allows defining matching rules to apply to the keys in a map
+ */
+class EachKey implements MatcherInterface
+{
+    /**
+     * @param array<mixed>|object $value
+     * @param MatcherInterface[]  $rules
+     */
+    public function __construct(private object|array $value, private array $rules)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+            'value'             => $this->value,
+            'rules'             => array_map(fn (MatcherInterface $rule) => $rule, $this->rules),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'eachKey';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EachKeyTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EachKeyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\EachKey;
+use PhpPact\Consumer\Matcher\Matchers\Regex;
+use PhpPact\Consumer\Matcher\Matchers\Type;
+use PHPUnit\Framework\TestCase;
+
+class EachKeyTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $value = [
+            'abc' => 123,
+            'def' => 111,
+            'ghi' => [
+                'test' => 'value',
+            ],
+        ];
+        $rules = [
+            new Type('string'),
+            new Regex('\w{3}'),
+        ];
+        $eachKey = new EachKey($value, $rules);
+        $this->assertSame(
+            '{"pact:matcher:type":"eachKey","value":{"abc":123,"def":111,"ghi":{"test":"value"}},"rules":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"regex","pact:generator:type":"Regex","regex":"\\\\w{3}"}]}',
+            json_encode($eachKey)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules

Depend on https://github.com/pact-foundation/pact-php/pull/414