### PR TITLE
deps: Remove slim/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,7 @@
     "require-dev": {
         "ext-sockets": "*",
         "roave/security-advisories": "dev-latest",
-        "slim/slim": "^4.6",
-        "slim/psr7": "^1.2.0",
+        "slim/slim": "^4.13",
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
         "phpstan/phpstan": "^1.9",


### PR DESCRIPTION
* `slim/psr7` is in `require-dev` because old version of slim framework need it in the past.
* Look like new version of Slim framework doesn't require `slim/psr7` to work.