### PR TITLE
deps: Require ffi extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-ffi": "*",
         "ext-json": "*",
         "composer/semver": "^1.4.0|^3.2.0",
         "symfony/process": "^4.4|^5.4|^6.0",


### PR DESCRIPTION
Not sure when or why it's removed. It's still there in my [original code](https://github.com/tienvx/pact-php/blob/rust-ffi/composer.json#L22)