### PR TITLE
fix: Fix error 'Cannot use object of type FFI\CData as array'

### DIFF
--- a/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriver.php
+++ b/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriver.php
@@ -39,7 +39,7 @@ class InteractionBodyDriver implements InteractionBodyDriverInterface
             case $body instanceof Multipart:
                 foreach ($body->getParts() as $part) {
                     $result = $this->client->call('pactffi_with_multipart_file_v2', $interaction->getHandle(), $partId, $part->getContentType(), $part->getPath(), $part->getName(), $body->getBoundary());
-                    if (isset($result->failed) && $result->failed instanceof CData) {
+                    if ($result->failed instanceof CData) {
                         throw new PartNotAddedException(FFI::string($result->failed));
                     }
                 }

--- a/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
@@ -149,9 +149,9 @@ class InteractionBodyDriverTest extends TestCase
             ->willReturnCallback(
                 fn (string $method, int $interactionId, int $partId, string $contentType, string $path, string $name, string $boundary) =>
                 match([$method, $interactionId, $partId, $contentType, $path, $name, $boundary]) {
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) [],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) [],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) ($success ? [] : ['failed' => $this->failed]),
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) ['failed' => null],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) ['failed' => null],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) (['failed' => $success ? null : $this->failed]),
                 }
             );
         if (!$success) {
@@ -172,9 +172,9 @@ class InteractionBodyDriverTest extends TestCase
             ->willReturnCallback(
                 fn (string $method, int $interactionId, int $partId, string $contentType, string $path, string $name, string $boundary) =>
                 match([$method, $interactionId, $partId, $contentType, $path, $name, $boundary]) {
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) [],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) [],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) ($success ? [] : ['failed' => $this->failed]),
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) ['failed' => null],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) ['failed' => null],
+                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) (['failed' => $success ? null : $this->failed]),
                 }
             );
         if (!$success) {


### PR DESCRIPTION
* The variable `$result` has type `CData`, so we can't use `isset`
* The property `failed` is always set by `pactffi_with_multipart_file_v2` so we don't have to check

The class `PhpPact\Consumer\Driver\Body\InteractionBodyDriver` is not used yet at this stage so I can't see this error sooner. I can only see it when I rebase on other branch.
