### PR TITLE
refactor: Add FFI\Lib to prevent using FFI\Client directly

### DIFF
--- a/src/PhpPact/FFI/Lib.php
+++ b/src/PhpPact/FFI/Lib.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\FFI;
+
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+
+class Lib implements LibInterface
+{
+    public function __construct(private ClientInterface $client)
+    {
+    }
+
+    public function getInteractionPartId(InteractionPart $part): int
+    {
+        return match ($part) {
+            InteractionPart::REQUEST => $this->client->get('InteractionPart_Request'),
+            InteractionPart::RESPONSE => $this->client->get('InteractionPart_Response'),
+        };
+    }
+}

--- a/src/PhpPact/FFI/LibInterface.php
+++ b/src/PhpPact/FFI/LibInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpPact\FFI;
+
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+
+interface LibInterface
+{
+    public function getInteractionPartId(InteractionPart $part): int;
+}

--- a/tests/PhpPact/FFI/LibTest.php
+++ b/tests/PhpPact/FFI/LibTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpPactTest\FFI;
+
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\FFI\Lib;
+use PhpPact\FFI\LibInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LibTest extends TestCase
+{
+    private ClientInterface|MockObject $client;
+    private LibInterface $lib;
+
+    public function setUp(): void
+    {
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->lib = new Lib($this->client);
+    }
+
+    public function testGetInteractionPartId(): void
+    {
+        $requestPartId = 1;
+        $responsePartId = 2;
+        $this->client
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->willReturnMap([
+                ['InteractionPart_Request', $requestPartId],
+                ['InteractionPart_Response', $responsePartId],
+            ]);
+
+        $this->assertSame($requestPartId, $this->lib->getInteractionPartId(InteractionPart::REQUEST));
+        $this->assertSame($responsePartId, $this->lib->getInteractionPartId(InteractionPart::RESPONSE));
+    }
+}


### PR DESCRIPTION
```
$this->lib->getInteractionPartId(InteractionPart::REQUEST);
```

will replace

```
$this->ffi->get('InteractionPart_Request');
```

Please suggest better name if `Lib` is not good one.

Depend on https://github.com/pact-foundation/pact-php/pull/483