### PR TITLE
ci: Update PHP to 8.3 for MacOS 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
           - os: ubuntu-latest
             php: 8.1
           - os: macos-12
-            php: 8.2
+            php: 8.3
           - os: macos-14
             php: 8.2
           - os: windows-latest


### PR DESCRIPTION
* PHP `8.3` replace `8.2` as default version in `macos-12` https://github.com/shivammathur/setup-php/commit/88841d1465a6792bd2428eb9e67f05bfbb15c304
* Time to install PHP reduced from `2m 12s` to `1m 16s`