### PR TITLE
refactor: Add NullValue matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/NullValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/NullValue.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * Match if the value is a null value (this is content specific, for JSON will match a JSON null)
+ */
+class NullValue implements MatcherInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'null';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/NullValueTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/NullValueTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\NullValue;
+use PHPUnit\Framework\TestCase;
+
+class NullValueTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $null = new NullValue();
+        $this->assertSame(
+            '{"pact:matcher:type":"null"}',
+            json_encode($null)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules