### PR TITLE
feat: Allow sending csv body in request

### DIFF
--- a/example/csv/consumer/tests/Service/HttpClientServiceTest.php
+++ b/example/csv/consumer/tests/Service/HttpClientServiceTest.php
@@ -3,6 +3,7 @@
 namespace CsvConsumer\Tests\Service;
 
 use CsvConsumer\Service\HttpClientService;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
 use PhpPact\Consumer\InteractionBuilder;
 use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
 use PhpPact\Consumer\Matcher\Matcher;
@@ -49,7 +50,7 @@ class HttpClientServiceTest extends TestCase
         if ($logLevel = \getenv('PACT_LOGLEVEL')) {
             $config->setLogLevel($logLevel);
         }
-        $builder = new InteractionBuilder($config, new CsvInteractionDriverFactory());
+        $builder = new InteractionBuilder($config, new CsvInteractionDriverFactory(InteractionPart::RESPONSE));
         $builder
             ->given('report.csv file exist')
             ->uponReceiving('request for a report.csv')

--- a/src/PhpPact/Plugins/Csv/Exception/CsvException.php
+++ b/src/PhpPact/Plugins/Csv/Exception/CsvException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Plugins\Csv\Exception;
+
+use PhpPact\Exception\BaseException;
+
+class CsvException extends BaseException
+{
+}

--- a/src/PhpPact/Plugins/Csv/Exception/MissingPluginPartsException.php
+++ b/src/PhpPact/Plugins/Csv/Exception/MissingPluginPartsException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Plugins\Csv\Exception;
+
+class MissingPluginPartsException extends CsvException
+{
+}

--- a/src/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactory.php
+++ b/src/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactory.php
@@ -2,27 +2,44 @@
 
 namespace PhpPact\Plugins\Csv\Factory;
 
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
 use PhpPact\Consumer\Driver\Interaction\InteractionDriver;
 use PhpPact\Consumer\Driver\Interaction\InteractionDriverInterface;
+use PhpPact\Consumer\Driver\InteractionPart\RequestDriver;
 use PhpPact\Consumer\Driver\InteractionPart\ResponseDriver;
 use PhpPact\Consumer\Factory\InteractionDriverFactoryInterface;
 use PhpPact\FFI\Client;
 use PhpPact\Plugin\Driver\Body\PluginBodyDriver;
 use PhpPact\Plugins\Csv\Driver\Body\CsvBodyDriver;
+use PhpPact\Plugins\Csv\Exception\MissingPluginPartsException;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;
 use PhpPact\Consumer\Service\MockServer;
 use PhpPact\Plugins\Csv\Driver\Pact\CsvPactDriver;
 
 class CsvInteractionDriverFactory implements InteractionDriverFactoryInterface
 {
+    /**
+     * @var InteractionPart[]
+     */
+    private array $pluginParts;
+
+    public function __construct(InteractionPart ...$pluginParts)
+    {
+        if (empty($pluginParts)) {
+            throw new MissingPluginPartsException('At least 1 interaction part must be csv');
+        }
+        $this->pluginParts = $pluginParts;
+    }
+
     public function create(MockServerConfigInterface $config): InteractionDriverInterface
     {
         $client = new Client();
         $pactDriver = new CsvPactDriver($client, $config);
         $mockServer = new MockServer($client, $pactDriver, $config);
         $csvBodyDriver = new CsvBodyDriver(new PluginBodyDriver($client));
-        $responseDriver = new ResponseDriver($client, $csvBodyDriver);
+        $requestDriver = in_array(InteractionPart::REQUEST, $this->pluginParts) ? new RequestDriver($client, $csvBodyDriver) : null;
+        $responseDriver = in_array(InteractionPart::RESPONSE, $this->pluginParts) ? new ResponseDriver($client, $csvBodyDriver) : null;
 
-        return new InteractionDriver($client, $mockServer, $pactDriver, null, $responseDriver);
+        return new InteractionDriver($client, $mockServer, $pactDriver, $requestDriver, $responseDriver);
     }
 }

--- a/tests/PhpPact/Helper/FactoryTrait.php
+++ b/tests/PhpPact/Helper/FactoryTrait.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPactTest\Helper;
+
+use ReflectionProperty;
+
+trait FactoryTrait
+{
+    /**
+     * @param array<string, string> $properties
+     */
+    private function assertPropertiesInstanceOf(object $object, ?string $class, array $properties): void
+    {
+        foreach ($properties as $property => $propertyClass) {
+            $reflection = new ReflectionProperty($class ?? $object, $property);
+            $value = $reflection->getValue($object);
+            $this->assertInstanceOf($propertyClass, $value);
+        }
+    }
+}

--- a/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
@@ -2,17 +2,23 @@
 
 namespace PhpPactTest\Plugins\Csv\Factory;
 
-use PhpPact\Consumer\Driver\Body\InteractionBodyDriverInterface;
+use PhpPact\Consumer\Driver\Body\InteractionBodyDriver;
 use PhpPact\Consumer\Driver\Enum\InteractionPart;
 use PhpPact\Consumer\Driver\Interaction\InteractionDriverInterface;
 use PhpPact\Consumer\Driver\InteractionPart\AbstractInteractionPartDriver;
+use PhpPact\Consumer\Driver\InteractionPart\RequestDriver;
 use PhpPact\Consumer\Driver\InteractionPart\RequestDriverInterface;
+use PhpPact\Consumer\Driver\InteractionPart\ResponseDriver;
 use PhpPact\Consumer\Driver\InteractionPart\ResponseDriverInterface;
 use PhpPact\Consumer\Factory\InteractionDriverFactoryInterface;
+use PhpPact\Consumer\Service\MockServer;
+use PhpPact\FFI\Client;
 use PhpPact\Plugins\Csv\Driver\Body\CsvBodyDriver;
+use PhpPact\Plugins\Csv\Driver\Pact\CsvPactDriver;
 use PhpPact\Plugins\Csv\Exception\MissingPluginPartsException;
 use PhpPact\Plugins\Csv\Factory\CsvInteractionDriverFactory;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;
+use PhpPactTest\Helper\FactoryTrait;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -20,6 +26,8 @@ use ReflectionProperty;
 
 class CsvInteractionDriverFactoryTest extends TestCase
 {
+    use FactoryTrait;
+
     private InteractionDriverFactoryInterface $factory;
     private MockServerConfigInterface|MockObject $config;
 
@@ -39,18 +47,23 @@ class CsvInteractionDriverFactoryTest extends TestCase
     {
         $this->factory = new CsvInteractionDriverFactory(...$pluginParts);
         $driver = $this->factory->create($this->config);
-        $requestBodyDriver = $this->getBodyDriver($this->getRequestDriver($driver));
-        if (in_array(InteractionPart::REQUEST, $pluginParts)) {
-            $this->assertCsvBodyDriver($requestBodyDriver);
-        } else {
-            $this->assertNotCsvBodyDriver($requestBodyDriver);
-        }
-        $responseBodyDriver = $this->getBodyDriver($this->getResponseDriver($driver));
-        if (in_array(InteractionPart::RESPONSE, $pluginParts)) {
-            $this->assertCsvBodyDriver($responseBodyDriver);
-        } else {
-            $this->assertNotCsvBodyDriver($responseBodyDriver);
-        }
+        $this->assertPropertiesInstanceOf($driver, null, [
+            'client' => Client::class,
+            'mockServer' => MockServer::class,
+            'pactDriver' => CsvPactDriver::class,
+            'requestDriver' => RequestDriver::class,
+            'responseDriver' => ResponseDriver::class,
+        ]);
+        $requestDriver = $this->getRequestDriver($driver);
+        $this->assertPropertiesInstanceOf($requestDriver, AbstractInteractionPartDriver::class, [
+            'client' => Client::class,
+            'bodyDriver' => in_array(InteractionPart::REQUEST, $pluginParts) ? CsvBodyDriver::class : InteractionBodyDriver::class,
+        ]);
+        $responseDriver = $this->getResponseDriver($driver);
+        $this->assertPropertiesInstanceOf($responseDriver, AbstractInteractionPartDriver::class, [
+            'client' => Client::class,
+            'bodyDriver' => in_array(InteractionPart::RESPONSE, $pluginParts) ? CsvBodyDriver::class : InteractionBodyDriver::class,
+        ]);
     }
 
     public function testMissingPluginPartsException(): void
@@ -73,22 +86,5 @@ class CsvInteractionDriverFactoryTest extends TestCase
         $reflection = new ReflectionProperty($driver, 'responseDriver');
 
         return $reflection->getValue($driver);
-    }
-
-    private function assertCsvBodyDriver(InteractionBodyDriverInterface $bodyDriver): void
-    {
-        $this->assertInstanceOf(CsvBodyDriver::class, $bodyDriver);
-    }
-
-    private function assertNotCsvBodyDriver(InteractionBodyDriverInterface $bodyDriver): void
-    {
-        $this->assertNotInstanceOf(CsvBodyDriver::class, $bodyDriver);
-    }
-
-    private function getBodyDriver(RequestDriverInterface|ResponseDriverInterface $interactionPartDriver): InteractionBodyDriverInterface
-    {
-        $reflection = new ReflectionProperty(AbstractInteractionPartDriver::class, 'bodyDriver');
-
-        return $reflection->getValue($interactionPartDriver);
     }
 }

--- a/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace PhpPactTest\Plugins\Csv\Factory;
+
+use PhpPact\Consumer\Driver\Body\InteractionBodyDriverInterface;
+use PhpPact\Consumer\Driver\Enum\InteractionPart;
+use PhpPact\Consumer\Driver\Interaction\InteractionDriverInterface;
+use PhpPact\Consumer\Driver\InteractionPart\AbstractInteractionPartDriver;
+use PhpPact\Consumer\Driver\InteractionPart\RequestDriverInterface;
+use PhpPact\Consumer\Driver\InteractionPart\ResponseDriverInterface;
+use PhpPact\Consumer\Factory\InteractionDriverFactoryInterface;
+use PhpPact\Plugins\Csv\Driver\Body\CsvBodyDriver;
+use PhpPact\Plugins\Csv\Exception\MissingPluginPartsException;
+use PhpPact\Plugins\Csv\Factory\CsvInteractionDriverFactory;
+use PhpPact\Standalone\MockService\MockServerConfigInterface;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+class CsvInteractionDriverFactoryTest extends TestCase
+{
+    private InteractionDriverFactoryInterface $factory;
+    private MockServerConfigInterface|MockObject $config;
+
+    public function setUp(): void
+    {
+        $this->config = $this->createMock(MockServerConfigInterface::class);
+        $this->config
+            ->expects($this->any())
+            ->method('getPactSpecificationVersion')
+            ->willReturn('4.0.0');
+    }
+
+    #[TestWith([InteractionPart::REQUEST])]
+    #[TestWith([InteractionPart::RESPONSE])]
+    #[TestWith([InteractionPart::REQUEST, InteractionPart::RESPONSE])]
+    public function testCreate(InteractionPart ...$pluginParts): void
+    {
+        $this->factory = new CsvInteractionDriverFactory(...$pluginParts);
+        $driver = $this->factory->create($this->config);
+        $requestBodyDriver = $this->getBodyDriver($this->getRequestDriver($driver));
+        if (in_array(InteractionPart::REQUEST, $pluginParts)) {
+            $this->assertCsvBodyDriver($requestBodyDriver);
+        } else {
+            $this->assertNotCsvBodyDriver($requestBodyDriver);
+        }
+        $responseBodyDriver = $this->getBodyDriver($this->getResponseDriver($driver));
+        if (in_array(InteractionPart::RESPONSE, $pluginParts)) {
+            $this->assertCsvBodyDriver($responseBodyDriver);
+        } else {
+            $this->assertNotCsvBodyDriver($responseBodyDriver);
+        }
+    }
+
+    public function testMissingPluginPartsException(): void
+    {
+        $this->expectException(MissingPluginPartsException::class);
+        $this->expectExceptionMessage('At least 1 interaction part must be csv');
+        $this->factory = new CsvInteractionDriverFactory();
+        $this->factory->create($this->config);
+    }
+
+    private function getRequestDriver(InteractionDriverInterface $driver): RequestDriverInterface
+    {
+        $reflection = new ReflectionProperty($driver, 'requestDriver');
+
+        return $reflection->getValue($driver);
+    }
+
+    private function getResponseDriver(InteractionDriverInterface $driver): ResponseDriverInterface
+    {
+        $reflection = new ReflectionProperty($driver, 'responseDriver');
+
+        return $reflection->getValue($driver);
+    }
+
+    private function assertCsvBodyDriver(InteractionBodyDriverInterface $bodyDriver): void
+    {
+        $this->assertInstanceOf(CsvBodyDriver::class, $bodyDriver);
+    }
+
+    private function assertNotCsvBodyDriver(InteractionBodyDriverInterface $bodyDriver): void
+    {
+        $this->assertNotInstanceOf(CsvBodyDriver::class, $bodyDriver);
+    }
+
+    private function getBodyDriver(RequestDriverInterface|ResponseDriverInterface $interactionPartDriver): InteractionBodyDriverInterface
+    {
+        $reflection = new ReflectionProperty(AbstractInteractionPartDriver::class, 'bodyDriver');
+
+        return $reflection->getValue($interactionPartDriver);
+    }
+}


### PR DESCRIPTION
Currently `CsvInteractionDriverFactory` only support csv in response.

This PR also support csv in request.