### PR TITLE
chore: Deprecate Values matcher

### DIFF
--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -84,16 +84,6 @@ class MatchersTest extends TestCase
                 ]),
                 'notEmpty' => $this->matcher->notEmpty(['1','2','3']),
                 'semver' => $this->matcher->semver('10.0.0-alpha4'),
-                'values' => $this->matcher->values([
-                    'a',
-                    'bb',
-                    'ccc',
-                ]),
-                'valuesWithKeys' => $this->matcher->values([
-                    'a' => 'a',
-                    'b' => 'bb',
-                    'c' => 'ccc',
-                ]),
                 'contentType' => $this->matcher->contentType('text/html'),
                 'eachKey' => $this->matcher->eachKey(
                     ['page 3' => 'example text'],
@@ -179,16 +169,6 @@ class MatchersTest extends TestCase
             ],
             'notEmpty' => ['1', '2', '3'],
             'semver' => '10.0.0-alpha4',
-            'values' => [
-                'a',
-                'bb',
-                'ccc',
-            ],
-            'valuesWithKeys' => [
-                'a' => 'a',
-                'b' => 'bb',
-                'c' => 'ccc',
-            ],
             'contentType' => 'text/html',
             'eachKey' => [
                 'page 3' => 'example text',

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -141,17 +141,7 @@
             "timeISO8601": "T22:44:30.652Z",
             "timestampRFC3339": "Mon, 31 Oct 2016 15:21:41 -0400",
             "url": "http://localhost:8080/users/1234/posts/latest",
-            "uuid": "52c9585e-f345-4964-aa28-a45c64b2b2eb",
-            "values": [
-              "a",
-              "bb",
-              "ccc"
-            ],
-            "valuesWithKeys": {
-              "a": "a",
-              "b": "bb",
-              "c": "ccc"
-            }
+            "uuid": "52c9585e-f345-4964-aa28-a45c64b2b2eb"
           },
           "contentType": "application/json",
           "encoded": false
@@ -550,22 +540,6 @@
                 {
                   "match": "regex",
                   "regex": "^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$"
-                }
-              ]
-            },
-            "$.values": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "values"
-                }
-              ]
-            },
-            "$.valuesWithKeys": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "values"
                 }
               ]
             }

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -53,18 +53,6 @@ $app->get('/matchers', function (Request $request, Response $response) {
         ],
         'notEmpty' => [111],
         'semver' => '0.27.1-beta2',
-        'values' => [ // Missing ending values are OK, additional values are NOT OK
-            'a',
-            'bb',
-            //'ccc',
-            //'dddd',
-        ],
-        'valuesWithKeys' => [ // Missing keys are OK, additional keys are NOT OK
-            //'a' => 'a',
-            'b' => 'bb',
-            //'c' => 'ccc',
-            //'d' => 'dddd',
-        ],
         'contentType' =>
             <<<HTML
             <!DOCTYPE html>

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -412,6 +412,8 @@ class Matcher
     /**
      * Match the values in a map, ignoring the keys
      *
+     * @deprecated use eachKey or eachValue
+     *
      * @param array<mixed> $values
      */
     public function values(array $values): MatcherInterface

--- a/src/PhpPact/Consumer/Matcher/Matchers/Values.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Values.php
@@ -4,6 +4,8 @@ namespace PhpPact\Consumer\Matcher\Matchers;
 
 /**
  * Match the values in a map, ignoring the keys
+ *
+ * @deprecated use EachKey or EachValue
  */
 class Values extends AbstractMatcher
 {


### PR DESCRIPTION
`Values` matcher has weird behaviors. This PR follow the same approach from `pact-js`: `Values` matcher is deprecated in favour of `EachKey` and `EachValue` matchers


See https://github.com/pact-foundation/pact-reference/pull/365