### PR TITLE
chore(deps): update to pact-ruby-standalone-v2.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
     "extra": {
         "downloads": {
             "pact-ruby-standalone": {
-                "version": "2.0.3",
+                "version": "2.4.0",
                 "variables": {
                     "{$os}": "PHP_OS_FAMILY === 'Windows' ? 'windows' : (PHP_OS === 'Darwin' ? 'osx' : 'linux')",
                     "{$architecture}": "strtolower(php_uname('m')) === 'arm64' || strtolower(php_uname('m')) === 'aarch64' ? '-arm64' : (strtolower(php_uname('m')) === 'x86' && PHP_OS_FAMILY === 'Windows' ? '-x86' : '-x86_64')",


### PR DESCRIPTION
Updates Ruby 3.3.0 (from Ruby 3.2.2) & OpenSSL 3.2.0 (from OpenSSL 1.1.1)

Drops requirement for bash 

See full changelog v2.0.1 -> v2.4.0

https://github.com/pact-foundation/pact-ruby-standalone/blob/master/CHANGELOG.md