### PR TITLE
refactor: Add StringValue matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/StringValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/StringValue.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Generators\RandomString;
+
+/**
+ * There is no matcher for string. We re-use `type` matcher.
+ */
+class StringValue extends GeneratorAwareMatcher
+{
+    public function __construct(private ?string $value = null)
+    {
+        if ($value === null) {
+            $this->setGenerator(new RandomString());
+        }
+    }
+
+    public function getType(): string
+    {
+        return 'type';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        $data = [
+            'pact:matcher:type' => $this->getType(),
+            'value' => $this->getValue() ?? 'some string',
+        ];
+
+        if ($this->getGenerator()) {
+            return $data + ['pact:generator:type' => $this->getGenerator()->getType()] + $this->getMergedAttributes()->getData();
+        }
+
+        return $data;
+    }
+
+    protected function getAttributesData(): array
+    {
+        return [];
+    }
+
+    protected function getValue(): ?string
+    {
+        return $this->value;
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/StringValueTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/StringValueTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\StringValue;
+use PHPUnit\Framework\TestCase;
+
+class StringValueTest extends TestCase
+{
+    protected StringValue $matcher;
+
+    protected function setUp(): void
+    {
+        $this->matcher = new StringValue();
+    }
+
+    /**
+     * @testWith [null,   "{\"pact:matcher:type\":\"type\",\"value\":\"some string\",\"pact:generator:type\":\"RandomString\",\"size\":10}"]
+     *           ["test", "{\"pact:matcher:type\":\"type\",\"value\":\"test\"}"]
+     */
+    public function testSerialize(?string $value, string $json): void
+    {
+        $this->matcher = new StringValue($value);
+        $this->assertSame($json, json_encode($this->matcher));
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules