### PR TITLE
feat: Add Selector class

### DIFF
--- a/UPGRADE-10.0.md
+++ b/UPGRADE-10.0.md
@@ -98,11 +98,9 @@ This migrates from a CLI driven process for the Pact Framework, to an FFI proces
            // we need to set the provider branch here for PactBrokerWithDynamicConfiguration
            // as $publishOptions->setProviderBranch value set above isn't used.
            $broker->setProviderBranch(exec('git rev-parse --abbrev-ref HEAD'));
-           // NOTE - this needs to be a boolean, not a string value, otherwise it doesn't pass through the selector.
-           // Maybe a pact-php or pact-rust thing
            $selectors = (new ConsumerVersionSelectors())
-               ->addSelector(' { "mainBranch" : true } ')
-               ->addSelector(' { "deployedOrReleased" : true } ');
+               ->addSelector(new Selector(mainBranch: true))
+               ->addSelector(new Selector(deployedOrReleased: true));
            $broker->setConsumerVersionSelectors($selectors);
            $broker->setEnablePending(true);
            $broker->setIncludeWipPactSince('2020-01-30');

--- a/src/PhpPact/Standalone/ProviderVerifier/Exception/InvalidSelectorValueException.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Exception/InvalidSelectorValueException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier\Exception;
+
+class InvalidSelectorValueException extends ProviderVerifierException
+{
+}

--- a/src/PhpPact/Standalone/ProviderVerifier/Exception/ProviderVerifierException.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Exception/ProviderVerifierException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier\Exception;
+
+use PhpPact\Exception\BaseException;
+
+class ProviderVerifierException extends BaseException
+{
+}

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectors.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectors.php
@@ -4,6 +4,8 @@ namespace PhpPact\Standalone\ProviderVerifier\Model;
 
 use Countable;
 use Iterator;
+use PhpPact\Standalone\ProviderVerifier\Model\Selector\SelectorInterface;
+use JsonException;
 
 /**
  * @implements Iterator<int, string>
@@ -16,16 +18,32 @@ class ConsumerVersionSelectors implements Iterator, Countable
     private array $selectors = [];
 
     /**
-     * @param array<int, string> $selectors
+     * @param array<int, string|SelectorInterface> $selectors
      */
     public function __construct(array $selectors = [])
     {
-        $this->selectors = $selectors;
+        $this->setSelectors($selectors);
     }
 
-    public function addSelector(string $selector): self
+    /**
+     * @param array<int, string|SelectorInterface> $selectors
+     */
+    public function setSelectors(array $selectors): self
     {
-        $this->selectors[] = $selector;
+        $this->selectors = [];
+        foreach ($selectors as $selector) {
+            $this->addSelector($selector);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @throws JsonException
+     */
+    public function addSelector(string|SelectorInterface $selector): self
+    {
+        $this->selectors[] = $selector instanceof SelectorInterface ? json_encode($selector, JSON_THROW_ON_ERROR) : $selector;
 
         return $this;
     }

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/Selector/Selector.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/Selector/Selector.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier\Model\Selector;
+
+use PhpPact\Standalone\ProviderVerifier\Exception\InvalidSelectorValueException;
+
+class Selector implements SelectorInterface
+{
+    public function __construct(
+        private ?bool $mainBranch = null,
+        private ?string $branch = null,
+        private ?string $fallbackBranch = null,
+        private ?bool $matchingBranch = null,
+        private ?string $tag = null,
+        private ?string $fallbackTag = null,
+        private ?bool $deployed = null,
+        private ?bool $released = null,
+        private ?bool $deployedOrReleased = null,
+        private ?string $environment = null,
+        private ?bool $latest = null,
+        private ?string $consumer = null,
+    ) {
+        foreach (get_object_vars($this) as $key => $value) {
+            if (false === $value && 'latest' !== $key) {
+                throw new InvalidSelectorValueException(sprintf("Value 'false' is not allowed for selector %s", $key));
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string|bool>
+     */
+    public function jsonSerialize(): array
+    {
+        return array_filter(get_object_vars($this), fn (null|string|bool $value) => null !== $value);
+    }
+}

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/Selector/SelectorInterface.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/Selector/SelectorInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier\Model\Selector;
+
+use JsonSerializable;
+
+interface SelectorInterface extends JsonSerializable
+{
+}

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectorsTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectorsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpPactTest\Standalone\ProviderVerifier\Model;
+
+use PhpPact\Standalone\ProviderVerifier\Model\ConsumerVersionSelectors;
+use PhpPact\Standalone\ProviderVerifier\Model\Selector\Selector;
+use PHPUnit\Framework\TestCase;
+
+class ConsumerVersionSelectorsTest extends TestCase
+{
+    /**
+     * @dataProvider selectorsProvider
+     */
+    public function testJsonSerialize(array $selectors, array $result): void
+    {
+        static::assertSame($result, iterator_to_array(new ConsumerVersionSelectors($selectors)));
+    }
+
+    /**
+     * @return array<int, array<mixed>>
+     */
+    public static function selectorsProvider(): array
+    {
+        return [
+            [['{ "mainBranch": true }', '{ "deployedOrReleased": true }'], ['{ "mainBranch": true }', '{ "deployedOrReleased": true }']],
+            [[new Selector(matchingBranch: true), '{ "mainBranch": true }', new Selector(deployedOrReleased: true)], ['{"matchingBranch":true}', '{ "mainBranch": true }', '{"deployedOrReleased":true}']],
+            [[new Selector(mainBranch: true)], ['{"mainBranch":true}']],
+        ];
+    }
+}

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/Selector/SelectorTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/Selector/SelectorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace PhpPactTest\Standalone\ProviderVerifier\Model\Selector;
+
+use PhpPact\Standalone\ProviderVerifier\Exception\InvalidSelectorValueException;
+use PhpPact\Standalone\ProviderVerifier\Model\Selector\Selector;
+use PHPUnit\Framework\TestCase;
+
+class SelectorTest extends TestCase
+{
+    /**
+     * @testWith ["mainBranch"]
+     *           ["matchingBranch"]
+     *           ["deployed"]
+     *           ["released"]
+     *           ["deployedOrReleased"]
+     */
+    public function testInvalidSelectorValue(string $key): void
+    {
+        $values = [$key => false];
+        $this->expectException(InvalidSelectorValueException::class);
+        $this->expectExceptionMessage(sprintf("Value 'false' is not allowed for selector %s", $key));
+        new Selector(...$values);
+    }
+
+    /**
+     * @testWith [{ "mainBranch": true }, "{\"mainBranch\":true}"]
+     *           [{ "branch": "feat-xxx" }, "{\"branch\":\"feat-xxx\"}"]
+     *           [{ "deployedOrReleased": true }, "{\"deployedOrReleased\":true}"]
+     *           [{ "matchingBranch": true }, "{\"matchingBranch\":true}"]
+     *           [{ "mainBranch": null, "branch": "fix-yyy", "fallbackBranch": null, "matchingBranch": null, "tag": null, "fallbackTag": null, "deployed": null, "released": null, "deployedOrReleased": null, "environment": null, "latest": null, "consumer": "my-consumer" }, "{\"branch\":\"fix-yyy\",\"consumer\":\"my-consumer\"}"]
+     */
+    public function testJsonSerialize(array $values, string $json): void
+    {
+        static::assertSame($json, json_encode(new Selector(...$values)));
+    }
+}


### PR DESCRIPTION
Instead of asking user to work with json directly, user only need to initiate the object of `Selector` class using PHP 8 named arguments feature. This class help validate and convert selector to json.

Related issue: https://github.com/pact-foundation/pact-php/issues/206
Docs: https://docs.pact.io/pact_broker/advanced_topics/consumer_version_selectors