### PR TITLE
test: Test xml's mixed content

### DIFF
--- a/example/xml/consumer/tests/Service/HttpClientServiceTest.php
+++ b/example/xml/consumer/tests/Service/HttpClientServiceTest.php
@@ -27,6 +27,7 @@ class HttpClientServiceTest extends TestCase
         $xmlBuilder
             ->root(
                 $xmlBuilder->name('movies'),
+                $xmlBuilder->content('List of movies'),
                 $xmlBuilder->eachLike(
                     $xmlBuilder->examples(1),
                     $xmlBuilder->name('movie'),

--- a/example/xml/pacts/xmlConsumer-xmlProvider.json
+++ b/example/xml/pacts/xmlConsumer-xmlProvider.json
@@ -31,7 +31,7 @@
         "path": "/movies"
       },
       "response": {
-        "body": "<?xml version='1.0'?><movies><movie><title>Big Buck Bunny</title><characters><character><name>Big Buck Bunny</name><actor>Jan Morgenstern</actor></character><character><name/><actor/></character></characters><plot>The plot follows a day in the life of Big Buck Bunny, during which time he meets three bullying rodents: the leader, Frank the flying squirrel, and his sidekicks Rinky the red squirrel and Gimera the chinchilla.\nThe rodents amuse themselves by harassing helpless creatures of the forest by throwing fruits, nuts, and rocks at them.</plot><great-lines><line>Open source movie</line></great-lines><rating type='stars'>6</rating></movie></movies>",
+        "body": "<?xml version='1.0'?><movies><movie><title>Big Buck Bunny</title><characters><character><name>Big Buck Bunny</name><actor>Jan Morgenstern</actor></character><character><name/><actor/></character></characters><plot>The plot follows a day in the life of Big Buck Bunny, during which time he meets three bullying rodents: the leader, Frank the flying squirrel, and his sidekicks Rinky the red squirrel and Gimera the chinchilla.\nThe rodents amuse themselves by harassing helpless creatures of the forest by throwing fruits, nuts, and rocks at them.</plot><great-lines><line>Open source movie</line></great-lines><rating type='stars'>6</rating></movie>List of movies</movies>",
         "headers": {
           "Content-Type": "application/xml"
         },

--- a/example/xml/provider/public/index.php
+++ b/example/xml/provider/public/index.php
@@ -13,6 +13,7 @@ $app->get('/movies', function (Request $request, Response $response) {
         <<<XML
         <?xml version='1.0' standalone='yes'?>
         <movies>
+            List of movies
             <movie>
                 <title>PHP: Behind the Parser</title>
                 <characters>

--- a/tests/PhpPact/Xml/XmlBuilderTest.php
+++ b/tests/PhpPact/Xml/XmlBuilderTest.php
@@ -42,6 +42,7 @@ class XmlBuilderTest extends TestCase
                 $this->builder->name('ns1:projects'),
                 $this->builder->attribute('id', '1234'),
                 $this->builder->attribute('xmlns:ns1', 'http://some.namespace/and/more/stuff'),
+                $this->builder->content('List of projects'),
                 $this->builder->eachLike(
                     $this->builder->examples(2),
                     $this->builder->name('ns1:project'),
@@ -52,6 +53,7 @@ class XmlBuilderTest extends TestCase
                     $this->builder->contentLike('Project 1 description'),
                     $this->builder->add(
                         $this->builder->name('ns1:tasks'),
+                        $this->builder->content('List of tasks'),
                         $this->builder->eachLike(
                             $this->builder->examples(5),
                             $this->builder->name('ns1:task'),
@@ -110,6 +112,9 @@ class XmlBuilderTest extends TestCase
                                             ],
                                             'examples' => 5,
                                         ],
+                                        [
+                                            'content' => 'List of tasks',
+                                        ],
                                     ],
                                     'attributes' => [],
                                 ],
@@ -136,6 +141,9 @@ class XmlBuilderTest extends TestCase
                             ],
                         ],
                         'examples' => 2,
+                    ],
+                    [
+                        'content' => 'List of projects',
                     ],
                 ],
                 'attributes' => [


### PR DESCRIPTION
* Test mixed content in xml's example
* Test mixed content in unit test

It's supported in core but it's not tested anywhere.

Here is the link I got about xml's mixed content: https://stackoverflow.com/questions/12130228/can-a-xml-element-contain-text-and-child-elements-at-the-same-time