### PR TITLE
feat: Throw exception when both generator and example value are set

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Exception/GeneratorNotRequiredException.php
+++ b/src/PhpPact/Consumer/Matcher/Exception/GeneratorNotRequiredException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Exception;
+
+class GeneratorNotRequiredException extends MatcherException
+{
+}

--- a/src/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcher.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Exception\GeneratorNotRequiredException;
 use PhpPact\Consumer\Matcher\Exception\GeneratorRequiredException;
 use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\GeneratorAwareInterface;
@@ -37,6 +38,8 @@ abstract class GeneratorAwareMatcher implements MatcherInterface, GeneratorAware
             }
 
             return $data + ['pact:generator:type' => $this->generator->getType()] + $this->getMergedAttributes()->getData();
+        } elseif ($this->generator) {
+            throw new GeneratorNotRequiredException(sprintf("Generator '%s' is not required for matcher '%s' when example value is set", $this->generator->getType(), $this->getType()));
         }
 
         return $data + $this->getAttributes()->getData() + ['value' => $this->getValue()];

--- a/tests/PhpPact/Consumer/Matcher/Matchers/BooleanTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/BooleanTest.php
@@ -3,12 +3,18 @@
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Matchers\Boolean;
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 
 class BooleanTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Boolean();
+        return new Boolean();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Boolean(false);
     }
 
     /**
@@ -18,7 +24,7 @@ class BooleanTest extends GeneratorAwareMatcherTestCase
      */
     public function testSerialize(?bool $value, string $json): void
     {
-        $this->matcher = new Boolean($value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Boolean($value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/DateTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/DateTest.php
@@ -3,12 +3,18 @@
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Matchers\Date;
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 
 class DateTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Date();
+        return new Date();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Date('yyyy-MM-dd', '2001-09-17');
     }
 
     /**
@@ -18,7 +24,7 @@ class DateTest extends GeneratorAwareMatcherTestCase
     public function testSerialize(?string $value, string $json): void
     {
         $format = 'yyyy-MM-dd';
-        $this->matcher = new Date($format, $value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Date($format, $value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/DateTimeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/DateTimeTest.php
@@ -3,12 +3,18 @@
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Matchers\DateTime;
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 
 class DateTimeTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new DateTime();
+        return new DateTime();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new DateTime("yyyy-MM-dd HH:mm", '2011-07-13 16:41');
     }
 
     /**
@@ -18,7 +24,7 @@ class DateTimeTest extends GeneratorAwareMatcherTestCase
     public function testSerialize(?string $value, string $json): void
     {
         $format = "yyyy-MM-dd'T'HH:mm:ss";
-        $this->matcher = new DateTime($format, $value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new DateTime($format, $value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/DecimalTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/DecimalTest.php
@@ -3,12 +3,18 @@
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Matchers\Decimal;
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 
 class DecimalTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Decimal();
+        return new Decimal();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Decimal(15.68);
     }
 
     /**
@@ -17,7 +23,7 @@ class DecimalTest extends GeneratorAwareMatcherTestCase
      */
     public function testSerialize(?float $value, string $json): void
     {
-        $this->matcher = new Decimal($value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Decimal($value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcherTestCase.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcherTestCase.php
@@ -2,19 +2,69 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Exception\GeneratorNotRequiredException;
 use PhpPact\Consumer\Matcher\Exception\GeneratorRequiredException;
+use PhpPact\Consumer\Matcher\Generators\Date;
+use PhpPact\Consumer\Matcher\Generators\DateTime;
+use PhpPact\Consumer\Matcher\Generators\MockServerURL;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
+use PhpPact\Consumer\Matcher\Generators\RandomBoolean;
+use PhpPact\Consumer\Matcher\Generators\RandomDecimal;
+use PhpPact\Consumer\Matcher\Generators\RandomHexadecimal;
+use PhpPact\Consumer\Matcher\Generators\RandomInt;
+use PhpPact\Consumer\Matcher\Generators\RandomString;
+use PhpPact\Consumer\Matcher\Generators\Regex;
+use PhpPact\Consumer\Matcher\Generators\Time;
+use PhpPact\Consumer\Matcher\Generators\Uuid;
 use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PHPUnit\Framework\TestCase;
 
 abstract class GeneratorAwareMatcherTestCase extends TestCase
 {
-    protected GeneratorAwareMatcher $matcher;
-
-    public function testMissingGenerator(): void
+    public function testGeneratorRequired(): void
     {
+        $matcher = $this->getMatcherWithoutExampleValue();
         $this->expectException(GeneratorRequiredException::class);
-        $this->expectExceptionMessage(sprintf("Generator is required for matcher '%s' when example value is not set", $this->matcher->getType()));
-        $this->matcher->setGenerator(null);
-        json_encode($this->matcher);
+        $this->expectExceptionMessage(sprintf("Generator is required for matcher '%s' when example value is not set", $matcher->getType()));
+        $matcher->setGenerator(null);
+        json_encode($matcher);
     }
+
+    /**
+     * @dataProvider generatorProvider
+     */
+    public function testGeneratorNotRequired(GeneratorInterface $generator): void
+    {
+        $matcher = $this->getMatcherWithExampleValue();
+        $this->expectException(GeneratorNotRequiredException::class);
+        $this->expectExceptionMessage(sprintf("Generator '%s' is not required for matcher '%s' when example value is set", $generator->getType(), $matcher->getType()));
+        $matcher->setGenerator($generator);
+        json_encode($matcher);
+    }
+
+    /**
+     * @return GeneratorInterface[]
+     */
+    public function generatorProvider(): array
+    {
+        return [
+            [new Date()],
+            [new DateTime()],
+            [new MockServerURL('.*(/\d+)$', 'http://example.com/123')],
+            [new ProviderState('${key}')],
+            [new RandomBoolean()],
+            [new RandomDecimal()],
+            [new RandomHexadecimal()],
+            [new RandomInt()],
+            [new RandomString()],
+            [new Regex('\w')],
+            [new Time()],
+            [new Uuid()],
+        ];
+    }
+
+    abstract protected function getMatcherWithExampleValue(): GeneratorAwareMatcher;
+
+    abstract protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher;
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/IntegerTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/IntegerTest.php
@@ -2,13 +2,19 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Matchers\Integer;
 
 class IntegerTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Integer();
+        return new Integer();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Integer(189);
     }
 
     /**
@@ -17,7 +23,7 @@ class IntegerTest extends GeneratorAwareMatcherTestCase
      */
     public function testSerialize(?int $value, string $json): void
     {
-        $this->matcher = new Integer($value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Integer($value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/NumberTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/NumberTest.php
@@ -2,13 +2,19 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Matchers\Number;
 
 class NumberTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Number();
+        return new Number();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Number(56.73);
     }
 
     /**
@@ -18,7 +24,7 @@ class NumberTest extends GeneratorAwareMatcherTestCase
      */
     public function testSerialize(int|float|null $value, string $json): void
     {
-        $this->matcher = new Number($value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Number($value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/RegexTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/RegexTest.php
@@ -3,15 +3,21 @@
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidRegexException;
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Matchers\Regex;
 
 class RegexTest extends GeneratorAwareMatcherTestCase
 {
     private string $regex = '\d+';
 
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Regex($this->regex);
+        return new Regex($this->regex);
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Regex($this->regex, ['1', '23']);
     }
 
     /**
@@ -28,7 +34,7 @@ class RegexTest extends GeneratorAwareMatcherTestCase
             $value = is_array($values) ? $values[0] : $values;
             $this->expectExceptionMessage("The pattern '{$this->regex}' is not valid for value '{$value}'. Failed with error code 0.");
         }
-        $this->matcher = new Regex($this->regex, $values);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Regex($this->regex, $values);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/SemverTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/SemverTest.php
@@ -2,13 +2,19 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Matchers\Semver;
 
 class SemverTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Semver();
+        return new Semver();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Semver('10.21.0-rc.1');
     }
 
     /**
@@ -17,7 +23,7 @@ class SemverTest extends GeneratorAwareMatcherTestCase
      */
     public function testSerialize(?string $value, string $json): void
     {
-        $this->matcher = new Semver($value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Semver($value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/StatusCodeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/StatusCodeTest.php
@@ -3,13 +3,19 @@
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidHttpStatusException;
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Matchers\StatusCode;
 
 class StatusCodeTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new StatusCode('info');
+        return new StatusCode('info');
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new StatusCode('error', 404);
     }
 
     /**
@@ -29,7 +35,7 @@ class StatusCodeTest extends GeneratorAwareMatcherTestCase
             $this->expectException(InvalidHttpStatusException::class);
             $this->expectExceptionMessage("Status 'invalid' is not supported. Supported status are: info, success, redirect, clientError, serverError, nonError, error");
         }
-        $this->matcher = new StatusCode($status, $value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new StatusCode($status, $value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/TimeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/TimeTest.php
@@ -2,13 +2,19 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Matchers\Time;
 
 class TimeTest extends GeneratorAwareMatcherTestCase
 {
-    protected function setUp(): void
+    protected function getMatcherWithoutExampleValue(): GeneratorAwareMatcher
     {
-        $this->matcher = new Time();
+        return new Time();
+    }
+
+    protected function getMatcherWithExampleValue(): GeneratorAwareMatcher
+    {
+        return new Time('HH:mm', '21:15');
     }
 
     /**
@@ -18,7 +24,7 @@ class TimeTest extends GeneratorAwareMatcherTestCase
     public function testSerialize(?string $value, string $json): void
     {
         $format = 'HH:mm:ss';
-        $this->matcher = new Time($format, $value);
-        $this->assertSame($json, json_encode($this->matcher));
+        $matcher = new Time($format, $value);
+        $this->assertSame($json, json_encode($matcher));
     }
 }


### PR DESCRIPTION
Generator can't be used along with example value:

- Generators (except `ProviderState`) will be silently ignored (without any notice).
- `ProviderState` generator will be used and example value will be ignored (without any notice)

User will be surprised by this.

This PR will throw exception instead.

These code won't be allowed:
- `$this->matcher->fromProviderState($this->matcher->integer(123), '${id}')` (user won't know, until the pact is verified on provider side. And user probably won't notice that `123` is used instead the number from provider)
- `$matchingRule = $this->matcher->integerV3(123); $matchingRule->setGenerator(new RandomInt());` (user probably won't notice that `123` is used instead of a random integer.)