### PR TITLE
chore: Remove unused exception PactNotRegisteredException

### DIFF
--- a/src/PhpPact/Consumer/Exception/PactNotRegisteredException.php
+++ b/src/PhpPact/Consumer/Exception/PactNotRegisteredException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace PhpPact\Consumer\Exception;
-
-use Exception;
-
-class PactNotRegisteredException extends Exception
-{
-}


### PR DESCRIPTION
It has been replaced by `MissingPactException`