### PR TITLE
refactor: Add PluginFormatter

### DIFF
--- a/example/csv/consumer/tests/Service/HttpClientServiceTest.php
+++ b/example/csv/consumer/tests/Service/HttpClientServiceTest.php
@@ -4,6 +4,8 @@ namespace CsvConsumer\Tests\Service;
 
 use CsvConsumer\Service\HttpClientService;
 use PhpPact\Consumer\InteractionBuilder;
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
+use PhpPact\Consumer\Matcher\Matcher;
 use PhpPact\Consumer\Model\Body\Text;
 use PhpPact\Consumer\Model\ConsumerRequest;
 use PhpPact\Consumer\Model\ProviderResponse;
@@ -15,6 +17,8 @@ class HttpClientServiceTest extends TestCase
 {
     public function testGetCsvFile(): void
     {
+        $matcher = new Matcher(new PluginFormatter());
+
         $request = new ConsumerRequest();
         $request
             ->setMethod('GET')
@@ -28,9 +32,9 @@ class HttpClientServiceTest extends TestCase
             ->setBody(new Text(
                 json_encode([
                     'csvHeaders' => false,
-                    'column:1' => "matching(type,'Name')",
-                    'column:2' => 'matching(number,100)',
-                    'column:3' => "matching(datetime, 'yyyy-MM-dd','2000-01-01')",
+                    'column:1' => $matcher->like('Name'),
+                    'column:2' => $matcher->number(100),
+                    'column:3' => $matcher->datetime('yyyy-MM-dd', '2000-01-01'),
                 ]),
                 'text/csv'
             ))

--- a/example/protobuf-sync-message/consumer/tests/ProtobufClientTest.php
+++ b/example/protobuf-sync-message/consumer/tests/ProtobufClientTest.php
@@ -2,6 +2,8 @@
 
 namespace ProtobufSyncMessageConsumer\Tests;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
+use PhpPact\Consumer\Matcher\Matcher;
 use PhpPact\Consumer\Model\Body\Text;
 use PhpPact\Plugins\Protobuf\Factory\ProtobufSyncMessageDriverFactory;
 use PhpPact\Standalone\MockService\MockServerConfig;
@@ -15,6 +17,7 @@ class ProtobufClientTest extends TestCase
 {
     public function testCalculateArea(): void
     {
+        $matcher = new Matcher(new PluginFormatter());
         $protoPath = __DIR__ . '/../../library/proto/area_calculator.proto';
 
         $config = new MockServerConfig();
@@ -38,12 +41,12 @@ class ProtobufClientTest extends TestCase
 
                     'request' => [
                         'rectangle' => [
-                            'length' => 'matching(number, 3)',
-                            'width' => 'matching(number, 4)',
+                            'length' => $matcher->number(3),
+                            'width' => $matcher->number(4),
                         ],
                     ],
                     'response' => [
-                        'value' => 'matching(number, 12)',
+                        'value' => $matcher->number(12),
                     ]
                 ]),
                 'application/grpc'

--- a/src/PhpPact/Consumer/Matcher/Exception/MatchingExpressionException.php
+++ b/src/PhpPact/Consumer/Matcher/Exception/MatchingExpressionException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Exception;
+
+class MatchingExpressionException extends MatcherException
+{
+}

--- a/src/PhpPact/Consumer/Matcher/Formatters/MinimalFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/MinimalFormatter.php
@@ -3,7 +3,6 @@
 namespace PhpPact\Consumer\Matcher\Formatters;
 
 use PhpPact\Consumer\Matcher\Model\FormatterInterface;
-use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 
 class MinimalFormatter implements FormatterInterface
@@ -11,7 +10,7 @@ class MinimalFormatter implements FormatterInterface
     /**
      * @return array<string, string>
      */
-    public function format(MatcherInterface $matcher, ?GeneratorInterface $generator, mixed $value): array
+    public function format(MatcherInterface $matcher): array
     {
         return [
             'pact:matcher:type' => $matcher->getType(),

--- a/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Formatters;
+
+use PhpPact\Consumer\Matcher\Exception\GeneratorNotRequiredException;
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Exception\MatchingExpressionException;
+use PhpPact\Consumer\Matcher\Matchers\AbstractDateTime;
+use PhpPact\Consumer\Matcher\Matchers\ContentType;
+use PhpPact\Consumer\Matcher\Matchers\EachKey;
+use PhpPact\Consumer\Matcher\Matchers\EachValue;
+use PhpPact\Consumer\Matcher\Matchers\MatchingField;
+use PhpPact\Consumer\Matcher\Matchers\NotEmpty;
+use PhpPact\Consumer\Matcher\Matchers\NullValue;
+use PhpPact\Consumer\Matcher\Matchers\Regex;
+use PhpPact\Consumer\Matcher\Matchers\Type;
+use PhpPact\Consumer\Matcher\Model\FormatterInterface;
+use PhpPact\Consumer\Matcher\Model\GeneratorAwareInterface;
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+class PluginFormatter implements FormatterInterface
+{
+    public const MATCHERS_WITHOUT_CONFIG = ['equality', 'type', 'number', 'integer', 'decimal', 'include', 'boolean', 'semver'];
+
+    public function format(MatcherInterface $matcher): string
+    {
+        if ($matcher instanceof GeneratorAwareInterface && null !== $matcher->getGenerator()) {
+            throw new GeneratorNotRequiredException('Generator is not support in plugin');
+        }
+
+        if ($matcher instanceof MatchingField) {
+            return $this->formatMatchingFieldMatcher($matcher);
+        }
+        if ($matcher instanceof NotEmpty) {
+            return $this->formatNotEmptyMatcher($matcher);
+        }
+        if ($matcher instanceof EachKey || $matcher instanceof EachValue) {
+            return $this->formatEachKeyAndEachValueMatchers($matcher);
+        }
+        if ($matcher instanceof NullValue) {
+            return $this->formatMatchersWithoutConfig(new Type(null));
+        }
+
+        if (in_array($matcher->getType(), self::MATCHERS_WITHOUT_CONFIG)) {
+            return $this->formatMatchersWithoutConfig($matcher);
+        }
+        if ($matcher instanceof AbstractDateTime || $matcher instanceof Regex || $matcher instanceof ContentType) {
+            return $this->formatMatchersWithConfig($matcher);
+        }
+
+        throw new MatcherNotSupportedException(sprintf("Matcher '%s' is not supported by plugin", $matcher->getType()));
+    }
+
+    private function formatMatchingFieldMatcher(MatchingField $matcher): string
+    {
+        return sprintf("matching($%s)", $this->normalize($matcher->getFieldName()));
+    }
+
+    private function formatMatchersWithoutConfig(MatcherInterface $matcher): string
+    {
+        $type = $matcher->getType() === 'equality' ? 'equalTo' : $matcher->getType();
+
+        return sprintf('matching(%s, %s)', $type, $this->normalize($matcher->getValue()));
+    }
+
+    private function formatMatchersWithConfig(AbstractDateTime|Regex|ContentType $matcher): string
+    {
+        $config = match (true) {
+            $matcher instanceof AbstractDateTime => $matcher->getFormat(),
+            $matcher instanceof Regex => $matcher->getRegex(),
+            $matcher instanceof ContentType => $matcher->getValue(),
+        };
+
+        return sprintf("matching(%s, %s, %s)", $matcher->getType(), $this->normalize($config), $this->normalize($matcher->getValue()));
+    }
+
+    private function formatNotEmptyMatcher(NotEmpty $matcher): string
+    {
+        return sprintf('notEmpty(%s)', $this->normalize($matcher->getValue()));
+    }
+
+    private function formatEachKeyAndEachValueMatchers(EachKey|EachValue $matcher): string
+    {
+        $rules = $matcher->getRules();
+        if (count($rules) === 0 || count($rules) > 1) {
+            throw new MatchingExpressionException(sprintf("Matcher '%s' only support 1 rule, %d provided", $matcher->getType(), count($rules)));
+        }
+        $rule = reset($rules);
+
+        return sprintf('%s(%s)', $matcher->getType(), $this->format($rule));
+    }
+
+    private function normalize(mixed $value): string
+    {
+        return match (gettype($value)) {
+            'string' => sprintf("'%s'", str_replace("'", "\\'", $value)),
+            'boolean' => $value ? 'true' : 'false',
+            'integer' => (string) $value,
+            'double' => (string) $value,
+            'NULL' => 'null',
+            default => throw new MatchingExpressionException(sprintf("Plugin formatter doesn't support value of type %s", gettype($value))),
+        };
+    }
+}

--- a/src/PhpPact/Consumer/Matcher/Formatters/ValueOptionalFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/ValueOptionalFormatter.php
@@ -3,7 +3,7 @@
 namespace PhpPact\Consumer\Matcher\Formatters;
 
 use PhpPact\Consumer\Matcher\Model\FormatterInterface;
-use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
+use PhpPact\Consumer\Matcher\Model\GeneratorAwareInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 
 class ValueOptionalFormatter implements FormatterInterface
@@ -11,16 +11,18 @@ class ValueOptionalFormatter implements FormatterInterface
     /**
      * @return array<string, mixed>
      */
-    public function format(MatcherInterface $matcher, ?GeneratorInterface $generator, mixed $value): array
+    public function format(MatcherInterface $matcher): array
     {
         $data = [
             'pact:matcher:type' => $matcher->getType(),
         ];
+        $attributes = $matcher->getAttributes();
+        $generator = $matcher instanceof GeneratorAwareInterface ? $matcher->getGenerator() : null;
 
         if ($generator) {
-            return $data + ['pact:generator:type' => $generator->getType()] + $matcher->getAttributes()->merge($generator->getAttributes())->getData();
+            return $data + ['pact:generator:type' => $generator->getType()] + $attributes->merge($generator->getAttributes())->getData();
         }
 
-        return $data + $matcher->getAttributes()->getData() + ['value' => $value];
+        return $data + $attributes->getData() + ['value' => $matcher->getValue()];
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Formatters/ValueRequiredFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/ValueRequiredFormatter.php
@@ -2,7 +2,6 @@
 
 namespace PhpPact\Consumer\Matcher\Formatters;
 
-use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 
 class ValueRequiredFormatter extends ValueOptionalFormatter
@@ -10,8 +9,8 @@ class ValueRequiredFormatter extends ValueOptionalFormatter
     /**
      * @return array<string, mixed>
      */
-    public function format(MatcherInterface $matcher, ?GeneratorInterface $generator, mixed $value): array
+    public function format(MatcherInterface $matcher): array
     {
-        return parent::format($matcher, $generator, $value) + ['value' => $value];
+        return parent::format($matcher) + ['value' => $matcher->getValue()];
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Formatters/XmlContentFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/XmlContentFormatter.php
@@ -3,7 +3,7 @@
 namespace PhpPact\Consumer\Matcher\Formatters;
 
 use PhpPact\Consumer\Matcher\Model\Attributes;
-use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
+use PhpPact\Consumer\Matcher\Model\GeneratorAwareInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 
 class XmlContentFormatter extends ValueOptionalFormatter
@@ -11,10 +11,11 @@ class XmlContentFormatter extends ValueOptionalFormatter
     /**
      * @return array<string, mixed>
      */
-    public function format(MatcherInterface $matcher, ?GeneratorInterface $generator, mixed $value): array
+    public function format(MatcherInterface $matcher): array
     {
+        $generator = $matcher instanceof GeneratorAwareInterface ? $matcher->getGenerator() : null;
         $data = [
-            'content' => $value,
+            'content' => $matcher->getValue(),
             'matcher' => [
                 'pact:matcher:type' => $matcher->getType(),
             ] + $matcher->getAttributes()->merge($generator ? $generator->getAttributes() : new Attributes($matcher))->getData(),

--- a/src/PhpPact/Consumer/Matcher/Formatters/XmlElementFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/XmlElementFormatter.php
@@ -3,7 +3,6 @@
 namespace PhpPact\Consumer\Matcher\Formatters;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
-use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PhpPact\Xml\XmlElement;
 
@@ -12,13 +11,14 @@ class XmlElementFormatter extends ValueOptionalFormatter
     /**
      * @return array<string, mixed>
      */
-    public function format(MatcherInterface $matcher, ?GeneratorInterface $generator, mixed $value): array
+    public function format(MatcherInterface $matcher): array
     {
+        $value = $matcher->getValue();
         if (!$value instanceof XmlElement) {
             throw new InvalidValueException('Value must be xml element');
         }
 
-        $result = parent::format($matcher, $generator, $value);
+        $result = parent::format($matcher);
         $examples = $value->getExamples();
 
         if (null !== $examples) {

--- a/src/PhpPact/Consumer/Matcher/Matchers/AbstractDateTime.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/AbstractDateTime.php
@@ -9,6 +9,11 @@ abstract class AbstractDateTime extends GeneratorAwareMatcher
         parent::__construct();
     }
 
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
     /**
      * @return array<string, string>
      */
@@ -17,7 +22,7 @@ abstract class AbstractDateTime extends GeneratorAwareMatcher
         return ['format' => $this->format];
     }
 
-    protected function getValue(): ?string
+    public function getValue(): ?string
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/AbstractMatcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/AbstractMatcher.php
@@ -4,11 +4,10 @@ namespace PhpPact\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Formatters\ValueOptionalFormatter;
 use PhpPact\Consumer\Matcher\Model\Attributes;
-use PhpPact\Consumer\Matcher\Model\FormatterAwareInterface;
 use PhpPact\Consumer\Matcher\Model\FormatterInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 
-abstract class AbstractMatcher implements MatcherInterface, FormatterAwareInterface
+abstract class AbstractMatcher implements MatcherInterface
 {
     private FormatterInterface $formatter;
 
@@ -28,11 +27,11 @@ abstract class AbstractMatcher implements MatcherInterface, FormatterAwareInterf
     }
 
     /**
-     * @return array<string, mixed>
+     * @return string|array<string, mixed>
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): string|array
     {
-        return $this->getFormatter()->format($this, null, $this->getValue());
+        return $this->getFormatter()->format($this);
     }
 
     public function getAttributes(): Attributes
@@ -44,6 +43,4 @@ abstract class AbstractMatcher implements MatcherInterface, FormatterAwareInterf
      * @return array<string, mixed>
      */
     abstract protected function getAttributesData(): array;
-
-    abstract protected function getValue(): mixed;
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/ArrayContains.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/ArrayContains.php
@@ -28,7 +28,7 @@ class ArrayContains extends AbstractMatcher
     /**
      * @todo Change return type to `null`
      */
-    protected function getValue(): mixed
+    public function getValue(): mixed
     {
         return null;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Boolean.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Boolean.php
@@ -27,7 +27,7 @@ class Boolean extends GeneratorAwareMatcher
         return [];
     }
 
-    protected function getValue(): ?bool
+    public function getValue(): ?bool
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/ContentType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/ContentType.php
@@ -17,7 +17,7 @@ class ContentType extends AbstractMatcher
         return [];
     }
 
-    protected function getValue(): string
+    public function getValue(): string
     {
         return $this->contentType;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Decimal.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Decimal.php
@@ -27,7 +27,7 @@ class Decimal extends GeneratorAwareMatcher
         return [];
     }
 
-    protected function getValue(): ?float
+    public function getValue(): ?float
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/EachKey.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/EachKey.php
@@ -29,7 +29,7 @@ class EachKey extends AbstractMatcher
     /**
      * @return array<mixed>|object
      */
-    protected function getValue(): object|array
+    public function getValue(): object|array
     {
         return $this->value;
     }
@@ -37,5 +37,13 @@ class EachKey extends AbstractMatcher
     public function getType(): string
     {
         return 'eachKey';
+    }
+
+    /**
+     * @return MatcherInterface[]
+     */
+    public function getRules(): array
+    {
+        return $this->rules;
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/EachValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/EachValue.php
@@ -29,7 +29,7 @@ class EachValue extends AbstractMatcher
     /**
      * @return array<mixed>|object
      */
-    protected function getValue(): object|array
+    public function getValue(): object|array
     {
         return $this->value;
     }
@@ -37,5 +37,13 @@ class EachValue extends AbstractMatcher
     public function getType(): string
     {
         return 'eachValue';
+    }
+
+    /**
+     * @return MatcherInterface[]
+     */
+    public function getRules(): array
+    {
+        return $this->rules;
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Equality.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Equality.php
@@ -23,7 +23,7 @@ class Equality extends AbstractMatcher
     /**
      * @return object|array<mixed>|string|float|int|bool|null
      */
-    protected function getValue(): object|array|string|float|int|bool|null
+    public function getValue(): object|array|string|float|int|bool|null
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcher.php
@@ -22,20 +22,18 @@ abstract class GeneratorAwareMatcher extends AbstractMatcher implements Generato
     }
 
     /**
-     * @return array<string, mixed>
+     * @return string|array<string, mixed>
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): string|array
     {
         if (null === $this->getValue()) {
             if (!$this->generator) {
                 throw new GeneratorRequiredException(sprintf("Generator is required for matcher '%s' when example value is not set", $this->getType()));
             }
-
-            return $this->getFormatter()->format($this, $this->generator, null);
         } elseif ($this->generator) {
             throw new GeneratorNotRequiredException(sprintf("Generator '%s' is not required for matcher '%s' when example value is set", $this->generator->getType(), $this->getType()));
         }
 
-        return $this->getFormatter()->format($this, $this->generator, $this->getValue());
+        return $this->getFormatter()->format($this);
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Includes.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Includes.php
@@ -17,7 +17,7 @@ class Includes extends AbstractMatcher
         return [];
     }
 
-    protected function getValue(): string
+    public function getValue(): string
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Integer.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Integer.php
@@ -27,7 +27,7 @@ class Integer extends GeneratorAwareMatcher
         return [];
     }
 
-    protected function getValue(): ?int
+    public function getValue(): ?int
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/MatchingField.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MatchingField.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+
+class MatchingField extends AbstractMatcher
+{
+    public const MATCHER_NOT_SUPPORTED_EXCEPTION_MESSAGE = 'MatchingField matcher only work with plugin';
+
+    public function __construct(private string $fieldName)
+    {
+    }
+
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+
+    public function getValue(): mixed
+    {
+        throw new MatcherNotSupportedException(self::MATCHER_NOT_SUPPORTED_EXCEPTION_MESSAGE);
+    }
+
+    public function getType(): string
+    {
+        throw new MatcherNotSupportedException(self::MATCHER_NOT_SUPPORTED_EXCEPTION_MESSAGE);
+    }
+
+    protected function getAttributesData(): array
+    {
+        throw new MatcherNotSupportedException(self::MATCHER_NOT_SUPPORTED_EXCEPTION_MESSAGE);
+    }
+
+    public function jsonSerialize(): string
+    {
+        $result = parent::jsonSerialize();
+        if (is_array($result)) {
+            throw new MatcherNotSupportedException(self::MATCHER_NOT_SUPPORTED_EXCEPTION_MESSAGE);
+        }
+
+        return $result;
+    }
+}

--- a/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
@@ -29,7 +29,7 @@ class MaxType extends AbstractMatcher
     /**
      * @return array<int, mixed>
      */
-    protected function getValue(): array
+    public function getValue(): array
     {
         return array_values($this->values);
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/MinMaxType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MinMaxType.php
@@ -33,7 +33,7 @@ class MinMaxType extends AbstractMatcher
     /**
      * @return array<int, mixed>
      */
-    protected function getValue(): array
+    public function getValue(): array
     {
         return array_values($this->values);
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
@@ -18,14 +18,6 @@ class MinType extends AbstractMatcher
         parent::__construct();
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->getFormatter()->format($this, null, array_values($this->values));
-    }
-
     public function getType(): string
     {
         return 'type';
@@ -42,7 +34,7 @@ class MinType extends AbstractMatcher
     /**
      * @return array<int, mixed>
      */
-    protected function getValue(): array
+    public function getValue(): array
     {
         return array_values($this->values);
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
@@ -23,7 +23,7 @@ class NotEmpty extends AbstractMatcher
     /**
      * @return object|array<mixed>|string|float|int|bool
      */
-    protected function getValue(): object|array|string|float|int|bool
+    public function getValue(): object|array|string|float|int|bool
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/NullValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/NullValue.php
@@ -27,7 +27,7 @@ class NullValue extends AbstractMatcher
     /**
      * @todo Change return type to `null`
      */
-    protected function getValue(): mixed
+    public function getValue(): mixed
     {
         return null;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Number.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Number.php
@@ -27,7 +27,7 @@ class Number extends GeneratorAwareMatcher
         return [];
     }
 
-    protected function getValue(): int|float|null
+    public function getValue(): int|float|null
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Regex.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Regex.php
@@ -24,9 +24,9 @@ class Regex extends GeneratorAwareMatcher
     }
 
     /**
-     * @return array<string, mixed>
+     * @return string|array<string, mixed>
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): string|array
     {
         if (null !== $this->values) {
             $this->validateRegex();
@@ -56,7 +56,7 @@ class Regex extends GeneratorAwareMatcher
     /**
      * @return string|string[]|null
      */
-    protected function getValue(): string|array|null
+    public function getValue(): string|array|null
     {
         return $this->values;
     }
@@ -67,5 +67,10 @@ class Regex extends GeneratorAwareMatcher
     protected function getAttributesData(): array
     {
         return ['regex' => $this->regex];
+    }
+
+    public function getRegex(): string
+    {
+        return $this->regex;
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Semver.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Semver.php
@@ -27,7 +27,7 @@ class Semver extends GeneratorAwareMatcher
         return [];
     }
 
-    protected function getValue(): ?string
+    public function getValue(): ?string
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/StatusCode.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/StatusCode.php
@@ -47,7 +47,7 @@ class StatusCode extends GeneratorAwareMatcher
         return ['status' => $this->status];
     }
 
-    protected function getValue(): ?int
+    public function getValue(): ?int
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/StringValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/StringValue.php
@@ -26,11 +26,11 @@ class StringValue extends GeneratorAwareMatcher
     }
 
     /**
-     * @return array<string, mixed>
+     * @return string|array<string, mixed>
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): string|array
     {
-        return $this->getFormatter()->format($this, $this->getGenerator(), $this->getValue());
+        return $this->getFormatter()->format($this);
     }
 
     protected function getAttributesData(): array
@@ -38,7 +38,7 @@ class StringValue extends GeneratorAwareMatcher
         return [];
     }
 
-    protected function getValue(): string
+    public function getValue(): string
     {
         return $this->value ?? self::DEFAULT_VALUE;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Type.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Type.php
@@ -23,7 +23,7 @@ class Type extends AbstractMatcher
     /**
      * @return object|array<mixed>|string|float|int|bool|null
      */
-    protected function getValue(): object|array|string|float|int|bool|null
+    public function getValue(): object|array|string|float|int|bool|null
     {
         return $this->value;
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Values.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Values.php
@@ -23,7 +23,7 @@ class Values extends AbstractMatcher
     /**
      * @return array<mixed>
      */
-    protected function getValue(): array
+    public function getValue(): array
     {
         return $this->values;
     }

--- a/src/PhpPact/Consumer/Matcher/Model/FormatterInterface.php
+++ b/src/PhpPact/Consumer/Matcher/Model/FormatterInterface.php
@@ -5,7 +5,7 @@ namespace PhpPact\Consumer\Matcher\Model;
 interface FormatterInterface
 {
     /**
-     * @return array<string, mixed>
+     * @return string|array<string, mixed>
      */
-    public function format(MatcherInterface $matcher, ?GeneratorInterface $generator, mixed $value): array;
+    public function format(MatcherInterface $matcher): string|array;
 }

--- a/src/PhpPact/Consumer/Matcher/Model/MatcherInterface.php
+++ b/src/PhpPact/Consumer/Matcher/Model/MatcherInterface.php
@@ -4,9 +4,11 @@ namespace PhpPact\Consumer\Matcher\Model;
 
 use JsonSerializable;
 
-interface MatcherInterface extends JsonSerializable
+interface MatcherInterface extends JsonSerializable, FormatterAwareInterface
 {
     public function getType(): string;
 
     public function getAttributes(): Attributes;
+
+    public function getValue(): mixed;
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/PluginFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/PluginFormatterTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Formatters;
+
+use PhpPact\Consumer\Matcher\Exception\GeneratorNotRequiredException;
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Exception\MatchingExpressionException;
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
+use PhpPact\Consumer\Matcher\Generators\RandomString;
+use PhpPact\Consumer\Matcher\Matchers\ArrayContains;
+use PhpPact\Consumer\Matcher\Matchers\Boolean;
+use PhpPact\Consumer\Matcher\Matchers\ContentType;
+use PhpPact\Consumer\Matcher\Matchers\Date;
+use PhpPact\Consumer\Matcher\Matchers\DateTime;
+use PhpPact\Consumer\Matcher\Matchers\Decimal;
+use PhpPact\Consumer\Matcher\Matchers\EachKey;
+use PhpPact\Consumer\Matcher\Matchers\EachValue;
+use PhpPact\Consumer\Matcher\Matchers\Equality;
+use PhpPact\Consumer\Matcher\Matchers\Includes;
+use PhpPact\Consumer\Matcher\Matchers\Integer;
+use PhpPact\Consumer\Matcher\Matchers\MatchingField;
+use PhpPact\Consumer\Matcher\Matchers\MaxType;
+use PhpPact\Consumer\Matcher\Matchers\MinMaxType;
+use PhpPact\Consumer\Matcher\Matchers\MinType;
+use PhpPact\Consumer\Matcher\Matchers\NotEmpty;
+use PhpPact\Consumer\Matcher\Matchers\NullValue;
+use PhpPact\Consumer\Matcher\Matchers\Number;
+use PhpPact\Consumer\Matcher\Matchers\Regex;
+use PhpPact\Consumer\Matcher\Matchers\Semver;
+use PhpPact\Consumer\Matcher\Matchers\StatusCode;
+use PhpPact\Consumer\Matcher\Matchers\StringValue;
+use PhpPact\Consumer\Matcher\Matchers\Time;
+use PhpPact\Consumer\Matcher\Matchers\Type;
+use PhpPact\Consumer\Matcher\Matchers\Values;
+use PhpPact\Consumer\Matcher\Model\FormatterInterface;
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+use PHPUnit\Framework\TestCase;
+
+class PluginFormatterTest extends TestCase
+{
+    private FormatterInterface $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new PluginFormatter();
+    }
+
+    public function testFormatWithGenerator(): void
+    {
+        $this->expectException(GeneratorNotRequiredException::class);
+        $this->expectExceptionMessage('Generator is not support in plugin');
+        $matcher = new StringValue('example value');
+        $matcher->setGenerator(new RandomString());
+        $this->formatter->format($matcher);
+    }
+
+    /**
+     * @dataProvider invalidRulesProvider
+     */
+    public function testInvalidRules(EachKey|EachValue $matcher): void
+    {
+        $this->expectException(MatchingExpressionException::class);
+        $this->expectExceptionMessage(sprintf("Matcher '%s' only support 1 rule, %d provided", $matcher->getType(), count($matcher->getRules())));
+        $this->formatter->format($matcher);
+    }
+
+    public function invalidRulesProvider(): array
+    {
+        return [
+            [new EachKey(["doesn't matter"], [])],
+            [new EachValue(["doesn't matter"], [])],
+            [new EachKey(["doesn't matter"], [new Type(1), new Type(2)])],
+            [new EachValue(["doesn't matter"], [new Type(1), new Type(2), new Type(3)])],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidValueProvider
+     */
+    public function testInvalidValue(MatcherInterface $matcher, string $type): void
+    {
+        $this->expectException(MatchingExpressionException::class);
+        $this->expectExceptionMessage(sprintf("Plugin formatter doesn't support value of type %s", $type));
+        $this->formatter->format($matcher);
+    }
+
+    public function invalidValueProvider(): array
+    {
+        return [
+            [new Type((object)['key' => 'value']), 'object'],
+            [new Type(['key' => 'value']), 'array'],
+            [new MinType(['Example value'], 1), 'array'],
+            [new MaxType(['Example value'], 2), 'array'],
+            [new MinMaxType(['Example value'], 1, 2), 'array'],
+        ];
+    }
+
+    /**
+     * @dataProvider notSupportedMatcherProvider
+     */
+    public function testNotSupportedMatcher(MatcherInterface $matcher): void
+    {
+        $this->expectException(MatcherNotSupportedException::class);
+        $this->expectExceptionMessage(sprintf("Matcher '%s' is not supported by plugin", $matcher->getType()));
+        $this->formatter->format($matcher);
+    }
+
+    public function notSupportedMatcherProvider(): array
+    {
+        return [
+            [new Values([1, 2, 3])],
+            [new ArrayContains([new Equality(1)])],
+            [new StatusCode('clientError', 405)],
+        ];
+    }
+
+    /**
+     * @dataProvider matcherProvider
+     */
+    public function testFormat(MatcherInterface $matcher, string $json): void
+    {
+        $this->assertSame($json, json_encode($this->formatter->format($matcher)));
+    }
+
+    public function matcherProvider(): array
+    {
+        return [
+            [new MatchingField('product'), '"matching($\'product\')"'],
+            [new NotEmpty('test'), '"notEmpty(\'test\')"'],
+            [new EachKey(["doesn't matter"], [new Regex('\$(\.\w+)+', '$.test.one')]), '"eachKey(matching(regex, \'\\\\$(\\\\.\\\\w+)+\', \'$.test.one\'))"'],
+            [new EachValue(["doesn't matter"], [new Type(100)]), '"eachValue(matching(type, 100))"'],
+            [new Equality('Example value'), '"matching(equalTo, \'Example value\')"'],
+            [new Type('Example value'), '"matching(type, \'Example value\')"'],
+            [new Number(100.09), '"matching(number, 100.09)"'],
+            [new Integer(100), '"matching(integer, 100)"'],
+            [new Decimal(100.01), '"matching(decimal, 100.01)"'],
+            [new Includes('testing'), '"matching(include, \'testing\')"'],
+            [new Boolean(true), '"matching(boolean, true)"'],
+            [new Semver('1.0.0'), '"matching(semver, \'1.0.0\')"'],
+            [new DateTime('yyyy-MM-dd HH:mm:ssZZZZZ', '2020-05-21 16:44:32+10:00'), '"matching(datetime, \'yyyy-MM-dd HH:mm:ssZZZZZ\', \'2020-05-21 16:44:32+10:00\')"'],
+            [new Date('yyyy-MM-dd', '2012-04-12'), '"matching(date, \'yyyy-MM-dd\', \'2012-04-12\')"'],
+            [new Time('HH:mm', '22:04'), '"matching(time, \'HH:mm\', \'22:04\')"'],
+            [new Regex('\\w{3}\\d+', 'abc123'), '"matching(regex, \'\\\\w{3}\\\\d+\', \'abc123\')"'],
+            [new ContentType('application/xml'), '"matching(contentType, \'application\/xml\', \'application\/xml\')"'],
+            [new NullValue(), '"matching(type, null)"'],
+        ];
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Formatters/ValueOptionalFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/ValueOptionalFormatterTest.php
@@ -17,9 +17,10 @@ class ValueOptionalFormatterTest extends TestCase
      */
     public function testFormat(bool $hasGenerator, ?string $value, array $result): void
     {
-        $matcher = new Date('yyyy-MM-dd', 5);
+        $matcher = new Date('yyyy-MM-dd', $value);
         $generator = $hasGenerator ? new RandomString(10) : null;
+        $matcher->setGenerator($generator);
         $formatter = new ValueOptionalFormatter();
-        $this->assertSame($result, $formatter->format($matcher, $generator, $value));
+        $this->assertSame($result, $formatter->format($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/ValueRequiredFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/ValueRequiredFormatterTest.php
@@ -17,9 +17,10 @@ class ValueRequiredFormatterTest extends TestCase
      */
     public function testFormat(bool $hasGenerator, ?string $value, array $result): void
     {
-        $matcher = new Date('yyyy-MM-dd', 5);
+        $matcher = new Date('yyyy-MM-dd', $value);
         $generator = $hasGenerator ? new RandomString(10) : null;
+        $matcher->setGenerator($generator);
         $formatter = new ValueRequiredFormatter();
-        $this->assertSame($result, $formatter->format($matcher, $generator, $value));
+        $this->assertSame($result, $formatter->format($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/XmlContentFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/XmlContentFormatterTest.php
@@ -15,9 +15,10 @@ class XmlContentFormatterTest extends TestCase
      */
     public function testFormat(bool $hasGenerator, ?string $value, array $result): void
     {
-        $matcher = new Date('yyyy-MM-dd', 5);
+        $matcher = new Date('yyyy-MM-dd', $value);
         $generator = $hasGenerator ? new RandomString(10) : null;
+        $matcher->setGenerator($generator);
         $formatter = new XmlContentFormatter();
-        $this->assertSame($result, $formatter->format($matcher, $generator, $value));
+        $this->assertSame($result, $formatter->format($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/XmlElementFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/XmlElementFormatterTest.php
@@ -3,10 +3,8 @@
 namespace PhpPactTest\Consumer\Matcher\Formatters;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
-use PhpPact\Consumer\Matcher\Formatters\XmlContentFormatter;
 use PhpPact\Consumer\Matcher\Formatters\XmlElementFormatter;
 use PhpPact\Consumer\Matcher\Generators\RandomString;
-use PhpPact\Consumer\Matcher\Matchers\Date;
 use PhpPact\Consumer\Matcher\Matchers\StringValue;
 use PhpPact\Consumer\Matcher\Matchers\Type;
 use PhpPact\Xml\XmlElement;
@@ -18,8 +16,10 @@ class XmlElementFormatterTest extends TestCase
     {
         $this->expectException(InvalidValueException::class);
         $this->expectExceptionMessage('Value must be xml element');
+        $matcher = new StringValue('example value');
+        $matcher->setGenerator(new RandomString());
         $formatter = new XmlElementFormatter();
-        $formatter->format(new StringValue(), new RandomString(), 'example value');
+        $formatter->format($matcher);
     }
 
     /**
@@ -34,6 +34,6 @@ class XmlElementFormatterTest extends TestCase
         );
         $matcher = new Type($value);
         $formatter = new XmlElementFormatter();
-        $this->assertSame(json_encode($result), json_encode($formatter->format($matcher, null, $value)));
+        $this->assertSame(json_encode($result), json_encode($formatter->format($matcher)));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -4,6 +4,8 @@ namespace PhpPactTest\Consumer\Matcher;
 
 use PhpPact\Consumer\Matcher\Exception\MatcherException;
 use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Formatters\MinimalFormatter;
+use PhpPact\Consumer\Matcher\Formatters\ValueOptionalFormatter;
 use PhpPact\Consumer\Matcher\Generators\MockServerURL;
 use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Generators\RandomHexadecimal;
@@ -21,6 +23,7 @@ use PhpPact\Consumer\Matcher\Matchers\EachValue;
 use PhpPact\Consumer\Matcher\Matchers\Equality;
 use PhpPact\Consumer\Matcher\Matchers\Includes;
 use PhpPact\Consumer\Matcher\Matchers\Integer;
+use PhpPact\Consumer\Matcher\Matchers\MatchingField;
 use PhpPact\Consumer\Matcher\Matchers\MaxType;
 use PhpPact\Consumer\Matcher\Matchers\MinMaxType;
 use PhpPact\Consumer\Matcher\Matchers\MinType;
@@ -298,6 +301,7 @@ class MatcherTest extends TestCase
     public function testFromProviderState(): void
     {
         $uuid = $this->matcher->uuid();
+        $this->assertInstanceOf(Regex::class, $uuid);
         $this->assertSame(Uuid::class, get_class($uuid->getGenerator()));
         $this->assertSame($uuid, $this->matcher->fromProviderState($uuid, '${id}'));
         $this->assertSame(ProviderState::class, get_class($uuid->getGenerator()));
@@ -392,5 +396,19 @@ class MatcherTest extends TestCase
         } else {
             $this->assertNull($url->getGenerator());
         }
+    }
+
+    public function testMatchingField(): void
+    {
+        $this->assertInstanceOf(MatchingField::class, $this->matcher->matchingField('address'));
+    }
+
+    public function testWithFormatter(): void
+    {
+        $uuid = $this->matcher->uuid();
+        $this->assertInstanceOf(ValueOptionalFormatter::class, $uuid->getFormatter());
+        $matcher = new Matcher($formatter = new MinimalFormatter());
+        $uuid = $matcher->uuid();
+        $this->assertSame($formatter, $uuid->getFormatter());
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MatchingFieldTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MatchingFieldTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Matchers;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Formatters\MinimalFormatter;
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
+use PhpPact\Consumer\Matcher\Formatters\ValueOptionalFormatter;
+use PhpPact\Consumer\Matcher\Formatters\ValueRequiredFormatter;
+use PhpPact\Consumer\Matcher\Formatters\XmlContentFormatter;
+use PhpPact\Consumer\Matcher\Formatters\XmlElementFormatter;
+use PhpPact\Consumer\Matcher\Matchers\MatchingField;
+use PHPUnit\Framework\TestCase;
+
+class MatchingFieldTest extends TestCase
+{
+    /**
+     * @testWith ["person",                "\"matching($'person')\""]
+     *           ["probably doesn't work", "\"matching($'probably doesn\\\\'t work')\""]
+     */
+    public function testSerialize(string $fieldName, string $json): void
+    {
+        $matcher = new MatchingField($fieldName);
+        $matcher->setFormatter(new PluginFormatter());
+        $this->assertSame(
+            $json,
+            json_encode($matcher)
+        );
+    }
+
+    /**
+     * @dataProvider formatterProvider
+     */
+    public function testNotSupportedFormatter(string $formatterClassName): void
+    {
+        $this->expectException(MatcherNotSupportedException::class);
+        $this->expectExceptionMessage('MatchingField matcher only work with plugin');
+        $matcher = new MatchingField('person');
+        $matcher->setFormatter(new $formatterClassName());
+        json_encode($matcher);
+    }
+
+    public function formatterProvider(): array
+    {
+        return [
+            [MinimalFormatter::class],
+            [ValueOptionalFormatter::class],
+            [ValueRequiredFormatter::class],
+            [XmlContentFormatter::class],
+            [XmlElementFormatter::class],
+        ];
+    }
+}


### PR DESCRIPTION
* Add `MatchingField` matcher
* Add `PluginFormatter`
* Allow customize formatter for `Matcher` helper class
* Apply it to plugin examples e.g. Replace `"matching(type,'Name')"` by `$matcher->like('Name')`
* Syntax and supported matchers of `matching` expression: https://github.com/pact-foundation/pact-plugins/blob/main/docs/matching-rule-definition-expressions.md
* All matchers: https://github.com/pact-foundation/pact-specification/tree/version-4#supported-matching-rules