### PR TITLE
deps: Update roadrunner binary

### DIFF
--- a/example/protobuf-sync-message/provider/composer.json
+++ b/example/protobuf-sync-message/provider/composer.json
@@ -14,7 +14,7 @@
     "extra": {
         "downloads": {
             "rr": {
-                "version": "2023.3.9",
+                "version": "2023.3.10",
                 "variables": {
                     "{$os}": "strtolower(PHP_OS_FAMILY)",
                     "{$architecture}": "in_array(php_uname('m'), ['x86_64', 'AMD64']) ? 'amd64' : 'arm64'",


### PR DESCRIPTION
Update roadrunner binary in the hope of fixing the error `Script phpunit --no-coverage handling the test event returned with error code -1073741819` but it couldn't