### PR TITLE
refactor: Add NotEmpty matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * Value must be present and not empty (not null or the empty string)
+ */
+class NotEmpty implements MatcherInterface
+{
+    /**
+     * @param object|array<mixed>|string|float|int|bool $value
+     */
+    public function __construct(private object|array|string|float|int|bool $value)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+            'value'             => $this->value,
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'notEmpty';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/NotEmptyTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/NotEmptyTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\NotEmpty;
+use PHPUnit\Framework\TestCase;
+
+class NotEmptyTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $array = new NotEmpty(['some text']);
+        $this->assertSame(
+            '{"pact:matcher:type":"notEmpty","value":["some text"]}',
+            json_encode($array)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules