### PR TITLE
deps: Update ffi library to 0.4.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,12 +109,12 @@
     "extra": {
         "downloads": {
             "pact-ffi-headers": {
-                "version": "0.4.14",
+                "version": "0.4.16",
                 "url": "https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v{$version}/pact.h",
                 "path": "bin/pact-ffi-headers/pact.h"
             },
             "pact-ffi-lib": {
-                "version": "0.4.14",
+                "version": "0.4.16",
                 "variables": {
                     "{$prefix}": "PHP_OS_FAMILY === 'Windows' ? 'pact_ffi' : 'libpact_ffi'",
                     "{$os}": "PHP_OS === 'Darwin' ? 'osx' : strtolower(PHP_OS_FAMILY)",


### PR DESCRIPTION
Update ffi library to `0.4.16` in the hope of fixing the error `Script phpunit --no-coverage handling the test event returned with error code -1073741819`, but it couldn't