### PR TITLE
refactor: Add EachValue matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/EachValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/EachValue.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * Allows defining matching rules to apply to the values in a collection. For maps, delgates to the Values matcher.
+ */
+class EachValue implements MatcherInterface
+{
+    /**
+     * @param array<mixed>|object $value
+     * @param MatcherInterface[]  $rules
+     */
+    public function __construct(private object|array $value, private array $rules)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+            'value'             => $this->value,
+            'rules'             => array_map(fn (MatcherInterface $rule) => $rule, $this->rules),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'eachValue';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\EachValue;
+use PhpPact\Consumer\Matcher\Matchers\Regex;
+use PhpPact\Consumer\Matcher\Matchers\Type;
+use PHPUnit\Framework\TestCase;
+
+class EachValueTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $value = [
+            'ab1',
+            'cd2',
+            'ef9',
+        ];
+        $rules = [
+            new Type('string'),
+            new Regex('\w{2}\d'),
+        ];
+        $eachValue = new EachValue($value, $rules);
+        $this->assertSame(
+            '{"pact:matcher:type":"eachValue","value":["ab1","cd2","ef9"],"rules":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"regex","pact:generator:type":"Regex","regex":"\\\\w{2}\\\\d"}]}',
+            json_encode($eachValue)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules

Depend on https://github.com/pact-foundation/pact-php/pull/414