### PR TITLE
refactor: Remove $this return value

### DIFF
--- a/src/PhpPact/Consumer/Driver/InteractionPart/AbstractInteractionPartDriver.php
+++ b/src/PhpPact/Consumer/Driver/InteractionPart/AbstractInteractionPartDriver.php
@@ -19,14 +19,12 @@ abstract class AbstractInteractionPartDriver
         $this->bodyDriver = $bodyDriver ?? new InteractionBodyDriver($client);
     }
 
-    protected function withBody(Interaction $interaction, InteractionPart $part): self
+    protected function withBody(Interaction $interaction, InteractionPart $part): void
     {
         $this->bodyDriver->registerBody($interaction, $part);
-
-        return $this;
     }
 
-    protected function withHeaders(Interaction $interaction, InteractionPart $interactionPart): self
+    protected function withHeaders(Interaction $interaction, InteractionPart $interactionPart): void
     {
         $headers = $interaction->getHeaders($interactionPart);
         $partId = match ($interactionPart) {
@@ -38,7 +36,5 @@ abstract class AbstractInteractionPartDriver
                 $this->client->call('pactffi_with_header_v2', $interaction->getHandle(), $partId, (string) $header, (int) $index, (string) $value);
             }
         }
-
-        return $this;
     }
 }

--- a/src/PhpPact/Consumer/Driver/InteractionPart/RequestDriver.php
+++ b/src/PhpPact/Consumer/Driver/InteractionPart/RequestDriver.php
@@ -9,29 +9,24 @@ class RequestDriver extends AbstractInteractionPartDriver implements RequestDriv
 {
     public function registerRequest(Interaction $interaction): void
     {
-        $this
-            ->withRequest($interaction)
-            ->withQueryParameters($interaction)
-            ->withHeaders($interaction, InteractionPart::REQUEST)
-            ->withBody($interaction, InteractionPart::REQUEST);
+        $this->withBody($interaction, InteractionPart::REQUEST);
+        $this->withHeaders($interaction, InteractionPart::REQUEST);
+        $this->withQueryParameters($interaction);
+        $this->withRequest($interaction);
     }
 
-    private function withQueryParameters(Interaction $interaction): self
+    private function withQueryParameters(Interaction $interaction): void
     {
         foreach ($interaction->getRequest()->getQuery() as $key => $values) {
             foreach (array_values($values) as $index => $value) {
                 $this->client->call('pactffi_with_query_parameter_v2', $interaction->getHandle(), (string) $key, (int) $index, (string) $value);
             }
         }
-
-        return $this;
     }
 
-    private function withRequest(Interaction $interaction): self
+    private function withRequest(Interaction $interaction): void
     {
         $request = $interaction->getRequest();
         $this->client->call('pactffi_with_request', $interaction->getHandle(), $request->getMethod(), $request->getPath());
-
-        return $this;
     }
 }

--- a/src/PhpPact/Consumer/Driver/InteractionPart/ResponseDriver.php
+++ b/src/PhpPact/Consumer/Driver/InteractionPart/ResponseDriver.php
@@ -9,16 +9,15 @@ class ResponseDriver extends AbstractInteractionPartDriver implements ResponseDr
 {
     public function registerResponse(Interaction $interaction): void
     {
-        $this
-            ->withResponse($interaction)
-            ->withHeaders($interaction, InteractionPart::RESPONSE)
-            ->withBody($interaction, InteractionPart::RESPONSE);
+        // @todo Fix 'Exception: String could not be parsed as XML' in xml's consumer test
+        // when calling `withBody` before `withHeaders`
+        $this->withHeaders($interaction, InteractionPart::RESPONSE);
+        $this->withBody($interaction, InteractionPart::RESPONSE);
+        $this->withResponse($interaction);
     }
 
-    private function withResponse(Interaction $interaction): self
+    private function withResponse(Interaction $interaction): void
     {
         $this->client->call('pactffi_response_status_v2', $interaction->getHandle(), $interaction->getResponse()->getStatus());
-
-        return $this;
     }
 }


### PR DESCRIPTION
* Methods can be call in any order
* Xml's consumer test failed for some reason. We need to check it in core
* That's why, when registering response, `withHeaders` need to be before `withBody` for now