### PR TITLE
test(compatibility-suite): Implement V2 scenarios

### DIFF
--- a/.github/workflows/compatibility-suite.yml
+++ b/.github/workflows/compatibility-suite.yml
@@ -22,3 +22,19 @@ jobs:
 
       - name: Run Behat
         run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V1
+  v2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.2
+          coverage: none
+
+      - uses: ramsey/composer-install@v2
+
+      - name: Run Behat
+        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V2

--- a/behat.yml
+++ b/behat.yml
@@ -1,3 +1,5 @@
 imports:
     - 'compatibility-suite/suites/v1/http/consumer.yml'
     - 'compatibility-suite/suites/v1/http/provider.yml'
+    - 'compatibility-suite/suites/v2/http/consumer.yml'
+    - 'compatibility-suite/suites/v2/http/provider.yml'

--- a/compatibility-suite/suites/v2/http/consumer.yml
+++ b/compatibility-suite/suites/v2/http/consumer.yml
@@ -1,0 +1,29 @@
+default:
+    suites:
+        v2_http_consumer:
+            paths: [ '%paths.base%/compatibility-suite/pact-compatibility-suite/features/V2/http_consumer.feature' ]
+
+            contexts:
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\Hook\SetUpContext'
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\InteractionsContext':
+                    - '@interactions_storage'
+                    - '@request_matching_rule_builder'
+                    - '@response_matching_rule_builder'
+                    - '@matching_rules_storage'
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\Transform\InteractionsContext':
+                    - '@interaction_builder'
+                    - '@matching_rules_storage'
+                - 'PhpPactTest\CompatibilitySuite\Context\V1\Http\ConsumerContext':
+                    - '@server'
+                    - '@request_builder'
+                    - '@client'
+                    - '@interactions_storage'
+                    - '@fixture_loader'
+                - 'PhpPactTest\CompatibilitySuite\Context\V2\Http\ConsumerContext':
+                    - '@server'
+                    - '@request_builder'
+                    - '@request_matching_rule_builder'
+                    - '@matching_rules_storage'
+                    - '@interactions_storage'
+
+            services: PhpPactTest\CompatibilitySuite\ServiceContainer\V2

--- a/compatibility-suite/suites/v2/http/provider.yml
+++ b/compatibility-suite/suites/v2/http/provider.yml
@@ -1,0 +1,30 @@
+default:
+    suites:
+        v2_http_provider:
+            paths: [ '%paths.base%/compatibility-suite/pact-compatibility-suite/features/V2/http_provider.feature' ]
+
+            contexts:
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\Hook\SetUpContext'
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\InteractionsContext':
+                    - '@interactions_storage'
+                    - '@request_matching_rule_builder'
+                    - '@response_matching_rule_builder'
+                    - '@matching_rules_storage'
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\Transform\InteractionsContext':
+                    - '@interaction_builder'
+                    - '@matching_rules_storage'
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\Hook\ProviderStateContext':
+                    - '@provider_state_server'
+                - 'PhpPactTest\CompatibilitySuite\Context\Shared\ProviderContext':
+                    - '@server'
+                    - '@provider_verifier'
+                    - '@provider_state_server'
+                - 'PhpPactTest\CompatibilitySuite\Context\V1\Http\ProviderContext':
+                    - '@server'
+                    - '@pact_writer'
+                    - '@pact_broker'
+                    - '@response_builder'
+                    - '@interactions_storage'
+                    - '@provider_verifier'
+
+            services: PhpPactTest\CompatibilitySuite\ServiceContainer\V2

--- a/compatibility-suite/tests/Context/V2/Http/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V2/Http/ConsumerContext.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpPactTest\CompatibilitySuite\Context\V2\Http;
+
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use PhpPactTest\CompatibilitySuite\Service\InteractionsStorageInterface;
+use PhpPactTest\CompatibilitySuite\Service\MatchingRulesStorageInterface;
+use PhpPactTest\CompatibilitySuite\Service\RequestBuilderInterface;
+use PhpPactTest\CompatibilitySuite\Service\RequestMatchingRuleBuilderInterface;
+use PhpPactTest\CompatibilitySuite\Service\ServerInterface;
+
+final class ConsumerContext implements Context
+{
+    public function __construct(
+        private ServerInterface $server,
+        private RequestBuilderInterface $requestBuilder,
+        private RequestMatchingRuleBuilderInterface $requestMatchingRuleBuilder,
+        private MatchingRulesStorageInterface $matchingRulesStorage,
+        private InteractionsStorageInterface $storage,
+    ) {
+    }
+
+    /**
+     * @When the mock server is started with interaction :id but with the following changes:
+     */
+    public function theMockServerIsStartedWithInteractionButWithTheFollowingChanges(int $id, TableNode $table): void
+    {
+        $request = $this->storage->get(InteractionsStorageInterface::SERVER_DOMAIN, $id)->getRequest();
+        $this->requestBuilder->build($request, $table->getHash()[0]);
+        if ($file = $this->matchingRulesStorage->get(MatchingRulesStorageInterface::REQUEST_DOMAIN, $id)) {
+            $this->requestMatchingRuleBuilder->build($request, $file);
+        }
+        $this->server->register($id);
+    }
+}

--- a/compatibility-suite/tests/ServiceContainer/V2.php
+++ b/compatibility-suite/tests/ServiceContainer/V2.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpPactTest\CompatibilitySuite\ServiceContainer;
+
+class V2 extends V1
+{
+    protected function getSpecification(): string
+    {
+        return '2.0.0';
+    }
+}


### PR DESCRIPTION
* Implement v2 scenarios (most code implemented from v1). The only different is applying matching rules to request.
* Register `v2/http/consumer` and `v2/http/provider` suites to behat
* Add v2 job to github actions