### PR TITLE
chore: add example for header matchers

### DIFF
--- a/example/matchers/consumer/src/Service/HttpClientService.php
+++ b/example/matchers/consumer/src/Service/HttpClientService.php
@@ -20,7 +20,7 @@ class HttpClientService
     public function sendRequest(): ResponseInterface
     {
         return $this->httpClient->get("{$this->baseUri}/matchers", [
-            'headers' => ['Accept' => 'application/json'],
+            'headers' => ['Accept' => 'application/json', 'Theme' => 'light'],
             'query' => 'pages=2&pages=3&locales[]=fr-BE&locales[]=ru-RU',
             'http_errors' => false,
         ]);

--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -34,12 +34,14 @@ class MatchersTest extends TestCase
                     json_encode($this->matcher->regex(['en-US', 'en-AU'], '^[a-z]{2}-[A-Z]{2}$')),
                 ],
             ])
-            ->addHeader('Accept', 'application/json');
+            ->addHeader('Accept', 'application/json')
+            ->addHeader('Theme', $this->matcher->regex('dark', 'light|dark')); // arrayContains, eachKey, eachValue matchers are not working with headers
 
         $response = new ProviderResponse();
         $response
             ->setStatus($this->matcher->statusCode(HttpStatus::SERVER_ERROR, 512))
             ->addHeader('Content-Type', 'application/json')
+            ->addHeader('X-Powered-By', $this->matcher->string('PHP'))
             ->setBody([
                 'like' => $this->matcher->like(['key' => 'value']),
                 'likeNull' => $this->matcher->like(null),

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -15,10 +15,23 @@
         "headers": {
           "Accept": [
             "application/json"
+          ],
+          "Theme": [
+            "dark"
           ]
         },
         "matchingRules": {
-          "header": {},
+          "header": {
+            "Theme": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "light|dark"
+                }
+              ]
+            }
+          },
           "path": {
             "combine": "AND",
             "matchers": [
@@ -149,6 +162,9 @@
         "headers": {
           "Content-Type": [
             "application/json"
+          ],
+          "X-Powered-By": [
+            "PHP"
           ]
         },
         "matchingRules": {
@@ -544,7 +560,16 @@
               ]
             }
           },
-          "header": {},
+          "header": {
+            "X-Powered-By": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          },
           "status": {
             "$": {
               "combine": "AND",

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -79,7 +79,12 @@ $app->get('/matchers', function (Request $request, Response $response) {
 
     return $response
         ->withHeader('Content-Type', 'application/json')
-        ->withStatus(503);
+        ->withStatus(503)
+        ->withHeader('X-Powered-By', [
+            'PHP',
+            'Nginx',
+            'Slim',
+        ]);
 });
 
 $app->post('/pact-change-state', function (Request $request, Response $response) {


### PR DESCRIPTION
* Add example about using matcher on request's header
* Add example about using matcher on response's header
* Add a note about arrayContains, eachKey, eachValue matchers that they are not working with headers