### PR TITLE
refactor: Add Type matcher class

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/Type.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Type.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+/**
+ * This executes a type based match against the values, that is, they are equal if they are the same type.
+ */
+class Type implements MatcherInterface
+{
+    /**
+     * @param object|array<mixed>|string|float|int|bool|null $value
+     */
+    public function __construct(private object|array|string|float|int|bool|null $value)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'pact:matcher:type' => $this->getType(),
+            'value'             => $this->value,
+        ];
+    }
+
+    public function getType(): string
+    {
+        return 'type';
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/TypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/TypeTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Matchers\Type;
+use PHPUnit\Framework\TestCase;
+
+class TypeTest extends TestCase
+{
+    public function testSerialize(): void
+    {
+        $value = (object) ['key' => 'value'];
+        $object = new Type($value);
+        $this->assertSame(
+            '{"pact:matcher:type":"type","value":{"key":"value"}}',
+            json_encode($object)
+        );
+    }
+}


### PR DESCRIPTION
The matcher is defined at https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules