### PR TITLE
feat: Allow set comments for interaction in v4

### DIFF
--- a/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
@@ -61,7 +61,7 @@ final class ConsumerContext implements Context
     public function theFirstInteractionInThePactFileWillHave(string $name, string $value): void
     {
         $pact = json_decode(file_get_contents($this->pactPath), true);
-        Assert::assertSame(json_decode($value), $pact['interactions'][0][$name]);
+        Assert::assertJsonStringEqualsJsonString($value, json_encode($pact['interactions'][0][$name]));
     }
 
     /**
@@ -77,7 +77,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheHttpInteraction(string $value): void
     {
-        throw new PendingException("Can't set interaction's comment using FFI call");
+        $this->interaction->setComments(['text' => json_encode([$value])]);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
@@ -67,7 +67,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheMessageInteraction(string $value): void
     {
-        throw new PendingException("Can't set message's comment using FFI call");
+        $this->message->setComments(['text' => json_encode([$value])]);
     }
 
     /**
@@ -76,6 +76,6 @@ final class ConsumerContext implements Context
     public function theFirstInteractionInThePactFileWillHave(string $name, string $value): void
     {
         $pact = json_decode(file_get_contents($this->pactPath), true);
-        Assert::assertSame(json_decode($value), $pact['interactions'][0][$name]);
+        Assert::assertJsonStringEqualsJsonString($value, json_encode($pact['interactions'][0][$name]));
     }
 }

--- a/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
@@ -69,7 +69,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheSynchronousMessageInteraction(string $value): void
     {
-        throw new PendingException("Can't set message's comment using FFI call");
+        $this->message->setComments(['text' => json_encode([$value])]);
     }
 
     /**
@@ -78,7 +78,7 @@ final class ConsumerContext implements Context
     public function theFirstInteractionInThePactFileWillHave(string $name, string $value): void
     {
         $pact = json_decode(file_get_contents($this->pactPath), true);
-        Assert::assertSame(json_decode($value), $pact['interactions'][0][$name]);
+        Assert::assertJsonStringEqualsJsonString($value, json_encode($pact['interactions'][0][$name]));
     }
 
     /**

--- a/src/PhpPact/Consumer/AbstractMessageBuilder.php
+++ b/src/PhpPact/Consumer/AbstractMessageBuilder.php
@@ -76,4 +76,16 @@ abstract class AbstractMessageBuilder implements BuilderInterface
 
         return $this;
     }
+
+    /**
+     * Add comments to the message interaction. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     *
+     * @param array<string, string> $comments
+     */
+    public function comments(array $comments): self
+    {
+        $this->message->setComments($comments);
+
+        return $this;
+    }
 }

--- a/src/PhpPact/Consumer/Driver/Exception/InteractionCommentNotSetException.php
+++ b/src/PhpPact/Consumer/Driver/Exception/InteractionCommentNotSetException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Consumer\Driver\Exception;
+
+class InteractionCommentNotSetException extends DriverException
+{
+}

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Consumer\Driver\Interaction;
 
+use PhpPact\Consumer\Driver\Exception\InteractionCommentNotSetException;
 use PhpPact\Consumer\Driver\Exception\InteractionKeyNotSetException;
 use PhpPact\Consumer\Driver\Exception\InteractionPendingNotSetException;
 use PhpPact\Consumer\Model\Interaction;
@@ -36,6 +37,16 @@ abstract class AbstractDriver
         $success = $this->client->call('pactffi_set_pending', $interaction->getHandle(), $pending);
         if (!$success) {
             throw new InteractionPendingNotSetException(sprintf("Can not mark interaction '%s' as pending", $interaction->getDescription()));
+        }
+    }
+
+    protected function setComments(Interaction|Message $interaction): void
+    {
+        foreach ($interaction->getComments() as $key => $value) {
+            $success = $this->client->call('pactffi_set_comment', $interaction->getHandle(), $key, $value);
+            if (!$success) {
+                throw new InteractionCommentNotSetException(sprintf("Can add comment '%s' to the interaction '%s'", $key, $interaction->getDescription()));
+            }
         }
     }
 }

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
@@ -30,6 +30,7 @@ abstract class AbstractMessageDriver extends AbstractDriver implements SharedMes
         $this->withContents($message);
         $this->setKey($message);
         $this->setPending($message);
+        $this->setComments($message);
     }
 
     public function writePactAndCleanUp(): void

--- a/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
@@ -43,6 +43,7 @@ class InteractionDriver extends AbstractDriver implements InteractionDriverInter
         $this->willRespondWith($interaction);
         $this->setKey($interaction);
         $this->setPending($interaction);
+        $this->setComments($interaction);
 
         if ($startMockServer) {
             $this->mockServer->start();

--- a/src/PhpPact/Consumer/InteractionBuilder.php
+++ b/src/PhpPact/Consumer/InteractionBuilder.php
@@ -95,4 +95,16 @@ class InteractionBuilder implements BuilderInterface
 
         return $this;
     }
+
+    /**
+     * Add comments to the interaction. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     *
+     * @param array<string, string> $comments
+     */
+    public function comments(array $comments): self
+    {
+        $this->interaction->setComments($comments);
+
+        return $this;
+    }
 }

--- a/src/PhpPact/Consumer/Model/Interaction.php
+++ b/src/PhpPact/Consumer/Model/Interaction.php
@@ -6,6 +6,7 @@ use PhpPact\Consumer\Driver\Enum\InteractionPart;
 use PhpPact\Consumer\Model\Body\Binary;
 use PhpPact\Consumer\Model\Body\Multipart;
 use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\Interaction\CommentsTrait;
 use PhpPact\Consumer\Model\Interaction\DescriptionTrait;
 use PhpPact\Consumer\Model\Interaction\HandleTrait;
 use PhpPact\Consumer\Model\Interaction\KeyTrait;
@@ -21,6 +22,7 @@ class Interaction
     use HandleTrait;
     use KeyTrait;
     use PendingTrait;
+    use CommentsTrait;
 
     private ConsumerRequest $request;
 

--- a/src/PhpPact/Consumer/Model/Interaction/CommentsTrait.php
+++ b/src/PhpPact/Consumer/Model/Interaction/CommentsTrait.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PhpPact\Consumer\Model\Interaction;
+
+trait CommentsTrait
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $comments = [];
+
+    /**
+     * @return array<string, string>
+     */
+    public function getComments(): array
+    {
+        return $this->comments;
+    }
+
+    /**
+     * @param array<string, string> $comments
+     */
+    public function setComments(array $comments): self
+    {
+        $this->comments = [];
+        foreach ($comments as $key => $value) {
+            $this->comments[$key] = $value;
+        }
+
+        return $this;
+    }
+}

--- a/src/PhpPact/Consumer/Model/Message.php
+++ b/src/PhpPact/Consumer/Model/Message.php
@@ -8,6 +8,7 @@ use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PhpPact\Consumer\Model\Body\Binary;
 use PhpPact\Consumer\Model\Body\Multipart;
 use PhpPact\Consumer\Model\Body\Text;
+use PhpPact\Consumer\Model\Interaction\CommentsTrait;
 use PhpPact\Consumer\Model\Interaction\DescriptionTrait;
 use PhpPact\Consumer\Model\Interaction\HandleTrait;
 use PhpPact\Consumer\Model\Interaction\KeyTrait;
@@ -23,6 +24,7 @@ class Message
     use HandleTrait;
     use KeyTrait;
     use PendingTrait;
+    use CommentsTrait;
 
     /**
      * @var array<string, string>

--- a/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
@@ -3,6 +3,7 @@
 namespace PhpPactTest\Consumer\Driver\Interaction;
 
 use PhpPact\Consumer\Driver\Body\MessageBodyDriverInterface;
+use PhpPact\Consumer\Driver\Exception\InteractionCommentNotSetException;
 use PhpPact\Consumer\Driver\Exception\InteractionKeyNotSetException;
 use PhpPact\Consumer\Driver\Exception\InteractionPendingNotSetException;
 use PhpPact\Consumer\Driver\Interaction\MessageDriver;
@@ -158,6 +159,36 @@ class MessageDriverTest extends TestCase
         if (!$success) {
             $this->expectException(InteractionPendingNotSetException::class);
             $this->expectExceptionMessage("Can not mark interaction '{$this->description}' as pending");
+        }
+        $this->assertClientCalls($calls);
+        $this->driver->registerMessage($this->message);
+    }
+
+    #[TestWith([[], true])]
+    #[TestWith([['key1' => 'value1'], false])]
+    #[TestWith([['key2' => 'value2', 'key3' => 'value3'], true])]
+    public function testSetComments(array $comments, $success): void
+    {
+        $this->message->setComments($comments);
+        $this->pactDriver
+            ->expects($this->once())
+            ->method('getPact')
+            ->willReturn(new Pact($this->pactHandle));
+        $calls = [
+            ['pactffi_new_message_interaction', $this->pactHandle, $this->description, $this->messageHandle],
+            ['pactffi_message_given', $this->messageHandle, 'item exist', null],
+            ['pactffi_message_given_with_param', $this->messageHandle, 'item exist', 'id', '12', null],
+            ['pactffi_message_given_with_param', $this->messageHandle, 'item exist', 'name', 'abc', null],
+            ['pactffi_message_expects_to_receive', $this->messageHandle, $this->description, null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
+        ];
+        foreach ($comments as $key => $value) {
+            $calls[] = ['pactffi_set_comment', $this->messageHandle, $key, $value, $success];
+        }
+        if (!$success) {
+            $this->expectException(InteractionCommentNotSetException::class);
+            $this->expectExceptionMessage("Can add comment '$key' to the interaction '{$this->description}'");
         }
         $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);


### PR DESCRIPTION
- Allow adding comments to interaction/message interaction
- This is for v4, using this feature on <= v3 doesn't have any effect to the pact file
- Update compatibility suite to use this feature
  - Related PR https://github.com/pact-foundation/pact-compatibility-suite/pull/8
- Add method `comments(array)` to builders for end-users