### PR TITLE
chore: Check string generator is working

### DIFF
--- a/example/generators/consumer/tests/Service/GeneratorsTest.php
+++ b/example/generators/consumer/tests/Service/GeneratorsTest.php
@@ -7,6 +7,7 @@ use GeneratorsConsumer\Service\HttpClientService;
 use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Matcher\HttpStatus;
 use PhpPact\Consumer\Matcher\Matcher;
+use PhpPact\Consumer\Matcher\Matchers\StringValue;
 use PhpPact\Consumer\Model\ConsumerRequest;
 use PhpPact\Consumer\Model\ProviderResponse;
 use PhpPact\Standalone\MockService\MockServerConfig;
@@ -93,6 +94,7 @@ class GeneratorsTest extends TestCase
         $this->assertTrue($this->validateDateTime($body['time'], 'H:i:s'));
         $this->assertTrue($this->validateDateTime($body['datetime'], "Y-m-d\TH:i:s"));
         $this->assertIsString($body['string']);
+        $this->assertNotSame(StringValue::DEFAULT_VALUE, $body['string']);
         $this->assertIsNumeric($body['number']);
         $this->assertNotSame('http://localhost/users/1234/posts/latest', $body['url']);
         $this->assertRegExp('/.*(\\/users\\/\\d+\\/posts\\/latest)$/', $body['url']);

--- a/src/PhpPact/Consumer/Matcher/Matchers/StringValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/StringValue.php
@@ -9,6 +9,8 @@ use PhpPact\Consumer\Matcher\Generators\RandomString;
  */
 class StringValue extends GeneratorAwareMatcher
 {
+    public const DEFAULT_VALUE = 'some string';
+
     public function __construct(private ?string $value = null)
     {
         if ($value === null) {
@@ -28,7 +30,7 @@ class StringValue extends GeneratorAwareMatcher
     {
         $data = [
             'pact:matcher:type' => $this->getType(),
-            'value' => $this->getValue() ?? 'some string',
+            'value' => $this->getValue() ?? self::DEFAULT_VALUE,
         ];
 
         if ($this->getGenerator()) {


### PR DESCRIPTION
I think `RandomString` generator work a bit different from other generators. It work even if the `value` is still there. But it's totally fine. We want this behavior, because:
1. There is no matcher for `string`
2. We need to re-use `type` matcher with a string value
3. That's why `value` must be always a string, even though we are using the `RandomString` generator or not.