### PR TITLE
chore: Only show logs if configured

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,6 +23,7 @@ linux_arm64_task:
   env:
     COMPOSER_ALLOW_SUPERUSER: 1
     PACT_DO_NOT_TRACK: true
+    PACT_LOGLEVEL: debug
     matrix:
       - VERSION: 8.2
       - VERSION: 8.1
@@ -39,6 +40,7 @@ macos_arm64_task:
 # https://www.markhesketh.com/switching-multiple-php-versions-on-macos/
   env:
     PACT_DO_NOT_TRACK: true
+    PACT_LOGLEVEL: debug
     matrix:
       - VERSION: 8.2
       - VERSION: 8.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,3 +92,4 @@ jobs:
         run: composer test
         env:
           PACT_DO_NOT_TRACK: true
+          PACT_LOGLEVEL: debug

--- a/example/binary/consumer/phpunit.xml
+++ b/example/binary/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/binary/provider/phpunit.xml
+++ b/example/binary/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/csv/consumer/phpunit.xml
+++ b/example/csv/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/csv/provider/phpunit.xml
+++ b/example/csv/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/generators/consumer/phpunit.xml
+++ b/example/generators/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/generators/provider/phpunit.xml
+++ b/example/generators/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/json/consumer/phpunit.xml
+++ b/example/json/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/json/provider/phpunit.xml
+++ b/example/json/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/matchers/consumer/phpunit.xml
+++ b/example/matchers/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/matchers/provider/phpunit.xml
+++ b/example/matchers/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/message/consumer/phpunit.xml
+++ b/example/message/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/message/consumer/src/ExampleMessageConsumer.php
+++ b/example/message/consumer/src/ExampleMessageConsumer.php
@@ -7,13 +7,15 @@ class ExampleMessageConsumer
     public function processMessage(string $message): void
     {
         $obj = \json_decode($message);
-        print " [x] Processing \n";
-        print " [x] Contents: \n";
-        print ' [x]     Text: ' . \print_r($obj->contents->text, true) . "\n";
-        print ' [x]     Number: ' . \print_r($obj->contents->number, true) . "\n";
-        print " [x] Metadata: \n";
-        print ' [x]     Queue: ' . \print_r($obj->metadata->queue, true) . "\n";
-        print ' [x]     Routing Key: ' . \print_r($obj->metadata->routing_key, true) . "\n";
-        print " [x] Processed \n";
+        if (\getenv('PACT_LOGLEVEL')) {
+            print " [x] Processing \n";
+            print " [x] Contents: \n";
+            print ' [x]     Text: ' . \print_r($obj->contents->text, true) . "\n";
+            print ' [x]     Number: ' . \print_r($obj->contents->number, true) . "\n";
+            print " [x] Metadata: \n";
+            print ' [x]     Queue: ' . \print_r($obj->metadata->queue, true) . "\n";
+            print ' [x]     Routing Key: ' . \print_r($obj->metadata->routing_key, true) . "\n";
+            print " [x] Processed \n";
+        }
     }
 }

--- a/example/message/provider/phpunit.xml
+++ b/example/message/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/multipart/consumer/phpunit.xml
+++ b/example/multipart/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/multipart/provider/phpunit.xml
+++ b/example/multipart/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/protobuf-async-message/consumer/phpunit.xml
+++ b/example/protobuf-async-message/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/protobuf-async-message/provider/phpunit.xml
+++ b/example/protobuf-async-message/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/protobuf-sync-message/consumer/phpunit.xml
+++ b/example/protobuf-sync-message/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/protobuf-sync-message/provider/phpunit.xml
+++ b/example/protobuf-sync-message/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/xml/consumer/phpunit.xml
+++ b/example/xml/consumer/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/example/xml/provider/phpunit.xml
+++ b/example/xml/provider/phpunit.xml
@@ -5,7 +5,4 @@
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <env name="PACT_LOGLEVEL" value="DEBUG"/>
-    </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -80,6 +80,5 @@
   <php>
     <env name="PACT_CONSUMER_NAME" value="someConsumer"/>
     <env name="PACT_PROVIDER_NAME" value="someProvider"/>
-    <env name="PACT_LOGLEVEL" value="DEBUG"/>
   </php>
 </phpunit>

--- a/tests/PhpPact/Helper/AbstractProcess.php
+++ b/tests/PhpPact/Helper/AbstractProcess.php
@@ -19,9 +19,12 @@ abstract class AbstractProcess
         if ($this->process->isRunning()) {
             return;
         }
-        $this->process->start(function (string $type, string $buffer): void {
-            echo "\n$type > $buffer";
-        });
+        if (\getenv('PACT_LOGLEVEL')) {
+            $callback = function (string $type, string $buffer): void {
+                echo "\n$type > $buffer";
+            };
+        }
+        $this->process->start($callback ?? null);
         $this->process->waitUntil(function (): bool {
             $fp = @fsockopen('127.0.0.1', $this->getPort());
             $isOpen = \is_resource($fp);


### PR DESCRIPTION
Depend on #451

For #419

* Don't show logs by default (when running `phpunit`)
* FFI: show logs based on value of `PACT_LOGLEVEL=trace|debug|info|warn|error`
* Provider processes: show logs if `PACT_LOGLEVEL` is set to any value (because I don't know which level is the best to start showing these logs)