### PR TITLE
chore: Remove old composer script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,6 @@
         }
     },
     "scripts": {
-        "start-provider": "php -S localhost:58000 -t example/src/Provider/public/",
         "static-code-analysis": "phpstan",
         "lint": "php-cs-fixer fix --dry-run",
         "fix": "php-cs-fixer fix",


### PR DESCRIPTION
This script is from version <=9.

In version 10 I refactored the example/ directory.

The public path in the script is not correct any more. And I don't think this script is useful. So I removed it.