### PR TITLE
refactor!: Move protobuf code to core

### DIFF
--- a/src/PhpPact/Plugins/Protobuf/Driver/Pact/ProtobufPactDriver.php
+++ b/src/PhpPact/Plugins/Protobuf/Driver/Pact/ProtobufPactDriver.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Driver\Pact;
+
+use PhpPact\Plugin\Driver\Pact\AbstractPluginPactDriver;
+
+class ProtobufPactDriver extends AbstractPluginPactDriver
+{
+    protected function getPluginName(): string
+    {
+        return 'protobuf';
+    }
+}

--- a/src/PhpPact/Plugins/Protobuf/Factory/ProtobufMessageDriverFactory.php
+++ b/src/PhpPact/Plugins/Protobuf/Factory/ProtobufMessageDriverFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Factory;
+
+use PhpPact\Config\PactConfigInterface;
+use PhpPact\Consumer\Driver\Interaction\MessageDriver;
+use PhpPact\Consumer\Driver\Interaction\MessageDriverInterface;
+use PhpPact\Consumer\Factory\MessageDriverFactoryInterface;
+use PhpPact\Consumer\Registry\Pact\PactRegistry;
+use PhpPact\FFI\Client;
+use PhpPact\Plugins\Protobuf\Driver\Pact\ProtobufPactDriver;
+use PhpPact\Plugins\Protobuf\Registry\Interaction\ProtobufMessageRegistry;
+
+class ProtobufMessageDriverFactory implements MessageDriverFactoryInterface
+{
+    public function create(PactConfigInterface $config): MessageDriverInterface
+    {
+        $client = new Client();
+        $pactRegistry = new PactRegistry($client);
+        $pactDriver = new ProtobufPactDriver($client, $config, $pactRegistry);
+        $messageRegistry = new ProtobufMessageRegistry($client, $pactRegistry);
+
+        return new MessageDriver($client, $pactDriver, $messageRegistry);
+    }
+}

--- a/src/PhpPact/Plugins/Protobuf/Factory/ProtobufSyncMessageDriverFactory.php
+++ b/src/PhpPact/Plugins/Protobuf/Factory/ProtobufSyncMessageDriverFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Factory;
+
+use PhpPact\Consumer\Registry\Pact\PactRegistry;
+use PhpPact\FFI\Client;
+use PhpPact\Plugins\Protobuf\Driver\Pact\ProtobufPactDriver;
+use PhpPact\Plugins\Protobuf\Registry\Interaction\ProtobufSyncMessageRegistry;
+use PhpPact\Plugins\Protobuf\Service\GrpcMockServer;
+use PhpPact\Standalone\MockService\MockServerConfigInterface;
+use PhpPact\SyncMessage\Driver\Interaction\SyncMessageDriver;
+use PhpPact\SyncMessage\Driver\Interaction\SyncMessageDriverInterface;
+use PhpPact\SyncMessage\Factory\SyncMessageDriverFactoryInterface;
+
+class ProtobufSyncMessageDriverFactory implements SyncMessageDriverFactoryInterface
+{
+    public function create(MockServerConfigInterface $config): SyncMessageDriverInterface
+    {
+        $client = new Client();
+        $pactRegistry = new PactRegistry($client);
+        $pactDriver = new ProtobufPactDriver($client, $config, $pactRegistry);
+        $grpcMockServer = new GrpcMockServer($client, $pactRegistry, $config);
+        $syncMessageRegistry = new ProtobufSyncMessageRegistry($client, $pactRegistry);
+
+        return new SyncMessageDriver($pactDriver, $syncMessageRegistry, $grpcMockServer);
+    }
+}

--- a/src/PhpPact/Plugins/Protobuf/Registry/Interaction/Body/ProtobufMessageContentsRegistry.php
+++ b/src/PhpPact/Plugins/Protobuf/Registry/Interaction/Body/ProtobufMessageContentsRegistry.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Registry\Interaction\Body;
+
+use PhpPact\Consumer\Registry\Interaction\MessageRegistryInterface;
+use PhpPact\Consumer\Registry\Interaction\Part\RequestPartTrait;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Plugin\Registry\Interaction\Body\AbstractPluginBodyRegistry;
+
+class ProtobufMessageContentsRegistry extends AbstractPluginBodyRegistry
+{
+    use RequestPartTrait;
+
+    public function __construct(
+        protected ClientInterface $client,
+        private MessageRegistryInterface $messageRegistry
+    ) {
+        parent::__construct($client);
+    }
+
+    protected function getInteractionId(): int
+    {
+        return $this->messageRegistry->getId();
+    }
+}

--- a/src/PhpPact/Plugins/Protobuf/Registry/Interaction/ProtobufMessageRegistry.php
+++ b/src/PhpPact/Plugins/Protobuf/Registry/Interaction/ProtobufMessageRegistry.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Registry\Interaction;
+
+use PhpPact\Consumer\Registry\Interaction\Body\BodyRegistryInterface;
+use PhpPact\Consumer\Registry\Interaction\MessageRegistry;
+use PhpPact\Consumer\Registry\Pact\PactRegistryInterface;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Plugins\Protobuf\Registry\Interaction\Body\ProtobufMessageContentsRegistry;
+
+class ProtobufMessageRegistry extends MessageRegistry
+{
+    public function __construct(
+        ClientInterface $client,
+        PactRegistryInterface $pactRegistry,
+        ?BodyRegistryInterface $messageContentsRegistry = null
+    ) {
+        parent::__construct($client, $pactRegistry, $messageContentsRegistry ?? new ProtobufMessageContentsRegistry($client, $this));
+    }
+}

--- a/src/PhpPact/Plugins/Protobuf/Registry/Interaction/ProtobufSyncMessageRegistry.php
+++ b/src/PhpPact/Plugins/Protobuf/Registry/Interaction/ProtobufSyncMessageRegistry.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Registry\Interaction;
+
+use PhpPact\Consumer\Registry\Interaction\Body\BodyRegistryInterface;
+use PhpPact\Consumer\Registry\Pact\PactRegistryInterface;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Plugins\Protobuf\Registry\Interaction\Body\ProtobufMessageContentsRegistry;
+use PhpPact\SyncMessage\Registry\Interaction\SyncMessageRegistry;
+
+class ProtobufSyncMessageRegistry extends SyncMessageRegistry
+{
+    public function __construct(
+        ClientInterface $client,
+        PactRegistryInterface $pactRegistry,
+        ?BodyRegistryInterface $messageContentsRegistry = null
+    ) {
+        parent::__construct($client, $pactRegistry, $messageContentsRegistry ?? new ProtobufMessageContentsRegistry($client, $this));
+    }
+}

--- a/src/PhpPact/Plugins/Protobuf/Service/GrpcMockServer.php
+++ b/src/PhpPact/Plugins/Protobuf/Service/GrpcMockServer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Service;
+
+use PhpPact\Consumer\Service\MockServer;
+
+class GrpcMockServer extends MockServer
+{
+    protected function getTransport(): string
+    {
+        return 'grpc';
+    }
+}


### PR DESCRIPTION
- Move code from [protobuf](https://github.com/tienvx/pact-php-protobuf) to this repo
- Only move the code, there are 2 examples for protobuf and will be in separated PRs
- No tests for these code yet