### PR TITLE
refactor: Add MinType matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * This executes a type based match against the values, that is, they are equal if they are the same type.
+ * In addition, if the values represent a collection, the length of the actual value is compared against the minimum.
+ */
+class MinType implements MatcherInterface
+{
+    /**
+     * @param array<mixed> $values
+     */
+    public function __construct(
+        private array $values,
+        private int $min,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+            'min'               => $this->min,
+            'value'             => array_values($this->values),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'type';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MinTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MinTypeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\MinType;
+use PHPUnit\Framework\TestCase;
+
+class MinTypeTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $values = [
+            123,
+            34,
+            5,
+        ];
+        $array = new MinType($values, 3);
+        $this->assertSame(
+            '{"pact:matcher:type":"type","min":3,"value":[123,34,5]}',
+            json_encode($array)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules