### PR TITLE
deps: Update ffi library to 0.4.13

### DIFF
--- a/compatibility-suite/tests/Context/V3/Http/ProviderContext.php
+++ b/compatibility-suite/tests/Context/V3/Http/ProviderContext.php
@@ -28,9 +28,9 @@ final class ProviderContext implements Context
     public function aPactFileForInteractionIsToBeVerifiedWithTheFollowingProviderStatesDefined(int $id, TableNode $table): void
     {
         $this->pactWriter->write($id, $this->pactPath);
-        $pact = json_decode(file_get_contents($this->pactPath), true);
+        $pact = json_decode(file_get_contents($this->pactPath));
         $rows = $table->getHash();
-        $pact['interactions'][0]['providerStates'] = array_map(fn (array $row): array => ['name' => $row['State Name'], 'params' => json_decode($row['Parameters'] ?? '{}', true)], $rows);
+        $pact->interactions[0]->providerStates = array_map(fn (array $row): array => ['name' => $row['State Name'], 'params' => json_decode($row['Parameters'] ?? '{}', true)], $rows);
         file_put_contents($this->pactPath, json_encode($pact));
         $this->providerVerifier->addSource($this->pactPath);
     }

--- a/composer.json
+++ b/composer.json
@@ -103,12 +103,12 @@
     "extra": {
         "downloads": {
             "pact-ffi-headers": {
-                "version": "0.4.11",
+                "version": "0.4.13",
                 "url": "https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v{$version}/pact.h",
                 "path": "bin/pact-ffi-headers/pact.h"
             },
             "pact-ffi-lib": {
-                "version": "0.4.11",
+                "version": "0.4.13",
                 "variables": {
                     "{$prefix}": "PHP_OS_FAMILY === 'Windows' ? 'pact_ffi' : 'libpact_ffi'",
                     "{$os}": "PHP_OS === 'Darwin' ? 'osx' : strtolower(PHP_OS_FAMILY)",

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -29,21 +29,21 @@
             ]
           },
           "query": {
-            "$.pages": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "regex",
-                  "regex": "\\d+"
-                }
-              ]
-            },
-            "$['locales[]']": {
+            "locales[]": {
               "combine": "AND",
               "matchers": [
                 {
                   "match": "regex",
                   "regex": "^[a-z]{2}-[A-Z]{2}$"
+                }
+              ]
+            },
+            "pages": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "\\d+"
                 }
               ]
             }
@@ -591,9 +591,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.11",
+      "ffi": "0.4.13",
       "mockserver": "1.2.4",
-      "models": "1.1.12"
+      "models": "1.1.16"
     },
     "pactSpecification": {
       "version": "4.0"


### PR DESCRIPTION
* Pact core internally change matching rule keys from `$.pages` to `pages`, `$['locales[]']` to `locales[]` in `0.4.12`
* Upgrade to `0.4.13` to fix issue related to `'locales[]` is not supported properly
* `"matchingRules": {"body": []}` now throw an error. It must be ``"matchingRules": {"body": {}}``