### PR TITLE
revert: Set up pact on demand to speed up factory's unit tests

### DIFF
--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractMessageDriver.php
@@ -23,6 +23,7 @@ abstract class AbstractMessageDriver extends AbstractDriver implements SharedMes
 
     public function registerMessage(Message $message): void
     {
+        $this->pactDriver->setUp();
         $this->newInteraction($message);
         $this->given($message);
         $this->expectsToReceive($message);

--- a/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/InteractionDriver.php
@@ -36,6 +36,7 @@ class InteractionDriver extends AbstractDriver implements InteractionDriverInter
 
     public function registerInteraction(Interaction $interaction, bool $startMockServer = true): bool
     {
+        $this->pactDriver->setUp();
         $this->newInteraction($interaction);
         $this->given($interaction);
         $this->uponReceiving($interaction);

--- a/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
+++ b/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
@@ -17,7 +17,6 @@ class PactDriver implements PactDriverInterface
         protected ClientInterface $client,
         protected PactConfigInterface $config
     ) {
-        $this->setUp();
     }
 
     public function cleanUp(): void
@@ -48,8 +47,11 @@ class PactDriver implements PactDriverInterface
         return $this->pact;
     }
 
-    protected function setUp(): void
+    public function setUp(): void
     {
+        if ($this->pact) {
+            return;
+        }
         $this->initWithLogLevel();
         $this->newPact();
         $this->withSpecification();

--- a/src/PhpPact/Consumer/Driver/Pact/PactDriverInterface.php
+++ b/src/PhpPact/Consumer/Driver/Pact/PactDriverInterface.php
@@ -6,6 +6,8 @@ use PhpPact\Consumer\Model\Pact\Pact;
 
 interface PactDriverInterface
 {
+    public function setUp(): void;
+
     public function cleanUp(): void;
 
     public function writePact(): void;

--- a/src/PhpPact/Plugin/Driver/Pact/AbstractPluginPactDriver.php
+++ b/src/PhpPact/Plugin/Driver/Pact/AbstractPluginPactDriver.php
@@ -14,7 +14,7 @@ abstract class AbstractPluginPactDriver extends PactDriver
         parent::cleanUp();
     }
 
-    protected function setUp(): void
+    public function setUp(): void
     {
         parent::setUp();
         $this->usingPlugin();

--- a/tests/PhpPact/Consumer/Factory/InteractionDriverFactoryTest.php
+++ b/tests/PhpPact/Consumer/Factory/InteractionDriverFactoryTest.php
@@ -9,7 +9,6 @@ use PhpPact\Consumer\Service\MockServer;
 use PhpPact\FFI\Client;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;
 use PhpPactTest\Helper\FactoryTrait;
-use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -38,6 +37,5 @@ class InteractionDriverFactoryTest extends TestCase
             'mockServer' => MockServer::class,
             'pactDriver' => PactDriver::class,
         ]);
-        $this->cleanUp($driver);
     }
 }

--- a/tests/PhpPact/Consumer/Factory/MessageDriverFactoryTest.php
+++ b/tests/PhpPact/Consumer/Factory/MessageDriverFactoryTest.php
@@ -8,7 +8,6 @@ use PhpPact\Consumer\Factory\MessageDriverFactoryInterface;
 use PhpPact\FFI\Client;
 use PhpPact\Standalone\MockService\MockServerConfigInterface;
 use PhpPactTest\Helper\FactoryTrait;
-use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -36,6 +35,5 @@ class MessageDriverFactoryTest extends TestCase
             'client' => Client::class,
             'pactDriver' => PactDriver::class,
         ]);
-        $this->cleanUp($driver);
     }
 }

--- a/tests/PhpPact/Helper/FactoryTrait.php
+++ b/tests/PhpPact/Helper/FactoryTrait.php
@@ -2,7 +2,6 @@
 
 namespace PhpPactTest\Helper;
 
-use PhpPact\Consumer\Driver\Pact\PactDriverInterface;
 use ReflectionProperty;
 
 trait FactoryTrait
@@ -17,13 +16,5 @@ trait FactoryTrait
             $value = $reflection->getValue($object);
             $this->assertInstanceOf($propertyClass, $value);
         }
-    }
-
-    private function cleanUp(object $driver): void
-    {
-        $reflection = new ReflectionProperty($driver, 'pactDriver');
-        $pactDriver = $reflection->getValue($driver);
-        $this->assertInstanceOf(PactDriverInterface::class, $pactDriver);
-        $pactDriver->cleanUp();
     }
 }

--- a/tests/PhpPact/Plugin/Driver/Pact/AbstractPluginPactDriverTestCase.php
+++ b/tests/PhpPact/Plugin/Driver/Pact/AbstractPluginPactDriverTestCase.php
@@ -2,6 +2,7 @@
 
 namespace PhpPactTest\Plugin\Driver\Pact;
 
+use PhpPact\Consumer\Driver\Exception\MissingPactException;
 use PhpPact\Plugin\Driver\Pact\AbstractPluginPactDriver;
 use PhpPact\Plugin\Exception\PluginNotSupportedBySpecificationException;
 use PhpPactTest\Consumer\Driver\Pact\PactDriverTest;
@@ -34,6 +35,7 @@ abstract class AbstractPluginPactDriverTestCase extends PactDriverTest
             ));
         }
         $this->driver = $this->createPactDriver();
+        $this->driver->setUp();
     }
 
     public function testCleanUpPlugin(): void
@@ -48,6 +50,13 @@ abstract class AbstractPluginPactDriverTestCase extends PactDriverTest
         ];
         $this->assertClientCalls($calls);
         $this->driver = $this->createPactDriver();
+        $this->driver->setUp();
+        $this->driver->cleanUp();
+    }
+
+    public function testCleanUpPluginWithoutPact(): void
+    {
+        $this->expectException(MissingPactException::class);
         $this->driver->cleanUp();
     }
 

--- a/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
@@ -64,7 +64,6 @@ class CsvInteractionDriverFactoryTest extends TestCase
             'client' => Client::class,
             'bodyDriver' => in_array(InteractionPart::RESPONSE, $pluginParts) ? CsvBodyDriver::class : InteractionBodyDriver::class,
         ]);
-        $this->cleanUp($driver);
     }
 
     public function testMissingPluginPartsException(): void
@@ -72,7 +71,6 @@ class CsvInteractionDriverFactoryTest extends TestCase
         $this->expectException(MissingPluginPartsException::class);
         $this->expectExceptionMessage('At least 1 interaction part must be csv');
         $this->factory = new CsvInteractionDriverFactory();
-        $this->factory->create($this->config);
     }
 
     private function getRequestDriver(InteractionDriverInterface $driver): RequestDriverInterface

--- a/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufMessageDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufMessageDriverFactoryTest.php
@@ -38,6 +38,5 @@ class ProtobufMessageDriverFactoryTest extends TestCase
             'pactDriver' => PactDriver::class,
             'messageBodyDriver' => ProtobufMessageBodyDriver::class,
         ]);
-        $this->cleanUp($driver);
     }
 }

--- a/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufSyncMessageDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufSyncMessageDriverFactoryTest.php
@@ -42,6 +42,5 @@ class ProtobufSyncMessageDriverFactoryTest extends TestCase
         $this->assertPropertiesInstanceOf($driver, AbstractMessageDriver::class, [
             'messageBodyDriver' => ProtobufMessageBodyDriver::class,
         ]);
-        $this->cleanUp($driver);
     }
 }

--- a/tests/PhpPact/SyncMessage/Factory/SyncMessageDriverFactoryTest.php
+++ b/tests/PhpPact/SyncMessage/Factory/SyncMessageDriverFactoryTest.php
@@ -38,6 +38,5 @@ class SyncMessageDriverFactoryTest extends TestCase
             'mockServer' => MockServer::class,
             'pactDriver' => PactDriver::class,
         ]);
-        $this->cleanUp($driver);
     }
 }


### PR DESCRIPTION
Revert: set up pact manually when registering message/interaction to speed up factory's unit tests