### PR TITLE
deps: Upgrade PHP to 8.3 and drop 8.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
-        php: [ '8.0', '8.1', '8.2' ]
+        php: [ '8.1', '8.2', '8.3' ]
         dependencies: [ 'lowest', 'locked' ]
     timeout-minutes: 5
 
@@ -60,7 +60,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          extensions: ${{ matrix.operating-system == 'windows-latest' && matrix.php == '8.2' && 'sockets, curl, zip, ffi' || 'sockets, curl, zip, ffi, grpc' }}
+          extensions: ${{ matrix.operating-system == 'windows-latest' && contains('["8.2","8.3"]', matrix.php) && 'sockets, curl, zip, ffi' || 'sockets, curl, zip, ffi, grpc' }}
           php-version: ${{ matrix.php }}
           coverage: none
           ini-values: ${{ matrix.operating-system == 'windows-latest' && 'opcache.enable=0 opcache.enable_cli=0' || '' }}
@@ -70,14 +70,12 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install gRPC Extension (for PHP 8.2 on Windows)
+      - name: Install gRPC Extension (for PHP 8.2 & 8.3 on Windows)
         run: |
           cd C:\tools\php
-          Invoke-WebRequest -Uri https://phpdev.toolsforresearch.com/php-8.2.7-nts-Win32-vs16-x64-grpc-protobuf.zip -OutFile php8.2.zip
-          unzip php8.2.zip ext/php_grpc.dll
-          rm php8.2.zip
+          Invoke-WebRequest -Uri https://github.com/tienvx/build-php-grpc-extension/releases/download/builds/grpc_windows-2022_php-${{ matrix.php }}.dll -OutFile ext\php_grpc.dll
           echo "extension=php_grpc.dll" >> php.ini
-        if: ${{ matrix.operating-system == 'windows-latest' && matrix.php == '8.2' }}
+        if: ${{ matrix.operating-system == 'windows-latest' && contains('["8.2","8.3"]', matrix.php) }}
         shell: pwsh
 
       - name: Composer install

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "ext-json": "*",
         "composer/semver": "^1.4.0|^3.2.0",
         "symfony/process": "^4.4|^5.4|^6.0",


### PR DESCRIPTION
* Upgrade PHP to 8.3
* Drop PHP 8.0
* I was able to compile grpc extension for PHP 8.2 & 8.3 on Windows, so I switch to that file
* Tests on PHP 8.2 and 8.3 on Windows are easier to fail than before with this error `Script phpunit --debug handling the test event returned with error code -1073741819`, I'm not sure why