### PR TITLE
refactor: Add MaxType matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * This executes a type based match against the values, that is, they are equal if they are the same type.
+ * In addition, if the values represent a collection, the length of the actual value is compared against the maximum.
+ */
+class MaxType implements MatcherInterface
+{
+    /**
+     * @param array<mixed>$values
+     */
+    public function __construct(
+        private array $values,
+        private int $max,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+            'max'               => $this->max,
+            'value'             => array_values($this->values),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'type';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MaxTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MaxTypeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\MaxType;
+use PHPUnit\Framework\TestCase;
+
+class MaxTypeTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $values = [
+            'string value',
+        ];
+        $array = new MaxType($values, 3);
+        $this->assertSame(
+            '{"pact:matcher:type":"type","max":3,"value":["string value"]}',
+            json_encode($array)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules
