### PR TITLE
feat: Allow set interaction key for v4

### DIFF
--- a/compatibility-suite/suites/v4/message/provider.yml
+++ b/compatibility-suite/suites/v4/message/provider.yml
@@ -11,6 +11,7 @@ default:
                     - '@interactions_storage'
                     - '@message_pact_writer'
                     - '@provider_verifier'
+                    - '@parser'
 
             filters:
                 tags: "@provider&&@message"

--- a/compatibility-suite/tests/Context/V3/Message/ProviderContext.php
+++ b/compatibility-suite/tests/Context/V3/Message/ProviderContext.php
@@ -5,6 +5,7 @@ namespace PhpPactTest\CompatibilitySuite\Context\V3\Message;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeStepScope;
 use Behat\Gherkin\Node\TableNode;
+use PhpPact\Consumer\Model\Message;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ProviderTransport;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 use PhpPactTest\CompatibilitySuite\Service\FixtureLoaderInterface;
@@ -80,7 +81,10 @@ final class ProviderContext implements Context
      */
     public function aPactFileForIsToBeVerified(string $name, string $fixture): void
     {
-        $this->pactWriter->write($name, $fixture, $this->pactPath);
+        $message = new Message();
+        $message->setDescription($name);
+        $message->setContents($this->parser->parseBody($fixture));
+        $this->pactWriter->write($message, $this->pactPath);
         $this->providerVerifier->addSource($this->pactPath);
     }
 

--- a/compatibility-suite/tests/Context/V4/CombinedContext.php
+++ b/compatibility-suite/tests/Context/V4/CombinedContext.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\CompatibilitySuite\Context\V4;
 
 use Behat\Behat\Context\Context;
 use PhpPact\Config\PactConfigInterface;
+use PhpPact\Consumer\Model\Message;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 use PhpPactTest\CompatibilitySuite\Service\InteractionBuilderInterface;
 use PhpPactTest\CompatibilitySuite\Service\InteractionsStorageInterface;
@@ -51,7 +52,9 @@ final class CombinedContext implements Context
     public function thePactFileForTheTestIsGenerated(): void
     {
         $this->pactWriter->write($this->id, $this->pactPath, PactConfigInterface::MODE_MERGE);
-        $this->messagePactWriter->write('message interaction', '', $this->pactPath, PactConfigInterface::MODE_MERGE);
+        $message = new Message();
+        $message->setDescription('message interaction');
+        $this->messagePactWriter->write($message, $this->pactPath, PactConfigInterface::MODE_MERGE);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
@@ -52,7 +52,7 @@ final class ConsumerContext implements Context
      */
     public function aKeyOfIsSpecifiedForTheHttpInteraction(string $key): void
     {
-        throw new PendingException("Can't set interaction's key using FFI call");
+        $this->interaction->setKey($key);
     }
 
     /**
@@ -61,7 +61,7 @@ final class ConsumerContext implements Context
     public function theFirstInteractionInThePactFileWillHave(string $name, string $value): void
     {
         $pact = json_decode(file_get_contents($this->pactPath), true);
-        Assert::assertSame($value, $pact['interactions'][0][$name]);
+        Assert::assertSame(json_decode($value), $pact['interactions'][0][$name]);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\CompatibilitySuite\Context\V4\Message;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Tester\Exception\PendingException;
+use PhpPact\Consumer\Model\Message;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 use PhpPactTest\CompatibilitySuite\Service\MessagePactWriterInterface;
 use PHPUnit\Framework\Assert;
@@ -11,6 +12,7 @@ use PHPUnit\Framework\Assert;
 final class ConsumerContext implements Context
 {
     private PactPath $pactPath;
+    private Message $message;
 
     public function __construct(
         private MessagePactWriterInterface $pactWriter
@@ -23,6 +25,8 @@ final class ConsumerContext implements Context
      */
     public function aMessageInteractionIsBeingDefinedForAConsumerTest(): void
     {
+        $this->message = new Message();
+        $this->message->setDescription('a message');
     }
 
     /**
@@ -30,7 +34,7 @@ final class ConsumerContext implements Context
      */
     public function thePactFileForTheTestIsGenerated(): void
     {
-        $this->pactWriter->write('a message', '', $this->pactPath);
+        $this->pactWriter->write($this->message, $this->pactPath);
     }
 
     /**
@@ -47,7 +51,7 @@ final class ConsumerContext implements Context
      */
     public function aKeyOfIsSpecifiedForTheMessageInteraction(string $key): void
     {
-        throw new PendingException("Can't set message's key using FFI call");
+        $this->message->setKey($key);
     }
 
     /**
@@ -72,6 +76,6 @@ final class ConsumerContext implements Context
     public function theFirstInteractionInThePactFileWillHave(string $name, string $value): void
     {
         $pact = json_decode(file_get_contents($this->pactPath), true);
-        Assert::assertSame($value, $pact['interactions'][0][$name]);
+        Assert::assertSame(json_decode($value), $pact['interactions'][0][$name]);
     }
 }

--- a/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
@@ -53,7 +53,7 @@ final class ConsumerContext implements Context
      */
     public function aKeyOfIsSpecifiedForTheSynchronousMessageInteraction(string $key): void
     {
-        throw new PendingException("Can't set sync message's key using FFI call");
+        $this->message->setKey($key);
     }
 
     /**
@@ -78,7 +78,7 @@ final class ConsumerContext implements Context
     public function theFirstInteractionInThePactFileWillHave(string $name, string $value): void
     {
         $pact = json_decode(file_get_contents($this->pactPath), true);
-        Assert::assertSame($value, $pact['interactions'][0][$name]);
+        Assert::assertSame(json_decode($value), $pact['interactions'][0][$name]);
     }
 
     /**

--- a/compatibility-suite/tests/Service/MessagePactWriter.php
+++ b/compatibility-suite/tests/Service/MessagePactWriter.php
@@ -17,7 +17,7 @@ class MessagePactWriter implements MessagePactWriterInterface
     ) {
     }
 
-    public function write(string $name, string $body, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void
+    public function write(Message $message, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void
     {
         $config = new MockServerConfig();
         $config
@@ -28,9 +28,6 @@ class MessagePactWriter implements MessagePactWriterInterface
             ->setPactFileWriteMode($mode);
         $driver = (new MessageDriverFactory())->create($config);
 
-        $message = new Message();
-        $message->setDescription($name);
-        $message->setContents($this->parser->parseBody($body));
         $driver->registerMessage($message);
         $driver->writePactAndCleanUp();
     }

--- a/compatibility-suite/tests/Service/MessagePactWriterInterface.php
+++ b/compatibility-suite/tests/Service/MessagePactWriterInterface.php
@@ -3,9 +3,10 @@
 namespace PhpPactTest\CompatibilitySuite\Service;
 
 use PhpPact\Config\PactConfigInterface;
+use PhpPact\Consumer\Model\Message;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 
 interface MessagePactWriterInterface
 {
-    public function write(string $name, string $body, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void;
+    public function write(Message $message, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void;
 }

--- a/composer.json
+++ b/composer.json
@@ -111,12 +111,12 @@
     "extra": {
         "downloads": {
             "pact-ffi-headers": {
-                "version": "0.4.16",
+                "version": "0.4.18",
                 "url": "https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v{$version}/pact.h",
                 "path": "bin/pact-ffi-headers/pact.h"
             },
             "pact-ffi-lib": {
-                "version": "0.4.16",
+                "version": "0.4.18",
                 "variables": {
                     "{$prefix}": "PHP_OS_FAMILY === 'Windows' ? 'pact_ffi' : 'libpact_ffi'",
                     "{$os}": "PHP_OS === 'Darwin' ? 'osx' : strtolower(PHP_OS_FAMILY)",

--- a/src/PhpPact/Consumer/AbstractMessageBuilder.php
+++ b/src/PhpPact/Consumer/AbstractMessageBuilder.php
@@ -56,4 +56,14 @@ abstract class AbstractMessageBuilder implements BuilderInterface
 
         return $this;
     }
+
+    /**
+     * Set key for message interaction. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     */
+    public function key(?string $key): self
+    {
+        $this->message->setKey($key);
+
+        return $this;
+    }
 }

--- a/src/PhpPact/Consumer/Driver/Exception/InteractionKeyNotSetException.php
+++ b/src/PhpPact/Consumer/Driver/Exception/InteractionKeyNotSetException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Exception;
+
+class InteractionKeyNotSetException extends DriverException
+{
+}

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Interaction;
+
+use PhpPact\Consumer\Driver\Exception\InteractionKeyNotSetException;
+use PhpPact\Consumer\Model\Interaction;
+use PhpPact\Consumer\Model\Message;
+use PhpPact\FFI\ClientInterface;
+
+abstract class AbstractDriver
+{
+    public function __construct(
+        protected ClientInterface $client,
+    ) {
+    }
+
+    protected function setKey(Interaction|Message $interaction): void
+    {
+        $key = $interaction->getKey();
+        if (null === $key) {
+            return;
+        }
+        $success = $this->client->call('pactffi_set_key', $interaction->getHandle(), $key);
+        if (!$success) {
+            throw new InteractionKeyNotSetException(sprintf("Can not set the key '%s' for the interaction '%s'", $key, $interaction->getDescription()));
+        }
+    }
+}

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
@@ -8,15 +8,16 @@ use PhpPact\Consumer\Driver\Pact\PactDriverInterface;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\FFI\ClientInterface;
 
-abstract class AbstractMessageDriver implements SharedMessageDriverInterface
+abstract class AbstractMessageDriver extends AbstractDriver implements SharedMessageDriverInterface
 {
     private MessageBodyDriverInterface $messageBodyDriver;
 
     public function __construct(
-        protected ClientInterface $client,
+        ClientInterface $client,
         protected PactDriverInterface $pactDriver,
         ?MessageBodyDriverInterface $messageBodyDriver = null
     ) {
+        parent::__construct($client);
         $this->messageBodyDriver = $messageBodyDriver ?? new MessageBodyDriver($client);
     }
 
@@ -27,6 +28,7 @@ abstract class AbstractMessageDriver implements SharedMessageDriverInterface
         $this->expectsToReceive($message);
         $this->withMetadata($message);
         $this->withContents($message);
+        $this->setKey($message);
     }
 
     public function writePactAndCleanUp(): void

--- a/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
@@ -12,18 +12,19 @@ use PhpPact\Consumer\Service\MockServerInterface;
 use PhpPact\FFI\ClientInterface;
 use PhpPact\Standalone\MockService\Model\VerifyResult;
 
-class InteractionDriver implements InteractionDriverInterface
+class InteractionDriver extends AbstractDriver implements InteractionDriverInterface
 {
     private RequestDriverInterface $requestDriver;
     private ResponseDriverInterface $responseDriver;
 
     public function __construct(
-        private ClientInterface $client,
+        ClientInterface $client,
         private MockServerInterface $mockServer,
         private PactDriverInterface $pactDriver,
         ?RequestDriverInterface $requestDriver = null,
         ?ResponseDriverInterface $responseDriver = null,
     ) {
+        parent::__construct($client);
         $this->requestDriver = $requestDriver ?? new RequestDriver($client);
         $this->responseDriver = $responseDriver ?? new ResponseDriver($client);
     }
@@ -40,6 +41,7 @@ class InteractionDriver implements InteractionDriverInterface
         $this->uponReceiving($interaction);
         $this->withRequest($interaction);
         $this->willRespondWith($interaction);
+        $this->setKey($interaction);
 
         if ($startMockServer) {
             $this->mockServer->start();

--- a/src/PhpPact/Consumer/InteractionBuilder.php
+++ b/src/PhpPact/Consumer/InteractionBuilder.php
@@ -75,4 +75,14 @@ class InteractionBuilder implements BuilderInterface
     {
         return $this->driver->verifyInteractions()->matched;
     }
+
+    /**
+     * Set key for interaction. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     */
+    public function key(?string $key): self
+    {
+        $this->interaction->setKey($key);
+
+        return $this;
+    }
 }

--- a/src/PhpPact/Consumer/Model/Interaction.php
+++ b/src/PhpPact/Consumer/Model/Interaction.php
@@ -8,6 +8,7 @@ use PhpPact\Consumer\Model\Body\Multipart;
 use PhpPact\Consumer\Model\Body\Text;
 use PhpPact\Consumer\Model\Interaction\DescriptionTrait;
 use PhpPact\Consumer\Model\Interaction\HandleTrait;
+use PhpPact\Consumer\Model\Interaction\KeyTrait;
 
 /**
  * Request/Response Pair to be posted to the Mock Server for PACT tests.
@@ -17,6 +18,7 @@ class Interaction
     use ProviderStates;
     use DescriptionTrait;
     use HandleTrait;
+    use KeyTrait;
 
     private ConsumerRequest $request;
 

--- a/src/PhpPact/Consumer/Model/Interaction/KeyTrait.php
+++ b/src/PhpPact/Consumer/Model/Interaction/KeyTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\Consumer\Model\Interaction;
+
+trait KeyTrait
+{
+    private ?string $key = null;
+
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+
+    public function setKey(?string $key): self
+    {
+        $this->key = $key;
+
+        return $this;
+    }
+}

--- a/src/PhpPact/Consumer/Model/Message.php
+++ b/src/PhpPact/Consumer/Model/Message.php
@@ -10,6 +10,7 @@ use PhpPact\Consumer\Model\Body\Multipart;
 use PhpPact\Consumer\Model\Body\Text;
 use PhpPact\Consumer\Model\Interaction\DescriptionTrait;
 use PhpPact\Consumer\Model\Interaction\HandleTrait;
+use PhpPact\Consumer\Model\Interaction\KeyTrait;
 
 /**
  * Message metadata and contents to be posted to the Mock Server for PACT tests.
@@ -19,6 +20,7 @@ class Message
     use ProviderStates;
     use DescriptionTrait;
     use HandleTrait;
+    use KeyTrait;
 
     /**
      * @var array<string, string>

--- a/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
@@ -8,12 +8,15 @@ use PhpPact\Consumer\Driver\Pact\PactDriver;
 use PhpPact\Consumer\Driver\Pact\PactDriverInterface;
 use PhpPact\Consumer\Exception\PactFileNotWroteException;
 use PhpPact\FFI\ClientInterface;
+use PhpPactTest\Helper\FFI\ClientTrait;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class PactDriverTest extends TestCase
 {
+    use ClientTrait;
+
     protected const SPEC_UNKNOWN = 0;
     protected const SPEC_V1 = 1;
     protected const SPEC_V1_1 = 2;
@@ -21,7 +24,6 @@ class PactDriverTest extends TestCase
     protected const SPEC_V3 = 4;
     protected const SPEC_V4 = 5;
     protected PactDriverInterface $driver;
-    protected ClientInterface|MockObject $client;
     protected PactConfigInterface|MockObject $config;
     protected int $pactHandle = 123;
     protected string $consumer = 'consumer';
@@ -151,19 +153,5 @@ class PactDriverTest extends TestCase
             ->expects($this->once())
             ->method('getProvider')
             ->willReturn($this->provider);
-    }
-
-    protected function assertClientCalls(array $calls): void
-    {
-        $this->client
-            ->expects($this->exactly(count($calls)))
-            ->method('call')
-            ->willReturnCallback(function (...$args) use (&$calls) {
-                $call = array_shift($calls);
-                $return = array_pop($call);
-                $this->assertSame($call, $args);
-
-                return $return;
-            });
     }
 }

--- a/tests/PhpPact/Helper/FFI/ClientTrait.php
+++ b/tests/PhpPact/Helper/FFI/ClientTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPactTest\Helper\FFI;
+
+use PhpPact\FFI\ClientInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+trait ClientTrait
+{
+    protected ClientInterface|MockObject $client;
+
+    protected function assertClientCalls(array $calls): void
+    {
+        $this->client
+            ->expects($this->exactly(count($calls)))
+            ->method('call')
+            ->willReturnCallback(function (...$args) use (&$calls) {
+                $call = array_shift($calls);
+                $return = array_pop($call);
+                $this->assertSame($call, $args);
+
+                return $return;
+            });
+    }
+}

--- a/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
+++ b/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
@@ -3,6 +3,7 @@
 namespace PhpPactTest\Consumer\Driver\Interaction;
 
 use PhpPact\Consumer\Driver\Body\MessageBodyDriverInterface;
+use PhpPact\Consumer\Driver\Exception\InteractionKeyNotSetException;
 use PhpPact\Consumer\Driver\Pact\PactDriverInterface;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\Consumer\Model\Pact\Pact;
@@ -11,14 +12,17 @@ use PhpPact\FFI\ClientInterface;
 use PhpPact\Standalone\MockService\Model\VerifyResult;
 use PhpPact\SyncMessage\Driver\Interaction\SyncMessageDriver;
 use PhpPact\SyncMessage\Driver\Interaction\SyncMessageDriverInterface;
+use PhpPactTest\Helper\FFI\ClientTrait;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class SyncMessageDriverTest extends TestCase
 {
+    use ClientTrait;
+
     private SyncMessageDriverInterface $driver;
     private MockServerInterface|MockObject $mockServer;
-    private ClientInterface|MockObject $client;
     private PactDriverInterface|MockObject $pactDriver;
     private MessageBodyDriverInterface|MockObject $messageBodyDriver;
     private Message $message;
@@ -91,17 +95,39 @@ class SyncMessageDriverTest extends TestCase
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
         ];
-        $this->client
-            ->expects($this->exactly(count($calls)))
-            ->method('call')
-            ->willReturnCallback(function (...$args) use (&$calls) {
-                $call = array_shift($calls);
-                $return = array_pop($call);
-                $this->assertSame($call, $args);
-
-                return $return;
-            });
+        $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);
         $this->assertSame($this->messageHandle, $this->message->getHandle());
+    }
+
+    #[TestWith([null, true])]
+    #[TestWith([null, true])]
+    #[TestWith(['123ABC', false])]
+    #[TestWith(['123ABC', true])]
+    public function testSetKey(?string $key, $success): void
+    {
+        $this->message->setKey($key);
+        $this->pactDriver
+            ->expects($this->once())
+            ->method('getPact')
+            ->willReturn(new Pact($this->pactHandle));
+        $calls = [
+            ['pactffi_new_sync_message_interaction', $this->pactHandle, $this->description, $this->messageHandle],
+            ['pactffi_given', $this->messageHandle, 'item exist', null],
+            ['pactffi_given_with_param', $this->messageHandle, 'item exist', 'id', '12', null],
+            ['pactffi_given_with_param', $this->messageHandle, 'item exist', 'name', 'abc', null],
+            ['pactffi_message_expects_to_receive', $this->messageHandle, $this->description, null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
+        ];
+        if (is_string($key)) {
+            $calls[] = ['pactffi_set_key', $this->messageHandle, $key, $success];
+        }
+        if (!$success) {
+            $this->expectException(InteractionKeyNotSetException::class);
+            $this->expectExceptionMessage("Can not set the key '$key' for the interaction '{$this->description}'");
+        }
+        $this->assertClientCalls($calls);
+        $this->driver->registerMessage($this->message);
     }
 }


### PR DESCRIPTION
* Allow setting interaction/message interaction's key 
* This is for v4, using this feature on <= v3 doesn't have any effect to the pact file
* Update compatibility suite to use this feature


I'm not sure:
  * Did other languages implement it for end-user?
  * How did other languages implement for end-user?
  * Should all languages follow the same naming convention?

So I invented 3 methods in builder:

```php
 $config = new MockServerConfig();
$config->setPactSpecificationVersion('4.0.0');
$builder = new InteractionBuilder($config);
$builder
    ->key('key')
    ->pending(true) // other PR
    ->comments(['key' => 'value']) // other PR
    ->given('Get Goodbye')
    ->uponReceiving('A get request to /goodbye/{name}')
    ->with($request)
    ->willRespondWith($response);
```


Is this okay?

Should I change to `setKey`, `setPending` `setComments`?
Should I change to `withKey`, `withPending`, `withComments` ?

What do you think? cc @YOU54F @JP-Ellis 