### PR TITLE
feat: Add url matcher

### DIFF
--- a/example/generators/consumer/tests/Service/GeneratorsTest.php
+++ b/example/generators/consumer/tests/Service/GeneratorsTest.php
@@ -48,6 +48,7 @@ class GeneratorsTest extends TestCase
                 'datetime' => $this->matcher->datetime("yyyy-MM-dd'T'HH:mm:ss", null),
                 'string' => $this->matcher->string(null),
                 'number' => $this->matcher->number(null),
+                'url' => $this->matcher->url('http://localhost/users/1234/posts/latest', '.*(\\/users\\/\\d+\\/posts\\/latest)$'),
                 'requestId' => 222,
             ]);
 
@@ -93,6 +94,8 @@ class GeneratorsTest extends TestCase
         $this->assertTrue($this->validateDateTime($body['datetime'], "Y-m-d\TH:i:s"));
         $this->assertIsString($body['string']);
         $this->assertIsNumeric($body['number']);
+        $this->assertNotSame('http://localhost/users/1234/posts/latest', $body['url']);
+        $this->assertRegExp('/.*(\\/users\\/\\d+\\/posts\\/latest)$/', $body['url']);
         $this->assertSame(222, $body['requestId']);
     }
 

--- a/example/generators/pacts/generatorsConsumer-generatorsProvider.json
+++ b/example/generators/pacts/generatorsConsumer-generatorsProvider.json
@@ -65,6 +65,7 @@
             "requestId": 222,
             "string": "some string",
             "time": null,
+            "url": null,
             "uuid": null
           },
           "contentType": "application/json",
@@ -112,6 +113,11 @@
             "$.time": {
               "format": "HH:mm:ss",
               "type": "Time"
+            },
+            "$.url": {
+              "example": "http://localhost/users/1234/posts/latest",
+              "regex": ".*(\\/users\\/\\d+\\/posts\\/latest)$",
+              "type": "MockServerURL"
             },
             "$.uuid": {
               "type": "Uuid"
@@ -212,6 +218,15 @@
                 {
                   "format": "HH:mm:ss",
                   "match": "time"
+                }
+              ]
+            },
+            "$.url": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": ".*(\\/users\\/\\d+\\/posts\\/latest)$"
                 }
               ]
             },

--- a/example/generators/provider/public/index.php
+++ b/example/generators/provider/public/index.php
@@ -23,6 +23,7 @@ $app->get('/generators', function (Request $request, Response $response) {
         'datetime' => '1997-07-16T19:20:30',
         'string' => 'another string',
         'number' => 112.3,
+        'url' => 'https://www.example.com/users/1234/posts/latest',
         'requestId' => $body['id'],
     ]));
 

--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -103,6 +103,7 @@ class MatchersTest extends TestCase
                     ['vehicle 1' => 'car'],
                     [$this->matcher->regex(null, 'car|bike|motorbike')]
                 ),
+                'url' => $this->matcher->url('http://localhost:8080/users/1234/posts/latest', '.*(\\/users\\/\\d+\\/posts\\/latest)$', false),
                 'query' => [
                     'pages' => '22',
                     'locales' => ['en-US', 'en-AU'],
@@ -195,6 +196,7 @@ class MatchersTest extends TestCase
             'eachValue' => [
                 'vehicle 1' => 'car',
             ],
+            'url' => 'http://localhost:8080/users/1234/posts/latest',
             'query' => [
                 'pages' => '22',
                 'locales' => ['en-US', 'en-AU'],

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -140,6 +140,7 @@
             "time": "23:59::58",
             "timeISO8601": "T22:44:30.652Z",
             "timestampRFC3339": "Mon, 31 Oct 2016 15:21:41 -0400",
+            "url": "http://localhost:8080/users/1234/posts/latest",
             "uuid": "52c9585e-f345-4964-aa28-a45c64b2b2eb",
             "values": [
               "a",
@@ -531,6 +532,15 @@
                 {
                   "match": "regex",
                   "regex": "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun),\\s\\d{2}\\s(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\\s\\d{4}\\s\\d{2}:\\d{2}:\\d{2}\\s(\\+|-)\\d{4}$"
+                }
+              ]
+            },
+            "$.url": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": ".*(\\/users\\/\\d+\\/posts\\/latest)$"
                 }
               ]
             },

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -85,6 +85,7 @@ $app->get('/matchers', function (Request $request, Response $response) {
             'item 1' => 'bike',
             'item 2' => 'motorbike',
         ],
+        'url' => 'https://www.example.com/users/1234/posts/latest',
         'query' => $request->getQueryParams(),
     ]));
 

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -4,6 +4,7 @@ namespace PhpPact\Consumer\Matcher;
 
 use PhpPact\Consumer\Matcher\Exception\MatcherException;
 use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Generators\MockServerURL;
 use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Generators\RandomHexadecimal;
 use PhpPact\Consumer\Matcher\Generators\Uuid;
@@ -439,5 +440,19 @@ class Matcher
     public function eachValue(array $values, array $rules): EachValue
     {
         return new EachValue($values, $rules);
+    }
+
+    /**
+     * @throws MatcherException
+     */
+    public function url(string $url, string $regex, bool $useMockServerBasePath = true): Regex
+    {
+        $matcher = new Regex($regex, $useMockServerBasePath ? null : $url);
+
+        if ($useMockServerBasePath) {
+            $matcher->setGenerator(new MockServerURL($regex, $url));
+        }
+
+        return $matcher;
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\Consumer\Matcher;
 
 use PhpPact\Consumer\Matcher\Exception\MatcherException;
 use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Generators\MockServerURL;
 use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Generators\RandomHexadecimal;
 use PhpPact\Consumer\Matcher\Generators\Uuid;
@@ -376,5 +377,20 @@ class MatcherTest extends TestCase
             $this->matcher->regex('car', 'car|bike|motorbike'),
         ];
         $this->assertInstanceOf(EachValue::class, $this->matcher->eachValue($values, $rules));
+    }
+
+    /**
+     * @testWith [true, true]
+     *           [false, false]
+     */
+    public function testUrl(bool $useMockServerBasePath, bool $hasGenerator): void
+    {
+        $url = $this->matcher->url('http://localhost:1234/path', '.*(/path)$', $useMockServerBasePath);
+        $this->assertInstanceOf(Regex::class, $url);
+        if ($hasGenerator) {
+            $this->assertSame(MockServerURL::class, get_class($url->getGenerator()));
+        } else {
+            $this->assertNull($url->getGenerator());
+        }
     }
 }


### PR DESCRIPTION
This matcher is inspired by `url()` and `url2()` matchers from pact-js
- [Source code](https://github.com/pact-foundation/pact-js/blob/master/src/v3/matchers.ts#L415-L461)
- [Test cases](https://github.com/pact-foundation/pact-js/blob/master/src/v3/matchers.spec.ts#L472-L536)

This PR also confirm my claim from another [PR](https://github.com/pact-foundation/pact-php/pull/420).

> // Temporary fix for inconsistancies between matchers and generators. Matchers use "value" attribute for
  // example values, while generators use "example"

I think this is not inconsistent problem, but it's actually a genius idea from Pact core team. We can remove this line from pact-js and it still work fine

```js
if (basePath == null) {
    return {
      // Remove this line
      // value: example,
    };
  }
```