### PR TITLE
refactor!: Move csv to core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,10 @@
             "GeneratorsConsumer\\": "example/generators/consumer/src",
             "GeneratorsConsumer\\Tests\\": "example/generators/consumer/tests",
             "GeneratorsProvider\\Tests\\": "example/generators/provider/tests",
+            "CsvConsumer\\": "example/csv/consumer/src",
+            "CsvConsumer\\Tests\\": "example/csv/consumer/tests",
+            "CsvProvider\\": "example/csv/provider/src",
+            "CsvProvider\\Tests\\": "example/csv/provider/tests",
             "": [
                 "example/protobuf-sync-message/library/src"
             ],

--- a/example/csv/consumer/phpunit.xml
+++ b/example/csv/consumer/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../../../vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="PhpPact Example Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="PACT_LOGLEVEL" value="DEBUG"/>
+    </php>
+</phpunit>

--- a/example/csv/consumer/src/Service/HttpClientService.php
+++ b/example/csv/consumer/src/Service/HttpClientService.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace CsvConsumer\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Uri;
+
+class HttpClientService
+{
+    private Client $httpClient;
+
+    private string $baseUri;
+
+    public function __construct(string $baseUri)
+    {
+        $this->httpClient = new Client();
+        $this->baseUri    = $baseUri;
+    }
+
+    public function getReport(): array
+    {
+        $response = $this->httpClient->get(new Uri("{$this->baseUri}/report.csv"), [
+            'headers' => ['Accept' => 'text/csv']
+        ]);
+
+        return str_getcsv($response->getBody());
+    }
+}

--- a/example/csv/consumer/tests/Service/HttpClientServiceTest.php
+++ b/example/csv/consumer/tests/Service/HttpClientServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace CsvConsumer\Tests\Service;
+
+use CsvConsumer\Service\HttpClientService;
+use PhpPact\Consumer\InteractionBuilder;
+use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\ConsumerRequest;
+use PhpPact\Consumer\Model\ProviderResponse;
+use PhpPact\Plugins\Csv\Factory\CsvInteractionDriverFactory;
+use PhpPact\Standalone\MockService\MockServerConfig;
+use PHPUnit\Framework\TestCase;
+
+class HttpClientServiceTest extends TestCase
+{
+    public function testGetCsvFile(): void
+    {
+        $request = new ConsumerRequest();
+        $request
+            ->setMethod('GET')
+            ->setPath('/report.csv')
+            ->addHeader('Accept', 'text/csv')
+        ;
+
+        $response = new ProviderResponse();
+        $response
+            ->setStatus(200)
+            ->setBody(new Text(
+                json_encode([
+                    'csvHeaders' => false,
+                    'column:1' => "matching(type,'Name')",
+                    'column:2' => 'matching(number,100)',
+                    'column:3' => "matching(datetime, 'yyyy-MM-dd','2000-01-01')",
+                ]),
+                'text/csv'
+            ))
+        ;
+
+        $config = new MockServerConfig();
+        $config
+            ->setConsumer('csvConsumer')
+            ->setProvider('csvProvider')
+            ->setPactSpecificationVersion('4.0.0')
+            ->setPactDir(__DIR__.'/../../../pacts');
+        if ($logLevel = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($logLevel);
+        }
+        $builder = new InteractionBuilder($config, new CsvInteractionDriverFactory());
+        $builder
+            ->given('report.csv file exist')
+            ->uponReceiving('request for a report.csv')
+            ->with($request)
+            ->willRespondWith($response)
+        ;
+
+        $service = new HttpClientService($config->getBaseUri());
+        $columns = $service->getReport();
+
+        $this->assertTrue($builder->verify());
+        $this->assertCount(3, $columns);
+        $this->assertSame(['Name', '100', '2000-01-01'], $columns);
+    }
+}

--- a/example/csv/pacts/csvConsumer-csvProvider.json
+++ b/example/csv/pacts/csvConsumer-csvProvider.json
@@ -1,0 +1,108 @@
+{
+  "consumer": {
+    "name": "csvConsumer"
+  },
+  "interactions": [
+    {
+      "description": "request for a report.csv",
+      "interactionMarkup": {
+        "markup": "# Data\n\n|Name|100|2000-01-01|\n",
+        "markupType": "COMMON_MARK"
+      },
+      "pending": false,
+      "pluginConfiguration": {
+        "csv": {
+          "csvHeaders": false
+        }
+      },
+      "providerStates": [
+        {
+          "name": "report.csv file exist"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Accept": [
+            "text/csv"
+          ]
+        },
+        "method": "GET",
+        "path": "/report.csv"
+      },
+      "response": {
+        "body": {
+          "content": "Name,100,2000-01-01\n",
+          "contentType": "text/csv;charset=utf-8",
+          "contentTypeHint": "DEFAULT",
+          "encoded": false
+        },
+        "generators": {
+          "body": {
+            "column:3": {
+              "format": "yyyy-MM-dd",
+              "type": "DateTime"
+            }
+          }
+        },
+        "headers": {
+          "content-type": [
+            "text/csv"
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "column:1": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            },
+            "column:2": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "number"
+                }
+              ]
+            },
+            "column:3": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "format": "yyyy-MM-dd",
+                  "match": "datetime"
+                }
+              ]
+            }
+          },
+          "status": {}
+        },
+        "status": 200
+      },
+      "transport": "http",
+      "type": "Synchronous/HTTP"
+    }
+  ],
+  "metadata": {
+    "pactRust": {
+      "ffi": "0.4.11",
+      "mockserver": "1.2.4",
+      "models": "1.1.12"
+    },
+    "pactSpecification": {
+      "version": "4.0"
+    },
+    "plugins": [
+      {
+        "configuration": {},
+        "name": "csv",
+        "version": "0.0.3"
+      }
+    ]
+  },
+  "provider": {
+    "name": "csvProvider"
+  }
+}

--- a/example/csv/provider/phpunit.xml
+++ b/example/csv/provider/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="../../../vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="PhpPact Example Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="PACT_LOGLEVEL" value="DEBUG"/>
+    </php>
+</phpunit>

--- a/example/csv/provider/public/index.php
+++ b/example/csv/provider/public/index.php
@@ -1,0 +1,15 @@
+<?php
+
+require __DIR__.'/../../../../vendor/autoload.php';
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+$app = AppFactory::create();
+
+$app->post('/pact-change-state', function (Request $request, Response $response) {
+    return $response;
+});
+
+$app->run();

--- a/example/csv/provider/public/report.csv
+++ b/example/csv/provider/public/report.csv
@@ -1,0 +1,11 @@
+"Mack Greenholt Jr.",943,2003-02-05
+"Luigi Ruecker",654,1980-09-11
+"Mr. Unique Zieme",79,2020-04-30
+"Leif Price",367,2013-04-07
+"Destiny Rodriguez",995,1983-03-20
+"Lavinia Carroll",344,2010-08-01
+"Reta Schoen",113,2001-01-26
+"Mrs. Carolina Swift",494,1982-01-20
+"Gene Crona PhD",852,1992-11-16
+"Dr. Santino Koepp",79,1984-05-05
+"Luigi Sanford",969,1995-07-02

--- a/example/csv/provider/tests/PactVerifyTest.php
+++ b/example/csv/provider/tests/PactVerifyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace XmlProvider\Tests;
+namespace CsvProvider\Tests;
 
 use GuzzleHttp\Psr7\Uri;
 use PhpPact\Standalone\ProviderVerifier\Model\VerifierConfig;
@@ -29,25 +29,22 @@ class PactVerifyTest extends TestCase
         $this->process->stop();
     }
 
-    /**
-     * This test will run after the web server is started.
-     */
-    public function testPactVerifyConsumer()
+    public function testPactVerifyConsumer(): void
     {
         $config = new VerifierConfig();
         $config->getProviderInfo()
-            ->setName('xmlProvider') // Providers name to fetch.
+            ->setName('csvProvider')
             ->setHost('localhost')
             ->setPort(7202);
         $config->getProviderState()
             ->setStateChangeUrl(new Uri('http://localhost:7202/pact-change-state'))
         ;
-        if ($level = \getenv('PACT_LOGLEVEL')) {
-            $config->setLogLevel($level);
+        if ($logLevel = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($logLevel);
         }
 
         $verifier = new Verifier($config);
-        $verifier->addFile(__DIR__ . '/../../pacts/xmlConsumer-xmlProvider.json');
+        $verifier->addFile(__DIR__ . '/../../pacts/csvConsumer-csvProvider.json');
 
         $verifyResult = $verifier->verify();
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -55,6 +55,12 @@
     <testsuite name="PhpPact Generators Provider Example Tests">
         <directory>./example/generators/provider/tests</directory>
     </testsuite>
+    <testsuite name="PhpPact Csv Consumer Example Tests">
+        <directory>./example/csv/consumer/tests</directory>
+    </testsuite>
+    <testsuite name="PhpPact Csv Provider Example Tests">
+        <directory>./example/csv/provider/tests</directory>
+    </testsuite>
     <testsuite name="PhpPact Protobuf Sync Message Consumer Example Tests">
         <directory>./example/protobuf-sync-message/consumer/tests</directory>
     </testsuite>

--- a/src/PhpPact/Plugins/Csv/Driver/Pact/CsvPactDriver.php
+++ b/src/PhpPact/Plugins/Csv/Driver/Pact/CsvPactDriver.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PhpPact\Plugins\Csv\Driver\Pact;
+
+use PhpPact\Plugin\Driver\Pact\AbstractPluginPactDriver;
+
+class CsvPactDriver extends AbstractPluginPactDriver
+{
+    protected function getPluginName(): string
+    {
+        return 'csv';
+    }
+}

--- a/src/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactory.php
+++ b/src/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PhpPact\Plugins\Csv\Factory;
+
+use PhpPact\Consumer\Driver\Interaction\InteractionDriver;
+use PhpPact\Consumer\Driver\Interaction\InteractionDriverInterface;
+use PhpPact\Consumer\Factory\InteractionDriverFactoryInterface;
+use PhpPact\Consumer\Registry\Pact\PactRegistry;
+use PhpPact\FFI\Client;
+use PhpPact\Standalone\MockService\MockServerConfigInterface;
+use PhpPact\Consumer\Service\MockServer;
+use PhpPact\Plugins\Csv\Driver\Pact\CsvPactDriver;
+use PhpPact\Plugins\Csv\Registry\Interaction\CsvInteractionRegistry;
+
+class CsvInteractionDriverFactory implements InteractionDriverFactoryInterface
+{
+    public function create(MockServerConfigInterface $config): InteractionDriverInterface
+    {
+        $client = new Client();
+        $pactRegistry = new PactRegistry($client);
+        $pactDriver = new CsvPactDriver($client, $config, $pactRegistry);
+        $mockServer = new MockServer($client, $pactRegistry, $config);
+        $interactionRegistry = new CsvInteractionRegistry($client, $pactRegistry);
+
+        return new InteractionDriver($pactDriver, $interactionRegistry, $mockServer);
+    }
+}

--- a/src/PhpPact/Plugins/Csv/Registry/Interaction/Body/CsvResponseBodyRegistry.php
+++ b/src/PhpPact/Plugins/Csv/Registry/Interaction/Body/CsvResponseBodyRegistry.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPact\Plugins\Csv\Registry\Interaction\Body;
+
+use PhpPact\Consumer\Registry\Interaction\InteractionRegistryInterface;
+use PhpPact\Consumer\Registry\Interaction\Part\ResponsePartTrait;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Plugin\Registry\Interaction\Body\AbstractPluginBodyRegistry;
+
+class CsvResponseBodyRegistry extends AbstractPluginBodyRegistry
+{
+    use ResponsePartTrait;
+
+    public function __construct(
+        protected ClientInterface $client,
+        private InteractionRegistryInterface $interactionRegistry
+    ) {
+        parent::__construct($client);
+    }
+
+    protected function getInteractionId(): int
+    {
+        return $this->interactionRegistry->getId();
+    }
+}

--- a/src/PhpPact/Plugins/Csv/Registry/Interaction/CsvInteractionRegistry.php
+++ b/src/PhpPact/Plugins/Csv/Registry/Interaction/CsvInteractionRegistry.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace PhpPact\Plugins\Csv\Registry\Interaction;
+
+use PhpPact\Consumer\Registry\Interaction\InteractionRegistry;
+use PhpPact\Consumer\Registry\Interaction\Part\RequestRegistryInterface;
+use PhpPact\Consumer\Registry\Interaction\Part\ResponseRegistry;
+use PhpPact\Consumer\Registry\Interaction\Part\ResponseRegistryInterface;
+use PhpPact\Consumer\Registry\Pact\PactRegistryInterface;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Plugins\Csv\Registry\Interaction\Body\CsvResponseBodyRegistry;
+
+class CsvInteractionRegistry extends InteractionRegistry
+{
+    public function __construct(
+        ClientInterface $client,
+        PactRegistryInterface $pactRegistry,
+        ?RequestRegistryInterface $requestRegistry = null,
+        ?ResponseRegistryInterface $responseRegistry = null,
+    ) {
+        $responseRegistry = $responseRegistry ?? new ResponseRegistry($client, $this, new CsvResponseBodyRegistry($client, $this));
+        parent::__construct($client, $pactRegistry, $requestRegistry, $responseRegistry);
+    }
+}


### PR DESCRIPTION
* Move code from [csv](https://github.com/tienvx/pact-php-csv) to this repo
* Update examples
  * Cleanup `csv` example
  * Fix typo `XmlConsumer` -> `XmlProvider`

Depend on https://github.com/pact-foundation/pact-php/pull/441