### PR TITLE
test(compatibility-suite): Add compatibility suite submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "compatibility-suite/pact-compatibility-suite"]
+	path = compatibility-suite/pact-compatibility-suite
+	url = https://github.com/pact-foundation/pact-compatibility-suite.git


### PR DESCRIPTION
[Suggested way](https://github.com/pact-foundation/pact-compatibility-suite#adding-it-to-a-project) of adding compatibility suite is using `git subtree`.

I don't have experience on subtree. I know `git submodule` a bit so I started using it and it sound natural to me. I didn't change since then. The only problem with submodule I got is removing it is a bit complicated.

If subtree is better, please let me know.