### PR TITLE
refactor: Remove file_exists checking

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",
         "ramsey/uuid": "^4.7",
-        "mikey179/vfsstream": "^1.6.7",
         "pact-foundation/example-protobuf-sync-message-provider": "@dev"
     },
     "autoload": {

--- a/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriver.php
+++ b/src/PhpPact/Consumer/Driver/Body/InteractionBodyDriver.php
@@ -40,7 +40,7 @@ class InteractionBodyDriver implements InteractionBodyDriverInterface
                 foreach ($body->getParts() as $part) {
                     $result = $this->client->call('pactffi_with_multipart_file_v2', $interaction->getHandle(), $partId, $part->getContentType(), $part->getPath(), $part->getName(), $body->getBoundary());
                     if ($result->failed instanceof CData) {
-                        throw new PartNotAddedException(FFI::string($result->failed));
+                        throw new PartNotAddedException(sprintf("Can not add part '%s': %s", $part->getName(), FFI::string($result->failed)));
                     }
                 }
                 $success = true;

--- a/src/PhpPact/Consumer/Exception/PartNotExistException.php
+++ b/src/PhpPact/Consumer/Exception/PartNotExistException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace PhpPact\Consumer\Exception;
-
-use Exception;
-
-class PartNotExistException extends Exception
-{
-}

--- a/src/PhpPact/Consumer/Model/Body/Part.php
+++ b/src/PhpPact/Consumer/Model/Body/Part.php
@@ -2,17 +2,12 @@
 
 namespace PhpPact\Consumer\Model\Body;
 
-use PhpPact\Consumer\Exception\PartNotExistException;
-
 class Part
 {
     use ContentTypeTrait;
 
     public function __construct(private string $path, private string $name, string $contentType)
     {
-        if (!file_exists($path)) {
-            throw new PartNotExistException(sprintf('File %s does not exist', $path));
-        }
         $this->setContentType($contentType);
     }
 

--- a/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
@@ -4,8 +4,6 @@ namespace PhpPactTest\Consumer\Driver\Body;
 
 use FFI;
 use FFI\CData;
-use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use PhpPact\Consumer\Driver\Body\InteractionBodyDriver;
 use PhpPact\Consumer\Driver\Body\InteractionBodyDriverInterface;
 use PhpPact\Consumer\Driver\Enum\InteractionPart;
@@ -38,15 +36,9 @@ class InteractionBodyDriverTest extends TestCase
     private string $boundary = 'abcde12345';
     private CData $failed;
     private string $message = 'error';
-    private vfsStreamDirectory $root;
 
     public function setUp(): void
     {
-        $this->root = vfsStream::setup();
-        file_put_contents($this->root->url() . '/id.txt', 'text');
-        file_put_contents($this->root->url() . '/address.json', 'json');
-        file_put_contents($this->root->url() . '/image.png', 'image');
-
         $this->client = $this->createMock(ClientInterface::class);
         $this->client
             ->expects($this->once())
@@ -63,9 +55,9 @@ class InteractionBodyDriverTest extends TestCase
         $this->binary = new Binary(__DIR__ . '/../../../../_resources/image.jpg', 'image/jpeg');
         $this->text = new Text('example', 'text/plain');
         $this->parts = [
-            new Part($this->root->url() . '/id.txt', 'id', 'text/plain'),
-            new Part($this->root->url() . '/address.json', 'address', 'application/json'),
-            new Part($this->root->url() . '/image.png', 'profileImage', 'image/png'),
+            new Part('/path/to/id.txt', 'id', 'text/plain'),
+            new Part('/path/to//address.json', 'address', 'application/json'),
+            new Part('/path/to//image.png', 'profileImage', 'image/png'),
         ];
         $this->multipart = new Multipart($this->parts, $this->boundary);
         $this->failed = FFI::new('char[5]');
@@ -156,7 +148,7 @@ class InteractionBodyDriverTest extends TestCase
             );
         if (!$success) {
             $this->expectException(PartNotAddedException::class);
-            $this->expectExceptionMessage($this->message);
+            $this->expectExceptionMessage("Can not add part '{$this->parts[2]->getName()}': {$this->message}");
         }
         $this->driver->registerBody($this->interaction, InteractionPart::REQUEST);
     }
@@ -179,7 +171,7 @@ class InteractionBodyDriverTest extends TestCase
             );
         if (!$success) {
             $this->expectException(PartNotAddedException::class);
-            $this->expectExceptionMessage($this->message);
+            $this->expectExceptionMessage("Can not add part '{$this->parts[2]->getName()}': {$this->message}");
         }
         $this->driver->registerBody($this->interaction, InteractionPart::RESPONSE);
     }


### PR DESCRIPTION
File's path will be validated by core. Here is the error when the file does not exist:

```
PhpPact\Consumer\Exception\PartNotAddedException: Can not add part 'full_name': with_multipart_file: failed to generate multipart body - convert_ptr_to_mime_part_body: Failed to generate multipart body: No such file or directory (os error 2)
```