### PR TITLE
ci: Split jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,11 +54,6 @@ jobs:
     name: PHP ${{ matrix.php }} on ${{ matrix.operating-system }} with ${{ matrix.dependencies }} dependencies
 
     steps:
-      - name: Tune Windows Network
-        if: ${{ runner.os == 'Windows' }}
-        shell: pwsh
-        run: Disable-NetAdapterChecksumOffload -Name * -TcpIPv4 -UdpIPv4 -TcpIPv6 -UdpIPv6
-
       - uses: actions/checkout@v3
         name: Checkout repository
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
-name: Pact-PHP Code Analysis & Test
+name: Code Analysis & Test
 
 on:
-  push: 
+  push:
   pull_request:
   # Once on the first of the month at 06:00 UTC
   schedule:
@@ -16,17 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        php: [ '8.2' ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout repository
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: 8.1
           coverage: none
 
       - uses: ramsey/composer-install@v2
@@ -39,54 +37,114 @@ jobs:
       - name: Static Code Analysis
         run: composer run static-code-analysis
 
-  test:
-    runs-on: ${{ matrix.operating-system }}
+  examples:
+    runs-on: ${{ matrix.os }}
     needs:
       - php-cs
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ ubuntu-latest, windows-latest, macos-12, macos-14 ]
-        php: [ '8.1', '8.2', '8.3' ]
-        dependencies: [ 'lowest', 'locked' ]
+        include:
+          - os: ubuntu-latest
+            php: 8.1
+          - os: macos-12
+            php: 8.2
+          - os: macos-14
+            php: 8.2
+          - os: windows-latest
+            example: 'json'
+            php: 8.2
+          - os: windows-latest
+            example: 'binary'
+            php: 8.2
+          - os: windows-latest
+            example: 'multipart'
+            php: 8.2
+          - os: windows-latest
+            example: 'xml'
+            php: 8.2
+          - os: windows-latest
+            example: 'message'
+            php: 8.2
+          - os: windows-latest
+            example: 'matchers'
+            php: 8.2
+          - os: windows-latest
+            example: 'generators'
+            php: 8.2
+          - os: windows-latest
+            example: 'csv'
+            php: 8.2
+          - os: windows-latest
+            example: 'protobuf-sync-message'
+            php: 8.1
+          - os: windows-latest
+            example: 'protobuf-async-message'
+            php: 8.2
     timeout-minutes: 5
 
-    name: PHP ${{ matrix.php }} on ${{ matrix.operating-system }} with ${{ matrix.dependencies }} dependencies
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout repository
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          extensions: ${{ matrix.operating-system == 'windows-latest' && contains('["8.2","8.3"]', matrix.php) && 'sockets, curl, zip, ffi' || 'sockets, curl, zip, ffi, grpc' }}
+          extensions: sockets, curl, zip, ffi ${{ (!matrix.example || matrix.example == 'protobuf-sync-message') && ', grpc' || '' }}
           php-version: ${{ matrix.php }}
           coverage: none
-          ini-values: ${{ matrix.operating-system == 'windows-latest' && 'opcache.enable=0 opcache.enable_cli=0' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Composer install
+        uses: ramsey/composer-install@v2
+        with:
+          dependency-versions: 'locked'
 
       - name: Install Protoc
-        uses: arduino/setup-protoc@v2
+        uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ !matrix.example || contains(matrix.example, 'protobuf') }}
 
-      - name: Install gRPC Extension (for PHP 8.2 & 8.3 on Windows)
+      - name: Generate Library
+        run: composer gen-lib
+        if: ${{ !matrix.example || contains(matrix.example, 'protobuf') }}
+
+      - name: Run example(s)
         run: |
-          cd C:\tools\php
-          Invoke-WebRequest -Uri https://github.com/tienvx/build-php-grpc-extension/releases/download/builds/grpc_windows-2022_php-${{ matrix.php }}.dll -OutFile ext\php_grpc.dll
-          echo "extension=php_grpc.dll" >> php.ini
-        if: ${{ matrix.operating-system == 'windows-latest' && contains('["8.2","8.3"]', matrix.php) }}
-        shell: pwsh
+          php -r "array_map('unlink', glob('./example/*/pacts/*.json'));"
+          vendor/bin/phpunit --no-coverage --exclude-testsuite unit ${{ matrix.example && format('--testsuite {0}-example', matrix.example) || '' }}
+        env:
+          PACT_DO_NOT_TRACK: true
+
+  unit:
+    runs-on: ubuntu-latest
+    needs:
+      - php-cs
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ '8.1', '8.2', '8.3' ]
+        dependencies: [ 'lowest', 'locked' ]
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout repository
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          extensions: 'sockets, curl, zip, ffi'
+          php-version: ${{ matrix.php }}
+          coverage: pcov
 
       - name: Composer install
         uses: ramsey/composer-install@v2
         with:
           dependency-versions: ${{ matrix.dependencies }}
 
-      - name: Generate Library
-        run: composer gen-lib
-
-      - name: Composer test
-        run: composer test
+      - name: Test Unit
+        run: vendor/bin/phpunit --testsuite unit
         env:
           PACT_DO_NOT_TRACK: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,9 +112,7 @@ jobs:
         if: ${{ !matrix.example || contains(matrix.example, 'protobuf') }}
 
       - name: Run example(s)
-        run: |
-          php -r "array_map('unlink', glob('./example/*/pacts/*.json'));"
-          vendor/bin/phpunit --no-coverage --exclude-testsuite unit ${{ matrix.example && format('--testsuite {0}-example', matrix.example) || '' }}
+        run: composer test -- --exclude-testsuite unit ${{ matrix.example && format('--testsuite {0}-example', matrix.example) || '' }}
         env:
           PACT_DO_NOT_TRACK: true
 

--- a/.github/workflows/compatibility-suite.yml
+++ b/.github/workflows/compatibility-suite.yml
@@ -1,4 +1,4 @@
-name: Pact-PHP Compatibility Suite
+name: Compatibility Suite
 
 on: [push, pull_request]
 

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,7 @@
         "lint": "php-cs-fixer fix --dry-run",
         "fix": "php-cs-fixer fix",
         "test": [
-            "php -r \"array_map('unlink', glob('./example/*/pacts/*.json'));\"",
+            "php -r \"array_map('unlink', glob('./example/*/pacts/*.json'));\" --",
             "phpunit --no-coverage"
         ],
         "gen-lib": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,68 +7,38 @@
     </report>
   </coverage>
   <testsuites>
-    <testsuite name="PhpPact Core Tests">
+    <testsuite name="unit">
       <directory>./tests</directory>
     </testsuite>
-    <testsuite name="PhpPact Json Consumer Example Tests">
-      <directory>./example/json/consumer/tests</directory>
+    <testsuite name="json-example">
+      <directory>./example/json</directory>
     </testsuite>
-    <testsuite name="PhpPact Json Provider Example Tests">
-      <directory>./example/json/provider/tests</directory>
+    <testsuite name="binary-example">
+      <directory>./example/binary</directory>
     </testsuite>
-    <testsuite name="PhpPact Binary Consumer Example Tests">
-      <directory>./example/binary/consumer/tests</directory>
+    <testsuite name="multipart-example">
+      <directory>./example/multipart</directory>
     </testsuite>
-    <testsuite name="PhpPact Binary Provider Example Tests">
-      <directory>./example/binary/provider/tests</directory>
+    <testsuite name="xml-example">
+      <directory>./example/xml</directory>
     </testsuite>
-    <testsuite name="PhpPact Multipart Consumer Example Tests">
-      <directory>./example/multipart/consumer/tests</directory>
+    <testsuite name="message-example">
+      <directory>./example/message</directory>
     </testsuite>
-    <testsuite name="PhpPact Multipart Provider Example Tests">
-      <directory>./example/multipart/provider/tests</directory>
+    <testsuite name="matchers-example">
+      <directory>./example/matchers</directory>
     </testsuite>
-    <testsuite name="PhpPact Xml Consumer Example Tests">
-      <directory>./example/xml/consumer/tests</directory>
+    <testsuite name="generators-example">
+      <directory>./example/generators</directory>
     </testsuite>
-    <testsuite name="PhpPact Xml Provider Example Tests">
-      <directory>./example/xml/provider/tests</directory>
+    <testsuite name="csv-example">
+      <directory>./example/csv</directory>
     </testsuite>
-    <testsuite name="PhpPact Message Consumer Example Tests">
-      <directory>./example/message/consumer/tests</directory>
+    <testsuite name="protobuf-sync-message-example">
+      <directory>./example/protobuf-sync-message</directory>
     </testsuite>
-    <testsuite name="PhpPact Message Provider Example Tests">
-      <directory>./example/message/provider/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Matchers Consumer Example Tests">
-      <directory>./example/matchers/consumer/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Matchers Provider Example Tests">
-      <directory>./example/matchers/provider/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Generators Consumer Example Tests">
-      <directory>./example/generators/consumer/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Generators Provider Example Tests">
-      <directory>./example/generators/provider/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Csv Consumer Example Tests">
-      <directory>./example/csv/consumer/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Csv Provider Example Tests">
-      <directory>./example/csv/provider/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Protobuf Sync Message Consumer Example Tests">
-      <directory>./example/protobuf-sync-message/consumer/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Protobuf Sync Message Provider Example Tests">
-      <directory>./example/protobuf-sync-message/provider/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Protobuf Async Message Consumer Example Tests">
-      <directory>./example/protobuf-async-message/consumer/tests</directory>
-    </testsuite>
-    <testsuite name="PhpPact Protobuf Async Message Provider Example Tests">
-      <directory>./example/protobuf-async-message/provider/tests</directory>
+    <testsuite name="protobuf-async-message-example">
+      <directory>./example/protobuf-async-message</directory>
     </testsuite>
   </testsuites>
   <logging>


### PR DESCRIPTION
Apply multiple changes to fix **random fails**:

* Update PHPUnit's config file `phpunit.xml`:
  * Reduce number of suites
  * Change suite's names to make it easier to reference in steps below.
* Default PHP version is used to speed up the jobs. According to this [table](https://github.com/shivammathur/setup-php?tab=readme-ov-file#cloud-osplatform-support):
  * Ubuntu: `8.1`
  * MacOS 12: `8.2`
  * Windows: `8.2`
  * MacOS 14 (ARM): currently not supported. Assume `8.2`
* Add `unit` job:
  * No need to run on multiple os, only `ubuntu` is enough
  * Need to run on multiple php versions `8.1 -> 8.3`
  * Need to run on multiple dependency configurations `lowest/locked`
  * Can now enable code coverage checking
* Rename `test` job to `examples`
  * No need to run on multiple php versions, single version is enough
  * No need to run on multiple dependency configuration, `locked` is fine
  * Ubuntu/MacOS:
    * Run all examples at once
    * Need `grpc` extension
    * Need `protoc` tool
  * **Windows**:
    * Run examples on **parallel** to fix **random fails**
    * `protobuf-sync-message` suite
      * Need `grpc` extension
      * Need `protoc` tool
      * Need PHP `8.1`
    * `protobuf-async-message` suite
      * No need `grpc` extension
      * Need `protoc` tool
      * Use default PHP version `8.2` to improve speed
    * Other suites
      * Use default PHP version `8.2` to improve speed
      * No need `grpc` extension
      * No need `protoc` tool
* Update `php-cs` job
  * Use default PHP version `8.1`
* MacOS 14 (ARM) still got this random error `dyld[7148]: Library not loaded: /opt/homebrew/opt/xz/lib/liblzma.5.dylib`, probably because it's not supported by `shivammathur/setup-php` action
* All actions are updated to remove node's version warnings
* Allow `composer test` script to take extra option (for `phpunit`)


Depend on https://github.com/pact-foundation/pact-php/pull/495