### PR TITLE
test(compatibility-suite): Fix compatibility suite v1 hang

### DIFF
--- a/compatibility-suite/tests/Service/PactBroker.php
+++ b/compatibility-suite/tests/Service/PactBroker.php
@@ -26,7 +26,7 @@ final class PactBroker implements PactBrokerInterface
 
     public function start(): void
     {
-        exec('docker run --rm --publish 9292:9292 --detach --env PACT_BROKER_DATABASE_URL=sqlite:////tmp/pact_broker.sqlite3 --name pact-broker pactfoundation/pact-broker:latest');
+        exec('docker run --rm --publish 9292:9292 --detach --env PACT_BROKER_DATABASE_URL=sqlite:////tmp/pact_broker.sqlite3 --name pact-broker pactfoundation/pact-broker:2.117.1-pactbroker2.109.1');
         while (true) {
             try {
                 $response = $this->client->get('http://localhost:9292/diagnostic/status/heartbeat', ['http_errors' => false]);


### PR DESCRIPTION
I think recent update to pact broker `2.115` or `2.116` cause pact broker to hang. Move to `2.114` a month ago solve the issue