### PR TITLE
fix: Fix 'call to unknown method' warning in ide

### DIFF
--- a/src/PhpPact/Standalone/ProviderVerifier/Model/Source/Url.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/Source/Url.php
@@ -16,7 +16,7 @@ class Url implements UrlInterface
         return $this->url;
     }
 
-    public function setUrl(UriInterface $url): self
+    public function setUrl(UriInterface $url): static
     {
         $this->url = $url;
 
@@ -28,7 +28,7 @@ class Url implements UrlInterface
         return $this->token;
     }
 
-    public function setToken(?string $token): self
+    public function setToken(?string $token): static
     {
         $this->token = $token;
 
@@ -40,7 +40,7 @@ class Url implements UrlInterface
         return $this->username;
     }
 
-    public function setUsername(string $username): self
+    public function setUsername(string $username): static
     {
         $this->username = $username;
 
@@ -52,7 +52,7 @@ class Url implements UrlInterface
         return $this->password;
     }
 
-    public function setPassword(string $password): self
+    public function setPassword(string $password): static
     {
         $this->password = $password;
 

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/Source/UrlInterface.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/Source/UrlInterface.php
@@ -8,17 +8,17 @@ interface UrlInterface
 {
     public function getUrl(): UriInterface;
 
-    public function setUrl(UriInterface $url): self;
+    public function setUrl(UriInterface $url): static;
 
     public function getToken(): ?string;
 
-    public function setToken(?string $token): self;
+    public function setToken(?string $token): static;
 
     public function getUsername(): ?string;
 
-    public function setUsername(string $username): self;
+    public function setUsername(string $username): static;
 
     public function getPassword(): ?string;
 
-    public function setPassword(string $password): self;
+    public function setPassword(string $password): static;
 }


### PR DESCRIPTION
```php
interface UrlInterface
{
    public function setUrl(UriInterface $url): self;

    public function setToken(?string $token): self;

    public function setUsername(string $username): self;

    public function setPassword(string $password): self;
}

interface BrokerInterface extends UrlInterface
{
    // ...
}


        $broker = (new Broker())
            ->setUrl($url)
            ->setToken($token)
            ->setUsername($username)
            ->setPassword($password)
            ->setEnablePending($enablePending) // ide warning here
            ->setIncludeWipPactSince($wipPactSince)
            ->setProviderTags($providerTags)
            ->setProviderBranch($providerBranch)
            ->setConsumerVersionSelectors($consumerVersionSelectors)
            ->setConsumerVersionTags($consumerVersionTags);
```