### PR TITLE
ci: Reduce test running time by setting PACT_DO_NOT_TRACK

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ BUILD_TEST_TASK_TEMPLATE: &BUILD_TEST_TASK_TEMPLATE
 linux_arm64_task:  
   env:
     COMPOSER_ALLOW_SUPERUSER: 1
+    PACT_DO_NOT_TRACK: true
     matrix:
       - VERSION: 8.2
       - VERSION: 8.1
@@ -37,6 +38,7 @@ linux_arm64_task:
 macos_arm64_task:
 # https://www.markhesketh.com/switching-multiple-php-versions-on-macos/
   env:
+    PACT_DO_NOT_TRACK: true
     matrix:
       - VERSION: 8.2
       - VERSION: 8.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,3 +90,5 @@ jobs:
 
       - name: Composer test
         run: composer test
+        env:
+          PACT_DO_NOT_TRACK: true

--- a/.github/workflows/compatibility-suite.yml
+++ b/.github/workflows/compatibility-suite.yml
@@ -3,7 +3,7 @@ name: Pact-PHP Compatibility Suite
 on: [push, pull_request]
 
 env:
-  pact_do_not_track: true
+  PACT_DO_NOT_TRACK: true
 
 jobs:
   v1:


### PR DESCRIPTION
* On local, where everything are set up, it reduce tests running time, from `6.549` seconds to `4.242` (need to set manually `PACT_DO_NOT_TRACK=true phpunit`)
* On github, it's harder to see the difference