### PR TITLE
ci: Tune network

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
     name: PHP ${{ matrix.php }} on ${{ matrix.operating-system }} with ${{ matrix.dependencies }} dependencies
 
     steps:
+      - name: Tune GitHub-hosted runner network
+        uses: smorimoto/tune-github-hosted-runner-network@v1
+
       - uses: actions/checkout@v3
         name: Checkout repository
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,10 @@ jobs:
     name: PHP ${{ matrix.php }} on ${{ matrix.operating-system }} with ${{ matrix.dependencies }} dependencies
 
     steps:
-      - name: Tune GitHub-hosted runner network
-        uses: smorimoto/tune-github-hosted-runner-network@v1
+      - name: Tune Windows Network
+        if: ${{ runner.os == 'Windows' }}
+        shell: pwsh
+        run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
 
       - uses: actions/checkout@v3
         name: Checkout repository


### PR DESCRIPTION
Try to fix flaky network by using https://github.com/smorimoto/tune-github-hosted-runner-network.

* Hope it help fixing bellow errors (happen mostly on Windows).
* There 2 errors still happen, but I reported [them](https://github.com/pactflow/pact-protobuf-plugin/issues/created_by/tienvx):
  * `Script phpunit --no-coverage handling the test event returned with error code -1073741819`
  * `ERROR ThreadId(01) pact_ffi::plugins: Could not load plugin - Plugin process did not output the correct startup message in 60 seconds: timed out waiting on channel`

```
Verifying a pact between jsonConsumer and jsonProvider

  A get request to /hello/{name} (0s loading, 5s 389ms verification)
      Request Failed - error sending request for url (http://localhost:50807/hello/Bob): operation timed out

  A get request to /goodbye/{name} (0s loading, 5s 49ms verification)
     Given Get Goodbye
      Request Failed - One or more of the setup state change handlers has failed
```


```

Verifying a pact between binaryConsumer and binaryProvider

  A get request to /image.jpg (0s loading, 5s 31ms verification)
     Given Image file image.jpg exists
      Request Failed - error sending request for url (http://localhost:49597/image.jpg): operation timed out

```

```
 2024-02-17T07:39:45.104502Z DEBUG ThreadId(01) verify_interaction{interaction="Person message sent"}: pact_verifier::provider_client: State change request failed with error error sending request for url (http://localhost:60194/pact-change-state): error trying to connect: tcp connect error: No connection could be made because the target machine actively refused it. (os error 10061)

Verifying a pact between protobufAsyncMessageConsumer and protobufAsyncMessageProvider

  Person message sent (0s loading, 3s 218ms verification)
     Given A person with fixed id exists
      Request Failed - One or more of the teardown state change handlers has failed


```


```
There was 1 error:

1) GeneratorsProvider\Tests\PactVerifyTest::testPactVerifyConsumer
Symfony\Component\Process\Exception\ProcessTimedOutException: The process "'php' '-S' '127.0.0.1:49292' '-t' '/Users/runner/work/pact-php/pact-php/example/generators/provider/tests/../public/'" exceeded the timeout of 60 seconds.

/Users/runner/work/pact-php/pact-php/vendor/symfony/process/Process.php:1156
/Users/runner/work/pact-php/pact-php/vendor/symfony/process/Process.php:464
/Users/runner/work/pact-php/pact-php/tests/PhpPact/Helper/AbstractProcess.php:36
/Users/runner/work/pact-php/pact-php/example/generators/provider/tests/PactVerifyTest.php:18
```


```

Verifying a pact between protobufAsyncMessageConsumer and protobufAsyncMessageProvider

  Person message sent (0s loading, 861ms verification)
     Given A person with fixed id exists
      Request Failed - error sending request for url (http://localhost:51222/): connection error: An existing connection was forcibly closed by the remote host. (os error 10054)

```

