### PR TITLE
ci(test): Compile grpc and cache Linux docker image on Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,17 +27,9 @@ linux_arm64_task:
       - VERSION: 8.1
       - VERSION: 8.0
   arm_container:
-    image: php:$VERSION
-    cpu: 4
-    memory: 12G
-  pre_req_script: 
-      - apt update --yes && apt install --yes zip unzip git libffi-dev protobuf-compiler
-      - curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php
-      - php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
-      - docker-php-ext-install sockets
-      - docker-php-ext-install ffi
-      - MAKEFLAGS=" -j4" pecl install grpc
-      - echo 'extension=grpc.so' >> /usr/local/etc/php/conf.d/grpc.ini
+    dockerfile: .cirrus/linux_arm64/Dockerfile
+    docker_arguments:
+      VERSION: $VERSION
   version_check_script: 
       - php --version
   << : *BUILD_TEST_TASK_TEMPLATE

--- a/.cirrus/linux_arm64/Dockerfile
+++ b/.cirrus/linux_arm64/Dockerfile
@@ -1,0 +1,8 @@
+ARG VERSION
+FROM php:${VERSION}
+RUN apt update --yes && apt install --yes zip unzip git libffi-dev protobuf-compiler
+COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
+RUN docker-php-ext-install sockets
+RUN docker-php-ext-install ffi
+RUN pecl install grpc
+RUN echo 'extension=grpc.so' >> /usr/local/etc/php/conf.d/grpc.ini


### PR DESCRIPTION
Depend on https://github.com/pact-foundation/pact-php/pull/444

Only apply to linux. The task is now run in `30 seconds` not `30 minutes` (with the same hardware: 2 cores, 4G ram).


Can't apply to macos, because of this error `Intel macOS instances are no longer supported!` https://cirrus-ci.com/task/6049929467002880. I tried [another approach](https://github.com/pact-foundation/pact-php/pull/446) but it doesn't work