### PR TITLE
deps: Update spiral/roadrunner-grpc

### DIFF
--- a/example/protobuf-sync-message/provider/composer.json
+++ b/example/protobuf-sync-message/provider/composer.json
@@ -2,7 +2,7 @@
     "name": "pact-foundation/example-protobuf-sync-message-provider",
     "require": {
         "grpc/grpc": "^1.57",
-        "spiral/roadrunner-grpc": "^2.0",
+        "spiral/roadrunner-grpc": "^3.2",
         "tienvx/composer-downloads-plugin": "^1.2"
     },
     "require-dev": {


### PR DESCRIPTION
Since PHP has been upgraded to 8.1, `spiral/roadrunner-grpc` can be updated to `^3.2`. This lib is only for testing, so updating isn't a breaking change