### PR TITLE
ci(compatibility-suite): Force output colors for behat

### DIFF
--- a/.github/workflows/compatibility-suite.yml
+++ b/.github/workflows/compatibility-suite.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: ramsey/composer-install@v2
 
       - name: Run Behat
-        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V1
+        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V1 --colors
   v2:
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +37,7 @@ jobs:
       - uses: ramsey/composer-install@v2
 
       - name: Run Behat
-        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V2
+        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V2 --colors
   v3:
     runs-on: ubuntu-latest
     steps:
@@ -53,7 +53,7 @@ jobs:
       - uses: ramsey/composer-install@v2
 
       - name: Run Behat
-        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V3 --name '/^((?!binary body \(negative|Message provider).)*$/'
+        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V3 --name '/^((?!binary body \(negative|Message provider).)*$/' --colors
   v4:
     runs-on: ubuntu-latest
     steps:
@@ -69,4 +69,4 @@ jobs:
       - uses: ramsey/composer-install@v2
 
       - name: Run Behat
-        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V4
+        run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V4 --colors


### PR DESCRIPTION
```
      --colors                           Force ANSI color in the output. By default color support is
                                         guessed based on your platform and the output if not specified.
```

Currently it guessed that github actions does not support color. So I have to force it to make it easier to see the results (which step pass, which fail)