### PR TITLE
fix: Fix unknown specification not working

### DIFF
--- a/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
+++ b/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
@@ -63,11 +63,11 @@ class PactDriver implements PactDriverInterface
             $this->versionEqualTo('2.0.0') => $this->client->get('PactSpecification_V2'),
             $this->versionEqualTo('3.0.0') => $this->client->get('PactSpecification_V3'),
             $this->versionEqualTo('4.0.0') => $this->client->get('PactSpecification_V4'),
-            default => function () {
+            default => call_user_func(function () {
                 trigger_error(sprintf("Specification version '%s' is unknown", $this->config->getPactSpecificationVersion()), E_USER_WARNING);
 
                 return $this->client->get('PactSpecification_Unknown');
-            },
+            }),
         };
     }
 

--- a/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
@@ -55,6 +55,8 @@ class PactDriverTest extends TestCase
     #[TestWith(['error', '1.0.0', self::SPEC_V1])]
     #[TestWith(['off'  , '1.1.0', self::SPEC_V1_1])]
     #[TestWith(['none' , '2.0.0', self::SPEC_V2])]
+    #[TestWith([null   , '0.1.2', self::SPEC_UNKNOWN])]
+    #[TestWith([null   , 'x.y.z', self::SPEC_UNKNOWN])]
     public function testSetUp(?string $logLevel, string $version, int $specificationHandle): void
     {
         $this->assertConfig($logLevel, $version);


### PR DESCRIPTION
Fix `TypeError: PhpPact\Consumer\Driver\Pact\PactDriver::getSpecification(): Return value must be of type int, Closure returned`