### PR TITLE
refactor: Add body drivers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,11 +34,12 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^9|^10.1|^11",
+        "phpunit/phpunit": "^10.1|^11",
         "guzzlehttp/guzzle": "^7.8",
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",
         "ramsey/uuid": "^4.7",
+        "mikey179/vfsstream": "^1.6.7",
         "pact-foundation/example-protobuf-sync-message-provider": "@dev"
     },
     "autoload": {

--- a/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriver.php
+++ b/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriver.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Body;
+
+use FFI;
+use FFI\CData;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Exception\InteractionBodyNotAddedException;
+use PhpPact\Consumer\Exception\PartNotAddedException;
+use PhpPact\Consumer\Model\Body\Binary;
+use PhpPact\Consumer\Model\Body\Multipart;
+use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\FFI\ClientInterface;
+
+class InteractionBodyDriver implements InteractionBodyDriverInterface
+{
+    public function __construct(protected ClientInterface $client)
+    {
+    }
+
+    public function registerBody(Interaction $interaction, InteractionPart $interactionPart): void
+    {
+        $body = $interaction->getBody($interactionPart);
+        $partId = match ($interactionPart) {
+            InteractionPart::REQUEST => $this->client->get('InteractionPart_Request'),
+            InteractionPart::RESPONSE => $this->client->get('InteractionPart_Response'),
+        };
+        switch (true) {
+            case $body instanceof Binary:
+                $data = $body->getData();
+                $success = $this->client->call('pactffi_with_binary_file', $interaction->getHandle(), $partId, $body->getContentType(), $data->getValue(), $data->getSize());
+                break;
+
+            case $body instanceof Text:
+                $success = $this->client->call('pactffi_with_body', $interaction->getHandle(), $partId, $body->getContentType(), $body->getContents());
+                break;
+
+            case $body instanceof Multipart:
+                foreach ($body->getParts() as $part) {
+                    $result = $this->client->call('pactffi_with_multipart_file_v2', $interaction->getHandle(), $partId, $part->getContentType(), $part->getPath(), $part->getName(), $body->getBoundary());
+                    if (isset($result->failed) && $result->failed instanceof CData) {
+                        throw new PartNotAddedException(FFI::string($result->failed));
+                    }
+                }
+                $success = true;
+                break;
+
+            default:
+                break;
+        };
+        if (isset($success) && false === $success) {
+            throw new InteractionBodyNotAddedException();
+        }
+    }
+}

--- a/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriverInterface.php
+++ b/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriverInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Body;
+
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Model\Interaction;
+
+interface InteractionBodyDriverInterface
+{
+    public function registerBody(Interaction $interaction, InteractionPart $part): void;
+}

--- a/src/PhpPact/Consumer/Driver/Body/MessageBodyDriver.php
+++ b/src/PhpPact/Consumer/Driver/Body/MessageBodyDriver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Body;
+
+use PhpPact\Consumer\Exception\MessageContentsNotAddedException;
+use PhpPact\Consumer\Model\Body\Binary;
+use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\Message;
+use PhpPact\FFI\ClientInterface;
+
+class MessageBodyDriver implements MessageBodyDriverInterface
+{
+    public function __construct(protected ClientInterface $client)
+    {
+    }
+
+    public function registerBody(Message $message): void
+    {
+        $body = $message->getContents();
+        $partId = $this->client->get('InteractionPart_Request');
+        switch (true) {
+            case $body instanceof Binary:
+                $data = $body->getData();
+                $success = $this->client->call('pactffi_with_binary_file', $message->getHandle(), $partId, $body->getContentType(), $data->getValue(), $data->getSize());
+                break;
+
+            case $body instanceof Text:
+                $success = $this->client->call('pactffi_with_body', $message->getHandle(), $partId, $body->getContentType(), $body->getContents());
+                break;
+
+            default:
+                break;
+        };
+        if (isset($success) && false === $success) {
+            throw new MessageContentsNotAddedException();
+        }
+    }
+}

--- a/src/PhpPact/Consumer/Driver/Body/MessageBodyDriverInterface.php
+++ b/src/PhpPact/Consumer/Driver/Body/MessageBodyDriverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Body;
+
+use PhpPact\Consumer\Model\Message;
+
+interface MessageBodyDriverInterface
+{
+    public function registerBody(Message $message): void;
+}

--- a/src/PhpPact/Plugin/Driver/Body/PluginBodyDriver.php
+++ b/src/PhpPact/Plugin/Driver/Body/PluginBodyDriver.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpPact\Plugin\Driver\Body;
+
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Exception\BodyNotSupportedException;
+use PhpPact\Consumer\Model\Body\Binary;
+use PhpPact\Consumer\Model\Body\Multipart;
+use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\Consumer\Model\Message;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Plugin\Exception\PluginBodyNotAddedException;
+
+class PluginBodyDriver implements PluginBodyDriverInterface
+{
+    public function __construct(protected ClientInterface $client)
+    {
+    }
+
+    public function registerBody(Interaction|Message $interaction, InteractionPart $interactionPart): void
+    {
+        $body = $interaction instanceof Message ? $interaction->getContents() : $interaction->getBody($interactionPart);
+        $partId = $interaction instanceof Message ? $this->client->get('InteractionPart_Request') : match ($interactionPart) {
+            InteractionPart::REQUEST => $this->client->get('InteractionPart_Request'),
+            InteractionPart::RESPONSE => $this->client->get('InteractionPart_Response'),
+        };
+        switch (true) {
+            case $body instanceof Binary:
+                throw new BodyNotSupportedException('Plugin does not support binary body');
+
+            case $body instanceof Text:
+                json_decode($body->getContents());
+                if (json_last_error() !== JSON_ERROR_NONE) {
+                    throw new BodyNotSupportedException('Plugin only support json body contents');
+                }
+                $error = $this->client->call('pactffi_interaction_contents', $interaction->getHandle(), $partId, $body->getContentType(), $body->getContents());
+                if ($error) {
+                    throw new PluginBodyNotAddedException($error);
+                }
+                break;
+
+            case $body instanceof Multipart:
+                throw new BodyNotSupportedException('Plugin does not support multipart body');
+
+            default:
+                break;
+        };
+    }
+}

--- a/src/PhpPact/Plugin/Driver/Body/PluginBodyDriverInterface.php
+++ b/src/PhpPact/Plugin/Driver/Body/PluginBodyDriverInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PhpPact\Plugin\Driver\Body;
+
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\Consumer\Model\Message;
+
+interface PluginBodyDriverInterface
+{
+    public function registerBody(Interaction|Message $interaction, InteractionPart $part): void;
+}

--- a/src/PhpPact/Plugins/Csv/Driver/Body/CsvBodyDriver.php
+++ b/src/PhpPact/Plugins/Csv/Driver/Body/CsvBodyDriver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\Plugins\Csv\Driver\Body;
+
+use PhpPact\Consumer\Driver\Body\InteractionBodyDriverInterface;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\Plugin\Driver\Body\PluginBodyDriverInterface;
+
+class CsvBodyDriver implements InteractionBodyDriverInterface
+{
+    public function __construct(private PluginBodyDriverInterface $pluginBodyDriver)
+    {
+    }
+
+    public function registerBody(Interaction $interaction, InteractionPart $part): void
+    {
+        $this->pluginBodyDriver->registerBody($interaction, $part);
+    }
+}

--- a/src/PhpPact/Plugins/Protobuf/Driver/Body/ProtobufMessageBodyDriver.php
+++ b/src/PhpPact/Plugins/Protobuf/Driver/Body/ProtobufMessageBodyDriver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\Plugins\Protobuf\Driver\Body;
+
+use PhpPact\Consumer\Driver\Body\MessageBodyDriverInterface;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Model\Message;
+use PhpPact\Plugin\Driver\Body\PluginBodyDriverInterface;
+
+class ProtobufMessageBodyDriver implements MessageBodyDriverInterface
+{
+    public function __construct(private PluginBodyDriverInterface $pluginBodyDriver)
+    {
+    }
+
+    public function registerBody(Message $message): void
+    {
+        $this->pluginBodyDriver->registerBody($message, InteractionPart::REQUEST);
+    }
+}

--- a/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace PhpPactTest\Consumer\Driver\Body;
+
+use FFI;
+use FFI\CData;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PhpPact\Consumer\Driver\Body\InteractionBodyDriver;
+use PhpPact\Consumer\Driver\Body\InteractionBodyDriverInterface;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Exception\InteractionBodyNotAddedException;
+use PhpPact\Consumer\Exception\PartNotAddedException;
+use PhpPact\Consumer\Model\Body\Binary;
+use PhpPact\Consumer\Model\Body\Multipart;
+use PhpPact\Consumer\Model\Body\Part;
+use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\ConsumerRequest;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\Consumer\Model\ProviderResponse;
+use PhpPact\FFI\ClientInterface;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class InteractionBodyDriverTest extends TestCase
+{
+    private InteractionBodyDriverInterface $driver;
+    private ClientInterface|MockObject $client;
+    private Interaction $interaction;
+    private int $requestPartId = 1;
+    private int $responsePartId = 2;
+    private int $interactionHandle = 123;
+    private Binary $binary;
+    private Text $text;
+    private Multipart $multipart;
+    private array $parts;
+    private string $boundary = 'abcde12345';
+    private CData $failed;
+    private string $message = 'error';
+    private vfsStreamDirectory $root;
+
+    public function setUp(): void
+    {
+        $this->root = vfsStream::setup();
+        file_put_contents($this->root->url() . '/id.txt', 'text');
+        file_put_contents($this->root->url() . '/address.json', 'json');
+        file_put_contents($this->root->url() . '/image.png', 'image');
+
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->client
+            ->expects($this->once())
+            ->method('get')
+            ->willReturnMap([
+                ['InteractionPart_Request', $this->requestPartId],
+                ['InteractionPart_Response', $this->responsePartId],
+            ]);
+        $this->driver = new InteractionBodyDriver($this->client);
+        $this->interaction = new Interaction();
+        $this->interaction->setHandle($this->interactionHandle);
+        $this->interaction->setRequest(new ConsumerRequest());
+        $this->interaction->setResponse(new ProviderResponse());
+        $this->binary = new Binary(__DIR__ . '/../../../../_resources/image.jpg', 'image/jpeg');
+        $this->text = new Text('example', 'text/plain');
+        $this->parts = [
+            new Part($this->root->url() . '/id.txt', 'id', 'text/plain'),
+            new Part($this->root->url() . '/address.json', 'address', 'application/json'),
+            new Part($this->root->url() . '/image.png', 'profileImage', 'image/png'),
+        ];
+        $this->multipart = new Multipart($this->parts, $this->boundary);
+        $this->failed = FFI::new('char[5]');
+        FFI::memcpy($this->failed, $this->message, 5);
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testRequestBinaryBody(bool $success): void
+    {
+        $data = $this->binary->getData();
+        $this->interaction->getRequest()->setBody($this->binary);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_with_binary_file', $this->interactionHandle, $this->requestPartId, $this->binary->getContentType(), $data->getValue(), $data->getSize())
+            ->willReturn($success);
+        if (!$success) {
+            $this->expectException(InteractionBodyNotAddedException::class);
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::REQUEST);
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testResponseBinaryBody(bool $success): void
+    {
+        $data = $this->binary->getData();
+        $this->interaction->getResponse()->setBody($this->binary);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_with_binary_file', $this->interactionHandle, $this->responsePartId, $this->binary->getContentType(), $data->getValue(), $data->getSize())
+            ->willReturn($success);
+        if (!$success) {
+            $this->expectException(InteractionBodyNotAddedException::class);
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::RESPONSE);
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testRequestTextBody(bool $success): void
+    {
+        $this->interaction->getRequest()->setBody($this->text);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_with_body', $this->interactionHandle, $this->requestPartId, $this->text->getContentType(), $this->text->getContents())
+            ->willReturn($success);
+        if (!$success) {
+            $this->expectException(InteractionBodyNotAddedException::class);
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::REQUEST);
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testResponseTextBody(bool $success): void
+    {
+        $this->interaction->getResponse()->setBody($this->text);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_with_body', $this->interactionHandle, $this->responsePartId, $this->text->getContentType(), $this->text->getContents())
+            ->willReturn($success);
+        if (!$success) {
+            $this->expectException(InteractionBodyNotAddedException::class);
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::RESPONSE);
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testRequestMultipartBody(bool $success): void
+    {
+        $this->interaction->getRequest()->setBody($this->multipart);
+        $this->client
+            ->expects($this->exactly(count($this->parts)))
+            ->method('call')
+            ->willReturnCallback(
+                fn (string $method, int $interactionId, int $partId, string $contentType, string $path, string $name, string $boundary) =>
+                match([$method, $interactionId, $partId, $contentType, $path, $name, $boundary]) {
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) [],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) [],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) ($success ? [] : ['failed' => $this->failed]),
+                }
+            );
+        if (!$success) {
+            $this->expectException(PartNotAddedException::class);
+            $this->expectExceptionMessage($this->message);
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::REQUEST);
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testResponseMultipartBody(bool $success): void
+    {
+        $this->interaction->getResponse()->setBody($this->multipart);
+        $this->client
+            ->expects($this->exactly(count($this->parts)))
+            ->method('call')
+            ->willReturnCallback(
+                fn (string $method, int $interactionId, int $partId, string $contentType, string $path, string $name, string $boundary) =>
+                match([$method, $interactionId, $partId, $contentType, $path, $name, $boundary]) {
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) [],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) [],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) ($success ? [] : ['failed' => $this->failed]),
+                }
+            );
+        if (!$success) {
+            $this->expectException(PartNotAddedException::class);
+            $this->expectExceptionMessage($this->message);
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::RESPONSE);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testEmptyBody(InteractionPart $part): void
+    {
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->driver->registerBody($this->interaction, $part);
+    }
+}

--- a/tests/PhpPact/Consumer/Driver/Body/MessageBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/MessageBodyDriverTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace PhpPactTest\Consumer\Driver\Body;
+
+use PhpPact\Consumer\Driver\Body\MessageBodyDriver;
+use PhpPact\Consumer\Driver\Body\MessageBodyDriverInterface;
+use PhpPact\Consumer\Exception\MessageContentsNotAddedException;
+use PhpPact\Consumer\Model\Body\Binary;
+use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\Message;
+use PhpPact\FFI\ClientInterface;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MessageBodyDriverTest extends TestCase
+{
+    private MessageBodyDriverInterface $driver;
+    private ClientInterface|MockObject $client;
+    private Message $message;
+    private int $requestPartId = 1;
+    private int $messageId = 123;
+    private Binary $binary;
+    private Text $text;
+
+    public function setUp(): void
+    {
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->driver = new MessageBodyDriver($this->client);
+        $this->client
+            ->expects($this->once())
+            ->method('get')
+            ->with('InteractionPart_Request')
+            ->willReturn($this->requestPartId);
+        $this->message = new Message();
+        $this->message->setHandle($this->messageId);
+        $this->binary = new Binary(__DIR__ . '/../../../../_resources/image.jpg', 'image/jpeg');
+        $this->text = new Text('example', 'text/plain');
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testMessageBinaryBody(bool $success): void
+    {
+        $data = $this->binary->getData();
+        $this->message->setContents($this->binary);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_with_binary_file', $this->messageId, $this->requestPartId, $this->binary->getContentType(), $data->getValue(), $data->getSize())
+            ->willReturn($success);
+        if (!$success) {
+            $this->expectException(MessageContentsNotAddedException::class);
+        }
+        $this->driver->registerBody($this->message);
+    }
+
+    #[TestWith([true])]
+    #[TestWith([false])]
+    public function testMessageTextBody(bool $success): void
+    {
+        $this->message->setContents($this->text);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_with_body', $this->messageId, $this->requestPartId, $this->text->getContentType(), $this->text->getContents())
+            ->willReturn($success);
+        if (!$success) {
+            $this->expectException(MessageContentsNotAddedException::class);
+        }
+        $this->driver->registerBody($this->message);
+    }
+
+    public function testEmptyBody(): void
+    {
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->driver->registerBody($this->message);
+    }
+}

--- a/tests/PhpPact/Plugin/Driver/Body/PluginBodyDriverTest.php
+++ b/tests/PhpPact/Plugin/Driver/Body/PluginBodyDriverTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace PhpPactTest\Plugin\Driver\Body;
+
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Exception\BodyNotSupportedException;
+use PhpPact\Consumer\Model\Body\Binary;
+use PhpPact\Consumer\Model\Body\Multipart;
+use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\ConsumerRequest;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\Consumer\Model\Message;
+use PhpPact\Consumer\Model\ProviderResponse;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Plugin\Driver\Body\PluginBodyDriver;
+use PhpPact\Plugin\Driver\Body\PluginBodyDriverInterface;
+use PhpPact\Plugin\Exception\PluginBodyNotAddedException;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PluginBodyDriverTest extends TestCase
+{
+    private PluginBodyDriverInterface $driver;
+    private ClientInterface|MockObject $client;
+    private Interaction $interaction;
+    private int $requestPartId = 1;
+    private int $responsePartId = 2;
+    private int $interactionId = 123;
+    private Message $message;
+    private int $messageId = 234;
+    private Binary $binary;
+    private Text $text;
+    private Text $json;
+    private Multipart $multipart;
+
+    public function setUp(): void
+    {
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->client
+            ->expects($this->once())
+            ->method('get')
+            ->willReturnMap([
+                ['InteractionPart_Request', $this->requestPartId],
+                ['InteractionPart_Response', $this->responsePartId],
+            ]);
+        $this->driver = new PluginBodyDriver($this->client);
+        $this->interaction = new Interaction();
+        $this->interaction->setHandle($this->interactionId);
+        $this->interaction->setRequest(new ConsumerRequest());
+        $this->interaction->setResponse(new ProviderResponse());
+        $this->message = new Message();
+        $this->message->setHandle($this->messageId);
+        $this->binary = new Binary(__DIR__ . '/../../../../_resources/image.jpg', 'image/jpeg');
+        $this->text = new Text('example', 'text/plain');
+        $this->json = new Text('{}', 'application/json');
+        $this->multipart = new Multipart([], 'abcde12345');
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testInteractionBinaryBody(InteractionPart $part): void
+    {
+        if ($part === InteractionPart::REQUEST) {
+            $this->interaction->getRequest()->setBody($this->binary);
+        } else {
+            $this->interaction->getResponse()->setBody($this->binary);
+        }
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->expectException(BodyNotSupportedException::class);
+        $this->expectExceptionMessage('Plugin does not support binary body');
+        $this->driver->registerBody($this->interaction, $part);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testMessageBinaryBody(InteractionPart $part): void
+    {
+        $this->message->setContents($this->binary);
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->expectException(BodyNotSupportedException::class);
+        $this->expectExceptionMessage('Plugin does not support binary body');
+        $this->driver->registerBody($this->message, $part);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testInteractionPlainTextBody(InteractionPart $part): void
+    {
+        if ($part === InteractionPart::REQUEST) {
+            $this->interaction->getRequest()->setBody($this->text);
+        } else {
+            $this->interaction->getResponse()->setBody($this->text);
+        }
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->expectException(BodyNotSupportedException::class);
+        $this->expectExceptionMessage('Plugin only support json body contents');
+        $this->driver->registerBody($this->interaction, $part);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testMessagePlainTextBody(InteractionPart $part): void
+    {
+        $this->message->setContents($this->text);
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->expectException(BodyNotSupportedException::class);
+        $this->expectExceptionMessage('Plugin only support json body contents');
+        $this->driver->registerBody($this->message, $part);
+    }
+
+    private function getPluginBodyErrorMessage(int $error): string
+    {
+        return match ($error) {
+            1 => 'A general panic was caught.',
+            2 => 'The mock server has already been started.',
+            3 => 'The interaction handle is invalid.',
+            4 => 'The content type is not valid.',
+            5 => 'The contents JSON is not valid JSON.',
+            6 => 'The plugin returned an error.',
+            default => 'Unknown error',
+        };
+    }
+
+    #[DataProvider('errorProvider')]
+    public function testRequestJsonBody(int $error): void
+    {
+        $this->interaction->getRequest()->setBody($this->json);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_interaction_contents', $this->interactionId, $this->requestPartId, $this->json->getContentType(), $this->json->getContents())
+            ->willReturn($error);
+        if ($error) {
+            $this->expectException(PluginBodyNotAddedException::class);
+            $this->expectExceptionMessage($this->getPluginBodyErrorMessage($error));
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::REQUEST);
+    }
+
+    #[DataProvider('errorProvider')]
+    public function testResponseJsonBody(int $error): void
+    {
+        $this->interaction->getResponse()->setBody($this->json);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_interaction_contents', $this->interactionId, $this->responsePartId, $this->json->getContentType(), $this->json->getContents())
+            ->willReturn($error);
+        if ($error) {
+            $this->expectException(PluginBodyNotAddedException::class);
+            $this->expectExceptionMessage($this->getPluginBodyErrorMessage($error));
+        }
+        $this->driver->registerBody($this->interaction, InteractionPart::RESPONSE);
+    }
+
+    #[DataProvider('errorProvider')]
+    public function testMessageJsonBody(int $error): void
+    {
+        $this->message->setContents($this->json);
+        $this->client
+            ->expects($this->once())
+            ->method('call')
+            ->with('pactffi_interaction_contents', $this->messageId, $this->requestPartId, $this->json->getContentType(), $this->json->getContents())
+            ->willReturn($error);
+        if ($error) {
+            $this->expectException(PluginBodyNotAddedException::class);
+            $this->expectExceptionMessage($this->getPluginBodyErrorMessage($error));
+        }
+        $this->driver->registerBody($this->message, InteractionPart::REQUEST);
+    }
+
+    public static function errorProvider(): array
+    {
+        return [
+            [0],
+            [1],
+            [2],
+            [3],
+            [4],
+            [5],
+            [6],
+            [7],
+        ];
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testInteractionMultipartBody(InteractionPart $part): void
+    {
+        if ($part === InteractionPart::REQUEST) {
+            $this->interaction->getRequest()->setBody($this->multipart);
+        } else {
+            $this->interaction->getResponse()->setBody($this->multipart);
+        }
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->expectException(BodyNotSupportedException::class);
+        $this->expectExceptionMessage('Plugin does not support multipart body');
+        $this->driver->registerBody($this->interaction, $part);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testEmptyInteractionBody(InteractionPart $part): void
+    {
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->driver->registerBody($this->interaction, $part);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testEmptyMessageBody(InteractionPart $part): void
+    {
+        $this->client
+            ->expects($this->never())
+            ->method('call');
+        $this->driver->registerBody($this->message, $part);
+    }
+}

--- a/tests/PhpPact/Plugins/Csv/Driver/Body/CsvBodyDriverTest.php
+++ b/tests/PhpPact/Plugins/Csv/Driver/Body/CsvBodyDriverTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpPactTest\Plugins\Csv\Driver\Body;
+
+use PhpPact\Consumer\Driver\Body\InteractionBodyDriverInterface;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\Plugin\Driver\Body\PluginBodyDriverInterface;
+use PhpPact\Plugins\Csv\Driver\Body\CsvBodyDriver;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class CsvBodyDriverTest extends TestCase
+{
+    private InteractionBodyDriverInterface $driver;
+    private PluginBodyDriverInterface|MockObject $decorated;
+
+    public function setUp(): void
+    {
+        $this->decorated = $this->createMock(PluginBodyDriverInterface::class);
+        $this->driver = new CsvBodyDriver($this->decorated);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testRegisterBody(InteractionPart $part): void
+    {
+        $interaction = new Interaction();
+        $this->decorated
+            ->expects($this->once())
+            ->method('registerBody')
+            ->with($interaction, $part);
+        $this->driver->registerBody($interaction, $part);
+    }
+}

--- a/tests/PhpPact/Plugins/Protobuf/Driver/Body/ProtobufMessageBodyDriverTest.php
+++ b/tests/PhpPact/Plugins/Protobuf/Driver/Body/ProtobufMessageBodyDriverTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpPactTest\Plugins\Csv\Driver\Body;
+
+use PhpPact\Consumer\Driver\Body\MessageBodyDriverInterface;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Model\Message;
+use PhpPact\Plugin\Driver\Body\PluginBodyDriverInterface;
+use PhpPact\Plugins\Protobuf\Driver\Body\ProtobufMessageBodyDriver;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ProtobufMessageBodyDriverTest extends TestCase
+{
+    private MessageBodyDriverInterface $driver;
+    private PluginBodyDriverInterface|MockObject $decorated;
+
+    public function setUp(): void
+    {
+        $this->decorated = $this->createMock(PluginBodyDriverInterface::class);
+        $this->driver = new ProtobufMessageBodyDriver($this->decorated);
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    public function testRegisterBody(InteractionPart $part): void
+    {
+        $message = new Message();
+        $this->decorated
+            ->expects($this->once())
+            ->method('registerBody')
+            ->with($message, InteractionPart::REQUEST);
+        $this->driver->registerBody($message);
+    }
+}


### PR DESCRIPTION
* Remove phpunit 9 (my bad, phpunit is on `require-dev`, so no need to install as many versions as possible. We can remove version 10 as well in the future PR)
* Add body drivers (code taken from body registry)
* Add tests for body drivers
  * Use phpunit 10 feature: attributes