### PR TITLE
refactor: Move xml to core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
         "phpstan/phpstan": "^1.9",
         "phpunit/phpunit": ">=8.5.23 <10",
         "guzzlehttp/guzzle": "^7.8",
-        "tienvx/pact-php-xml": "^0.1",
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",
         "ramsey/uuid": "^4.7"

--- a/example/xml/consumer/tests/Service/HttpClientServiceTest.php
+++ b/example/xml/consumer/tests/Service/HttpClientServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace XmlConsumer\Tests\Service;
 
-use Tienvx\PactPhpXml\XmlBuilder;
+use PhpPact\Xml\XmlBuilder;
 use XmlConsumer\Service\HttpClientService;
 use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Model\ConsumerRequest;

--- a/src/PhpPact/Xml/Model/Builder/ElementTrait.php
+++ b/src/PhpPact/Xml/Model/Builder/ElementTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace PhpPact\Xml\Model\Builder;
+
+use PhpPact\Xml\Model\Matcher\Matcher;
+use PhpPact\Xml\XmlElement;
+use PhpPact\Xml\XmlText;
+
+trait ElementTrait
+{
+    private XmlElement $root;
+
+    public function root(callable ...$options): void
+    {
+        $this->root = new XmlElement(...$options);
+    }
+
+    public function add(callable ...$options): callable
+    {
+        return fn (XmlElement $element) => $element->addChild(new XmlElement(...$options));
+    }
+
+    public function name(string $name): callable
+    {
+        return fn (XmlElement $element) => $element->setName($name);
+    }
+
+    public function text(callable ...$options): callable
+    {
+        return fn (XmlElement $element) => $element->setText(new XmlText(...$options));
+    }
+
+    public function attribute(string $name, mixed $value): callable
+    {
+        return fn (XmlElement $element) => $element->addAttribute($name, $value);
+    }
+
+    public function eachLike(int $min = 1, ?int $max = null, int $examples = 1): callable
+    {
+        return function (XmlElement $element) use ($min, $max, $examples): void {
+            $options = [
+                'min' => $min,
+                'examples' => $examples,
+            ];
+            if (isset($max)) {
+                $options['max'] = $max;
+            }
+            $element->setMatcher(new Matcher(
+                fn (Matcher $matcher) => $matcher->setType('type'),
+                fn (Matcher $matcher) => $matcher->setOptions($options),
+            ));
+        };
+    }
+}

--- a/src/PhpPact/Xml/Model/Builder/GeneratorTrait.php
+++ b/src/PhpPact/Xml/Model/Builder/GeneratorTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PhpPact\Xml\Model\Builder;
+
+use PhpPact\Xml\Model\Matcher\Generator;
+
+trait GeneratorTrait
+{
+    public function generatorType(string $type): callable
+    {
+        return fn (Generator $generator) => $generator->setType($type);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function generatorOptions(array $options): callable
+    {
+        return fn (Generator $generator) => $generator->setOptions($options);
+    }
+}

--- a/src/PhpPact/Xml/Model/Builder/MatcherTrait.php
+++ b/src/PhpPact/Xml/Model/Builder/MatcherTrait.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace PhpPact\Xml\Model\Builder;
+
+use PhpPact\Xml\Model\Matcher\Matcher;
+
+trait MatcherTrait
+{
+    public function matcherType(string $type): callable
+    {
+        return fn (Matcher $matcher) => $matcher->setType($type);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function matcherOptions(array $options): callable
+    {
+        return fn (Matcher $matcher) => $matcher->setOptions($options);
+    }
+}

--- a/src/PhpPact/Xml/Model/Builder/TextTrait.php
+++ b/src/PhpPact/Xml/Model/Builder/TextTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PhpPact\Xml\Model\Builder;
+
+use PhpPact\Xml\Model\Matcher\Generator;
+use PhpPact\Xml\Model\Matcher\Matcher;
+use PhpPact\Xml\XmlText;
+
+trait TextTrait
+{
+    public function content(string|int|float $content): callable
+    {
+        return fn (XmlText $text) => $text->setContent($content);
+    }
+
+    public function matcher(callable ...$options): callable
+    {
+        return fn (XmlText $text) => $text->setMatcher(new Matcher(...$options));
+    }
+
+    public function generator(callable ...$options): callable
+    {
+        return fn (XmlText $text) => $text->setGenerator(new Generator(...$options));
+    }
+
+    public function contentLike(string|int|float $content): callable
+    {
+        return function (XmlText $text) use ($content): void {
+            $text->setContent($content);
+            $text->setMatcher(new Matcher(
+                fn (Matcher $matcher) => $matcher->setType('type')
+            ));
+        };
+    }
+}

--- a/src/PhpPact/Xml/Model/Matcher/Generator.php
+++ b/src/PhpPact/Xml/Model/Matcher/Generator.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PhpPact\Xml\Model\Matcher;
+
+class Generator
+{
+    private string $type;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $options = [];
+
+    public function __construct(callable ...$options)
+    {
+        array_walk($options, fn (callable $option) => $option($this));
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): self
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getArray(): array
+    {
+        return ['pact:generator:type' => $this->type] + $this->options;
+    }
+}

--- a/src/PhpPact/Xml/Model/Matcher/Matcher.php
+++ b/src/PhpPact/Xml/Model/Matcher/Matcher.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PhpPact\Xml\Model\Matcher;
+
+class Matcher
+{
+    private string $type;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $options = [];
+
+    public function __construct(callable ...$options)
+    {
+        array_walk($options, fn (callable $option) => $option($this));
+    }
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): self
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getArray(): array
+    {
+        return ['pact:matcher:type' => $this->type] + $this->options;
+    }
+}

--- a/src/PhpPact/Xml/XmlBuilder.php
+++ b/src/PhpPact/Xml/XmlBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PhpPact\Xml;
+
+use PhpPact\Xml\Model\Builder\ElementTrait;
+use PhpPact\Xml\Model\Builder\GeneratorTrait;
+use PhpPact\Xml\Model\Builder\MatcherTrait;
+use PhpPact\Xml\Model\Builder\TextTrait;
+
+class XmlBuilder
+{
+    use ElementTrait;
+    use TextTrait;
+    use MatcherTrait;
+    use GeneratorTrait;
+
+    public function __construct(private string $version, private string $charset)
+    {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getArray(): array
+    {
+        return [
+            'version' => $this->version,
+            'charset' => $this->charset,
+            'root' => $this->root->getArray(),
+        ];
+    }
+}

--- a/src/PhpPact/Xml/XmlElement.php
+++ b/src/PhpPact/Xml/XmlElement.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace PhpPact\Xml;
+
+use PhpPact\Xml\Model\Matcher\Generator;
+use PhpPact\Xml\Model\Matcher\Matcher;
+
+class XmlElement
+{
+    private string $name;
+
+    /**
+     * @var XmlElement[]
+     */
+    private array $children = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $attributes = [];
+
+    private ?XmlText $text = null;
+
+    private ?Matcher $matcher = null;
+
+    private ?Generator $generator = null;
+
+    public function __construct(callable ...$options)
+    {
+        array_walk($options, fn (callable $option) => $option($this));
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = preg_replace('/(^[0-9]+|[^a-zA-Z0-9\-\_\:]+)/', '', $name);
+
+        return $this;
+    }
+
+    public function addChild(self $child): self
+    {
+        $this->children[] = $child;
+
+        return $this;
+    }
+
+    public function setText(?XmlText $text): self
+    {
+        $this->text = $text;
+
+        return $this;
+    }
+
+    public function setMatcher(?Matcher $matcher): self
+    {
+        $this->matcher = $matcher;
+
+        return $this;
+    }
+
+    public function setGenerator(?Generator $generator): self
+    {
+        $this->generator = $generator;
+
+        return $this;
+    }
+
+    public function addAttribute(string $name, mixed $value): self
+    {
+        $this->attributes[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getArray(): array
+    {
+        if ($this->matcher) {
+            $result = [
+                'value' => $this->getBaseArray(),
+            ];
+            $result += $this->matcher->getArray();
+
+            if ($this->generator) {
+                $result += $this->generator->getArray();
+            }
+        } else {
+            $result = $this->getBaseArray();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getBaseArray(): array
+    {
+        $result = [
+            'name' => $this->name,
+            'children' => array_map(fn (XmlElement $element) => $element->getArray(), $this->children),
+            'attributes' => $this->attributes
+        ];
+
+        if ($this->text) {
+            $result['children'][] = $this->text->getArray();
+        }
+
+        return $result;
+    }
+}

--- a/src/PhpPact/Xml/XmlText.php
+++ b/src/PhpPact/Xml/XmlText.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace PhpPact\Xml;
+
+use PhpPact\Xml\Model\Matcher\Generator;
+use PhpPact\Xml\Model\Matcher\Matcher;
+
+class XmlText
+{
+    private string|int|float $content;
+
+    private ?Matcher $matcher = null;
+
+    private ?Generator $generator = null;
+
+    public function __construct(callable ...$options)
+    {
+        array_walk($options, fn (callable $option) => $option($this));
+    }
+
+    public function setContent(string|int|float $content): self
+    {
+        $this->content = $content;
+
+        return $this;
+    }
+
+    public function setMatcher(?Matcher $matcher): self
+    {
+        $this->matcher = $matcher;
+
+        return $this;
+    }
+
+    public function setGenerator(?Generator $generator): self
+    {
+        $this->generator = $generator;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getArray(): array
+    {
+        $result = $this->getBaseArray();
+
+        if ($this->matcher) {
+            $result['matcher'] = $this->matcher->getArray();
+        }
+
+        if ($this->generator) {
+            $generator = $this->generator->getArray();
+            $result['pact:generator:type'] = $generator['pact:generator:type'];
+            $result['matcher'] += array_diff_key($generator, array_flip(['pact:generator:type']));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getBaseArray(): array
+    {
+        return [
+            'content' => $this->content,
+        ];
+    }
+}

--- a/tests/PhpPact/Xml/XmlBuilderIntegrationTest.php
+++ b/tests/PhpPact/Xml/XmlBuilderIntegrationTest.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace PhpPactTest\Xml;
+
+use PhpPact\Consumer\Matcher\Matcher;
+use PHPUnit\Framework\TestCase;
+use PhpPact\Xml\XmlBuilder;
+
+class XmlBuilderIntegrationTest extends TestCase
+{
+    private XmlBuilder $builder;
+    private Matcher $matcher;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->builder = new XmlBuilder('1.0', 'UTF-8');
+        $this->matcher = new Matcher();
+    }
+
+    public function testBuildWithMatchersOnAttributes(): void
+    {
+        $this->builder
+            ->root(
+                $this->builder->name('ns1:projects'),
+                $this->builder->attribute('id', '1234'),
+                $this->builder->attribute('xmlns:ns1', 'http://some.namespace/and/more/stuff'),
+                $this->builder->add(
+                    $this->builder->eachLike(examples: 2),
+                    $this->builder->name('ns1:project'),
+                    $this->builder->attribute('id', $this->matcher->integerV3(1)),
+                    $this->builder->attribute('type', 'activity'),
+                    $this->builder->attribute('name', $this->matcher->string('Project 1')),
+                    $this->builder->attribute('due', $this->matcher->datetime("yyyy-MM-dd'T'HH:mm:ss.SZ", '2016-02-11T09:46:56.023Z')),
+                    $this->builder->add(
+                        $this->builder->name('ns1:tasks'),
+                        $this->builder->add(
+                            $this->builder->eachLike(examples: 5),
+                            $this->builder->name('ns1:task'),
+                            $this->builder->attribute('id', $this->matcher->integerV3(1)),
+                            $this->builder->attribute('name', $this->matcher->string('Task 1')),
+                            $this->builder->attribute('done', $this->matcher->boolean()),
+                        ),
+                    ),
+                ),
+            );
+
+        $expectedArray = [
+            'version' => '1.0',
+            'charset' => 'UTF-8',
+            'root' => [
+                'name' => 'ns1:projects',
+                'children' => [
+                    [
+                        'value' => [
+                            'name' => 'ns1:project',
+                            'children' => [
+                                [
+                                    'name' => 'ns1:tasks',
+                                    'children' => [
+                                        [
+                                            'value' => [
+                                                'name' => 'ns1:task',
+                                                'children' => [],
+                                                'attributes' => [
+                                                    'id' => [
+                                                        'pact:matcher:type' =>
+                                                            'integer',
+                                                        'value' => 1,
+                                                    ],
+                                                    'name' => [
+                                                        'pact:matcher:type' => 'type',
+                                                        'value' => 'Task 1',
+                                                    ],
+                                                    'done' => [
+                                                        'pact:matcher:type' => 'type',
+                                                        'value' => true,
+                                                    ],
+                                                ],
+                                            ],
+                                            'pact:matcher:type' => 'type',
+                                            'min' => 1,
+                                            'examples' => 5,
+                                        ],
+                                    ],
+                                    'attributes' => [],
+                                ],
+                            ],
+                            'attributes' => [
+                                'id' => [
+                                    'pact:matcher:type' => 'integer',
+                                    'value' => 1,
+                                ],
+                                'type' => 'activity',
+                                'name' => [
+                                    'pact:matcher:type' => 'type',
+                                    'value' => 'Project 1',
+                                ],
+                                'due' => [
+                                    'pact:matcher:type' => 'datetime',
+                                    'format' => "yyyy-MM-dd'T'HH:mm:ss.SZ",
+                                    'value' => '2016-02-11T09:46:56.023Z',
+                                ],
+                            ],
+                        ],
+                        'pact:matcher:type' => 'type',
+                        'min' => 1,
+                        'examples' => 2,
+                    ],
+                ],
+                'attributes' => [
+                    'id' => '1234',
+                    'xmlns:ns1' => 'http://some.namespace/and/more/stuff',
+                ],
+            ],
+        ];
+
+        $this->assertSame(json_encode($expectedArray), json_encode($this->builder->getArray()));
+    }
+
+    public function testBuildWithMatchersOnContent(): void
+    {
+        $this->builder
+            ->root(
+                $this->builder->name('movies'),
+                $this->builder->add(
+                    $this->builder->eachLike(),
+                    $this->builder->name('movie'),
+                    $this->builder->add(
+                        $this->builder->name('title'),
+                        $this->builder->text(
+                            $this->builder->contentLike('PHP: Behind the Parser'),
+                        ),
+                    ),
+                    $this->builder->add(
+                        $this->builder->name('characters'),
+                        $this->builder->add(
+                            $this->builder->eachLike(examples: 2),
+                            $this->builder->name('character'),
+                            $this->builder->add(
+                                $this->builder->name('name'),
+                                $this->builder->text(
+                                    $this->builder->contentLike('Ms. Coder'),
+                                ),
+                            ),
+                            $this->builder->add(
+                                $this->builder->name('actor'),
+                                $this->builder->text(
+                                    $this->builder->contentLike('Onlivia Actora'),
+                                ),
+                            ),
+                        ),
+                    ),
+                    $this->builder->add(
+                        $this->builder->name('plot'),
+                        $this->builder->text(
+                            $this->builder->contentLike(
+                                $plot = <<<EOF
+                                So, this language. It's like, a programming language. Or is it a
+                                scripting language? All is revealed in this thrilling horror spoof
+                                of a documentary.
+                                EOF
+                            ),
+                        ),
+                    ),
+                    $this->builder->add(
+                        $this->builder->name('great-lines'),
+                        $this->builder->add(
+                            $this->builder->eachLike(),
+                            $this->builder->name('line'),
+                            $this->builder->text(
+                                $this->builder->contentLike('PHP solves all my web problems'),
+                            ),
+                        ),
+                    ),
+                    $this->builder->add(
+                        $this->builder->name('rating'),
+                        $this->builder->attribute('type', 'thumbs'),
+                        $this->builder->text(
+                            $this->builder->contentLike(7),
+                        ),
+                    ),
+                    $this->builder->add(
+                        $this->builder->name('rating'),
+                        $this->builder->attribute('type', 'stars'),
+                        $this->builder->text(
+                            $this->builder->contentLike(5),
+                        ),
+                    ),
+                ),
+            );
+
+        $expectedArray = [
+            'version' => '1.0',
+            'charset' => 'UTF-8',
+            'root' => [
+                'name' => 'movies',
+                'children' => [
+                    [
+                        'value' => [
+                            'name' => 'movie',
+                            'children' => [
+                                [
+                                    'name' => 'title',
+                                    'children' => [
+                                        [
+                                            'content' => 'PHP: Behind the Parser',
+                                            'matcher' => [
+                                                'pact:matcher:type' => 'type',
+                                            ],
+                                        ],
+                                    ],
+                                    'attributes' => [],
+                                ],
+                                [
+                                    'name' => 'characters',
+                                    'children' => [
+                                        [
+                                            'value' => [
+                                                'name' => 'character',
+                                                'children' => [
+                                                    [
+                                                        'name' => 'name',
+                                                        'children' => [
+                                                            [
+                                                                'content' =>
+                                                                    'Ms. Coder',
+                                                                'matcher' => [
+                                                                    'pact:matcher:type' =>
+                                                                        'type',
+                                                                ],
+                                                            ],
+                                                        ],
+                                                        'attributes' => [],
+                                                    ],
+                                                    [
+                                                        'name' => 'actor',
+                                                        'children' => [
+                                                            [
+                                                                'content' =>
+                                                                    'Onlivia Actora',
+                                                                'matcher' => [
+                                                                    'pact:matcher:type' =>
+                                                                        'type',
+                                                                ],
+                                                            ],
+                                                        ],
+                                                        'attributes' => [],
+                                                    ],
+                                                ],
+                                                'attributes' => [],
+                                            ],
+                                            'pact:matcher:type' => 'type',
+                                            'min' => 1,
+                                            'examples' => 2,
+                                        ],
+                                    ],
+                                    'attributes' => [],
+                                ],
+                                [
+                                    'name' => 'plot',
+                                    'children' => [
+                                        [
+                                            'content' => $plot,
+                                            'matcher' => [
+                                                'pact:matcher:type' => 'type',
+                                            ],
+                                        ],
+                                    ],
+                                    'attributes' => [],
+                                ],
+                                [
+                                    'name' => 'great-lines',
+                                    'children' => [
+                                        [
+                                            'value' => [
+                                                'name' => 'line',
+                                                'children' => [
+                                                    [
+                                                        'content' =>
+                                                            'PHP solves all my web problems',
+                                                        'matcher' => [
+                                                            'pact:matcher:type' =>
+                                                                'type',
+                                                        ],
+                                                    ],
+                                                ],
+                                                'attributes' => [],
+                                            ],
+                                            'pact:matcher:type' => 'type',
+                                            'min' => 1,
+                                            'examples' => 1,
+                                        ],
+                                    ],
+                                    'attributes' => [],
+                                ],
+                                [
+                                    'name' => 'rating',
+                                    'children' => [
+                                        [
+                                            'content' => 7,
+                                            'matcher' => [
+                                                'pact:matcher:type' => 'type',
+                                            ],
+                                        ],
+                                    ],
+                                    'attributes' => ['type' => 'thumbs'],
+                                ],
+                                [
+                                    'name' => 'rating',
+                                    'children' => [
+                                        [
+                                            'content' => 5,
+                                            'matcher' => [
+                                                'pact:matcher:type' => 'type',
+                                            ],
+                                        ],
+                                    ],
+                                    'attributes' => ['type' => 'stars'],
+                                ],
+                            ],
+                            'attributes' => [],
+                        ],
+                        'pact:matcher:type' => 'type',
+                        'min' => 1,
+                        'examples' => 1,
+                    ],
+                ],
+                'attributes' => [],
+            ],
+        ];
+
+        $this->assertSame(json_encode($expectedArray), json_encode($this->builder->getArray()));
+    }
+}

--- a/tests/PhpPact/Xml/XmlBuilderTest.php
+++ b/tests/PhpPact/Xml/XmlBuilderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace PhpPactTest\Xml;
+
+use PHPUnit\Framework\TestCase;
+use PhpPact\Xml\XmlBuilder;
+
+class XmlBuilderTest extends TestCase
+{
+    public function testGetArray(): void
+    {
+        $builder = new XmlBuilder('1.0', 'UTF-8');
+
+        $builder
+            ->root(
+                $builder->name('Root'),
+                $builder->add(
+                    $builder->name('First Child Second Element'),
+                    $builder->text(
+                        $builder->contentLike('Example Test')
+                    )
+                ),
+                $builder->add(
+                    $builder->name('Second Parent'),
+                    $builder->add(
+                        $builder->name('Second child 1'),
+                        $builder->attribute('myAttr', 'Attr Value')
+                    ),
+                    $builder->add(
+                        $builder->name('Second child 2'),
+                        $builder->text(
+                            $builder->content('Test')
+                        )
+                    ),
+                    $builder->add(
+                        $builder->name('Third Parent'),
+                        $builder->add(
+                            $builder->eachLike(),
+                            $builder->name('Child')
+                        )
+                    ),
+                ),
+                $builder->add(
+                    $builder->name('First Child Third Element'),
+                ),
+            )
+        ;
+
+        $expectedArray = [
+            'version' => '1.0',
+            'charset' => 'UTF-8',
+            'root' => [
+                'name' => 'Root',
+                'children' => [
+                    [
+                        'name' => 'FirstChildSecondElement',
+                        'children' => [
+                            [
+                                'content' => 'Example Test',
+                                'matcher' => ['pact:matcher:type' => 'type'],
+                            ],
+                        ],
+                        'attributes' => [],
+                    ],
+                    [
+                        'name' => 'SecondParent',
+                        'children' => [
+                            [
+                                'name' => 'Secondchild1',
+                                'children' => [],
+                                'attributes' => ['myAttr' => 'Attr Value'],
+                            ],
+                            [
+                                'name' => 'Secondchild2',
+                                'children' => [['content' => 'Test']],
+                                'attributes' => [],
+                            ],
+                            [
+                                'name' => 'ThirdParent',
+                                'children' => [
+                                    [
+                                        'value' => [
+                                            'name' => 'Child',
+                                            'children' => [],
+                                            'attributes' => [],
+                                        ],
+                                        'pact:matcher:type' => 'type',
+                                        'min' => 1,
+                                        'examples' => 1,
+                                    ],
+                                ],
+                                'attributes' => [],
+                            ],
+                        ],
+                        'attributes' => [],
+                    ],
+                    [
+                        'name' => 'FirstChildThirdElement',
+                        'children' => [],
+                        'attributes' => [],
+                    ],
+                ],
+                'attributes' => [],
+            ],
+        ];
+
+
+        $this->assertSame(json_encode($expectedArray), json_encode($builder->getArray()));
+    }
+}

--- a/tests/PhpPact/Xml/XmlElementTest.php
+++ b/tests/PhpPact/Xml/XmlElementTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace PhpPactTest\Xml;
+
+use PHPUnit\Framework\TestCase;
+use PhpPact\Xml\Model\Matcher\Generator;
+use PhpPact\Xml\Model\Matcher\Matcher;
+use PhpPact\Xml\XmlElement;
+
+class XmlElementTest extends TestCase
+{
+    private XmlElement $element;
+
+    public function setUp(): void
+    {
+        $this->element = new XmlElement();
+        $this->element->setName('Child');
+        $this->element->addAttribute('myAttr', 'attr-value');
+    }
+
+    public function testGetMatcherArray(): void
+    {
+        $this->element->setMatcher(new Matcher(
+            fn (Matcher $matcher) => $matcher->setType('type'),
+            fn (Matcher $matcher) => $matcher->setOptions(['examples' => 7]),
+        ));
+
+        $this->assertSame(
+            json_encode([
+                'value' => [
+                    'name' => 'Child',
+                    'children' => [],
+                    'attributes' => [
+                        'myAttr' => 'attr-value',
+                    ],
+                ],
+                'pact:matcher:type' => 'type',
+                'examples' => 7,
+            ]),
+            json_encode($this->element->getArray())
+        );
+    }
+
+    public function testGetGeneratorArray(): void
+    {
+        $this->element->setMatcher(new Matcher(
+            fn (Matcher $matcher) => $matcher->setType('type'),
+            fn (Matcher $matcher) => $matcher->setOptions(['examples' => 7]),
+        ));
+        $this->element->setGenerator(new Generator(
+            fn (Generator $generator) => $generator->setType('Uuid'),
+            fn (Generator $generator) => $generator->setOptions(['format' => 'simple']),
+        ));
+
+        $this->assertSame(
+            json_encode([
+                'value' => [
+                    'name' => 'Child',
+                    'children' => [],
+                    'attributes' => [
+                        'myAttr' => 'attr-value',
+                    ]
+                ],
+                'pact:matcher:type' => 'type',
+                'examples' => 7,
+                'pact:generator:type' => 'Uuid',
+                'format' => 'simple',
+            ]),
+            json_encode($this->element->getArray())
+        );
+    }
+
+    public function testGetBaseArray(): void
+    {
+        $this->assertSame(
+            json_encode([
+                'name' => 'Child',
+                'children' => [],
+                'attributes' => [
+                    'myAttr' => 'attr-value',
+                ]
+            ]),
+            json_encode($this->element->getArray())
+        );
+    }
+}

--- a/tests/PhpPact/Xml/XmlTextTest.php
+++ b/tests/PhpPact/Xml/XmlTextTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace PhpPactTest\Xml;
+
+use PHPUnit\Framework\TestCase;
+use PhpPact\Xml\Model\Matcher\Generator;
+use PhpPact\Xml\Model\Matcher\Matcher;
+use PhpPact\Xml\XmlText;
+
+class XmlTextTest extends TestCase
+{
+    private XmlText $text;
+
+    public function setUp(): void
+    {
+        $this->text = new XmlText();
+        $this->text->setContent('testing');
+    }
+
+    public function testGetMatcherArray(): void
+    {
+        $this->text->setMatcher(new Matcher(
+            fn (Matcher $matcher) => $matcher->setType('include'),
+            fn (Matcher $matcher) => $matcher->setOptions(['value' => "te"]),
+        ));
+
+        $this->assertSame(
+            json_encode([
+                'content' => 'testing',
+                'matcher' => [
+                    'pact:matcher:type' => 'include',
+                    'value' => 'te',
+                ]
+            ]),
+            json_encode($this->text->getArray())
+        );
+    }
+
+    public function testGetGeneratorArray(): void
+    {
+        $this->text->setContent(7);
+        $this->text->setMatcher(new Matcher(
+            fn (Matcher $matcher) => $matcher->setType('integer'),
+        ));
+        $this->text->setGenerator(new Generator(
+            fn (Generator $generator) => $generator->setType('RandomInt'),
+            fn (Generator $generator) => $generator->setOptions(['min' => 2, 'max' => 8]),
+        ));
+
+        $this->assertSame(
+            json_encode([
+                'content' => 7,
+                'matcher' => [
+                    'pact:matcher:type' => 'integer',
+                    'min' => 2,
+                    'max' => 8,
+                ],
+                'pact:generator:type' => 'RandomInt'
+            ]),
+            json_encode($this->text->getArray())
+        );
+    }
+
+    public function testGetBaseArray(): void
+    {
+        $this->assertSame(
+            json_encode([
+                'content' => 'testing',
+            ]),
+            json_encode($this->text->getArray())
+        );
+    }
+}


### PR DESCRIPTION
* Move code from [xml](https://github.com/tienvx/pact-php-xml) to this repo
* Update code
  * Change namespace
  * Remove this `(object) ` type casting https://github.com/tienvx/pact-php-xml/blob/main/src/XmlElement.php#L104 to make tests pass. I remember it's just a hack to make tests pass in the original repo.
* Update tests
  * Handle new line (`\n` to `\r\n`) on Windows
  * Move `Integration/XmlBuilder` to `XmlBuilderIntegrationTest`