### PR TITLE
feat: Allow mark interaction as pending for v4

### DIFF
--- a/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
@@ -69,7 +69,7 @@ final class ConsumerContext implements Context
      */
     public function theHttpInteractionIsMarkedAsPending(): void
     {
-        throw new PendingException("Can't set interaction's pending using FFI call");
+        $this->interaction->setPending(true);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
@@ -59,7 +59,7 @@ final class ConsumerContext implements Context
      */
     public function theMessageInteractionIsMarkedAsPending(): void
     {
-        throw new PendingException("Can't set message's pending using FFI call");
+        $this->message->setPending(true);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
@@ -61,7 +61,7 @@ final class ConsumerContext implements Context
      */
     public function theSynchronousMessageInteractionIsMarkedAsPending(): void
     {
-        throw new PendingException("Can't set sync message's pending using FFI call");
+        $this->message->setPending(true);
     }
 
     /**

--- a/src/PhpPact/Consumer/AbstractMessageBuilder.php
+++ b/src/PhpPact/Consumer/AbstractMessageBuilder.php
@@ -66,4 +66,14 @@ abstract class AbstractMessageBuilder implements BuilderInterface
 
         return $this;
     }
+
+    /**
+     * Mark the message interaction as pending. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     */
+    public function pending(?bool $pending): self
+    {
+        $this->message->setPending($pending);
+
+        return $this;
+    }
 }

--- a/src/PhpPact/Consumer/Driver/Exception/InteractionPendingNotSetException.php
+++ b/src/PhpPact/Consumer/Driver/Exception/InteractionPendingNotSetException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Exception;
+
+class InteractionPendingNotSetException extends DriverException
+{
+}

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
@@ -3,6 +3,7 @@
 namespace PhpPact\Consumer\Driver\Interaction;
 
 use PhpPact\Consumer\Driver\Exception\InteractionKeyNotSetException;
+use PhpPact\Consumer\Driver\Exception\InteractionPendingNotSetException;
 use PhpPact\Consumer\Model\Interaction;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\FFI\ClientInterface;
@@ -23,6 +24,18 @@ abstract class AbstractDriver
         $success = $this->client->call('pactffi_set_key', $interaction->getHandle(), $key);
         if (!$success) {
             throw new InteractionKeyNotSetException(sprintf("Can not set the key '%s' for the interaction '%s'", $key, $interaction->getDescription()));
+        }
+    }
+
+    protected function setPending(Interaction|Message $interaction): void
+    {
+        $pending = $interaction->getPending();
+        if (null === $pending) {
+            return;
+        }
+        $success = $this->client->call('pactffi_set_pending', $interaction->getHandle(), $pending);
+        if (!$success) {
+            throw new InteractionPendingNotSetException(sprintf("Can not mark interaction '%s' as pending", $interaction->getDescription()));
         }
     }
 }

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
@@ -29,6 +29,7 @@ abstract class AbstractMessageDriver extends AbstractDriver implements SharedMes
         $this->withMetadata($message);
         $this->withContents($message);
         $this->setKey($message);
+        $this->setPending($message);
     }
 
     public function writePactAndCleanUp(): void

--- a/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
@@ -42,6 +42,7 @@ class InteractionDriver extends AbstractDriver implements InteractionDriverInter
         $this->withRequest($interaction);
         $this->willRespondWith($interaction);
         $this->setKey($interaction);
+        $this->setPending($interaction);
 
         if ($startMockServer) {
             $this->mockServer->start();

--- a/src/PhpPact/Consumer/InteractionBuilder.php
+++ b/src/PhpPact/Consumer/InteractionBuilder.php
@@ -85,4 +85,14 @@ class InteractionBuilder implements BuilderInterface
 
         return $this;
     }
+
+    /**
+     * Mark the interaction as pending. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     */
+    public function pending(?bool $pending): self
+    {
+        $this->interaction->setPending($pending);
+
+        return $this;
+    }
 }

--- a/src/PhpPact/Consumer/Model/Interaction.php
+++ b/src/PhpPact/Consumer/Model/Interaction.php
@@ -9,6 +9,7 @@ use PhpPact\Consumer\Model\Body\Text;
 use PhpPact\Consumer\Model\Interaction\DescriptionTrait;
 use PhpPact\Consumer\Model\Interaction\HandleTrait;
 use PhpPact\Consumer\Model\Interaction\KeyTrait;
+use PhpPact\Consumer\Model\Interaction\PendingTrait;
 
 /**
  * Request/Response Pair to be posted to the Mock Server for PACT tests.
@@ -19,6 +20,7 @@ class Interaction
     use DescriptionTrait;
     use HandleTrait;
     use KeyTrait;
+    use PendingTrait;
 
     private ConsumerRequest $request;
 

--- a/src/PhpPact/Consumer/Model/Interaction/PendingTrait.php
+++ b/src/PhpPact/Consumer/Model/Interaction/PendingTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\Consumer\Model\Interaction;
+
+trait PendingTrait
+{
+    private ?bool $pending = null;
+
+    public function getPending(): ?bool
+    {
+        return $this->pending;
+    }
+
+    public function setPending(?bool $pending): self
+    {
+        $this->pending = $pending;
+
+        return $this;
+    }
+}

--- a/src/PhpPact/Consumer/Model/Message.php
+++ b/src/PhpPact/Consumer/Model/Message.php
@@ -11,6 +11,7 @@ use PhpPact\Consumer\Model\Body\Text;
 use PhpPact\Consumer\Model\Interaction\DescriptionTrait;
 use PhpPact\Consumer\Model\Interaction\HandleTrait;
 use PhpPact\Consumer\Model\Interaction\KeyTrait;
+use PhpPact\Consumer\Model\Interaction\PendingTrait;
 
 /**
  * Message metadata and contents to be posted to the Mock Server for PACT tests.
@@ -21,6 +22,7 @@ class Message
     use DescriptionTrait;
     use HandleTrait;
     use KeyTrait;
+    use PendingTrait;
 
     /**
      * @var array<string, string>

--- a/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
+++ b/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\Consumer\Driver\Interaction;
 
 use PhpPact\Consumer\Driver\Body\MessageBodyDriverInterface;
 use PhpPact\Consumer\Driver\Exception\InteractionKeyNotSetException;
+use PhpPact\Consumer\Driver\Exception\InteractionPendingNotSetException;
 use PhpPact\Consumer\Driver\Pact\PactDriverInterface;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\Consumer\Model\Pact\Pact;
@@ -126,6 +127,39 @@ class SyncMessageDriverTest extends TestCase
         if (!$success) {
             $this->expectException(InteractionKeyNotSetException::class);
             $this->expectExceptionMessage("Can not set the key '$key' for the interaction '{$this->description}'");
+        }
+        $this->assertClientCalls($calls);
+        $this->driver->registerMessage($this->message);
+    }
+
+    #[TestWith([null, true])]
+    #[TestWith([null, true])]
+    #[TestWith([true, false])]
+    #[TestWith([true, true])]
+    #[TestWith([false, false])]
+    #[TestWith([false, true])]
+    public function testSetPending(?bool $pending, $success): void
+    {
+        $this->message->setPending($pending);
+        $this->pactDriver
+            ->expects($this->once())
+            ->method('getPact')
+            ->willReturn(new Pact($this->pactHandle));
+        $calls = [
+            ['pactffi_new_sync_message_interaction', $this->pactHandle, $this->description, $this->messageHandle],
+            ['pactffi_given', $this->messageHandle, 'item exist', null],
+            ['pactffi_given_with_param', $this->messageHandle, 'item exist', 'id', '12', null],
+            ['pactffi_given_with_param', $this->messageHandle, 'item exist', 'name', 'abc', null],
+            ['pactffi_message_expects_to_receive', $this->messageHandle, $this->description, null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
+        ];
+        if (is_bool($pending)) {
+            $calls[] = ['pactffi_set_pending', $this->messageHandle, $pending, $success];
+        }
+        if (!$success) {
+            $this->expectException(InteractionPendingNotSetException::class);
+            $this->expectExceptionMessage("Can not mark interaction '{$this->description}' as pending");
         }
         $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);


### PR DESCRIPTION
- Allow marking interaction/message interaction as pending
- This is for v4, using this feature on <= v3 doesn't have any effect to the pact file
- Update compatibility suite to use this feature
- Add method `pending(bool)` to builders for end-users