### PR TITLE
refactor: Add Semver matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/Semver.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Semver.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Generators\Regex;
+
+/**
+ * Value must be valid based on the semver specification
+ */
+class Semver extends GeneratorAwareMatcher
+{
+    public function __construct(private ?string $value = null)
+    {
+        if ($value === null) {
+            $this->setGenerator(new Regex('\d+\.\d+\.\d+'));
+        }
+    }
+
+    public function getType(): string
+    {
+        return 'semver';
+    }
+
+    protected function getAttributesData(): array
+    {
+        return [];
+    }
+
+    protected function getValue(): ?string
+    {
+        return $this->value;
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/SemverTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/SemverTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\Semver;
+
+class SemverTest extends GeneratorAwareMatcherTestCase
+{
+    protected function setUp(): void
+    {
+        $this->matcher = new Semver();
+    }
+
+    /**
+     * @testWith [null,    "{\"pact:matcher:type\":\"semver\",\"pact:generator:type\":\"Regex\",\"regex\":\"\\\\d+\\\\.\\\\d+\\\\.\\\\d+\"}"]
+     *           ["1.2.3", "{\"pact:matcher:type\":\"semver\",\"value\":\"1.2.3\"}"]
+     */
+    public function testSerialize(?string $value, string $json): void
+    {
+        $this->matcher = new Semver($value);
+        $this->assertSame($json, json_encode($this->matcher));
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules