### PR TITLE
add output json flag to can-i-deploy function

### DIFF
--- a/src/PhpPact/Standalone/Broker/Broker.php
+++ b/src/PhpPact/Standalone/Broker/Broker.php
@@ -28,7 +28,8 @@ class Broker
                 [
                     'can-i-deploy',
                     '--pacticipant=\'' . $this->config->getPacticipant().'\'',
-                    '--version=' . $this->config->getVersion()
+                    '--version=' . $this->config->getVersion(),
+                    '--output=json',
                 ],
                 $this->getArguments()
             )


### PR DESCRIPTION
Added `--output=json` to the arguments of the `canIDeploy` function. Without it it would throw an error every time trying to decode the output of the runner.