### PR TITLE
deps: Require ext-openssl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     ],
     "require": {
         "php": "^8.1",
+        "ext-openssl": "*",
         "ext-ffi": "*",
         "ext-json": "*",
         "composer/semver": "^1.4.0|^3.2.0",


### PR DESCRIPTION
* Look like `ext-openssl` is required in <= v8 because we call `file_get_contents` with `https` scheme https://github.com/pact-foundation/pact-php/commit/50140a53210fca4ba9363f98f8d68ddf6bd0acb3
    ```php
        $uri  = "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.29.2/{$fileName}";
        $data = \file_get_contents($uri);
    ```
* v9 + v10 use composer to download files with `https` scheme. Composer will "require" `ext-openssl` for us, by throwing an exception if it's not available https://github.com/composer/composer/blob/main/src/Composer/Downloader/FileDownloader.php#L468-L470
    ```php
        if (!extension_loaded('openssl') && 0 === strpos($url, 'https:')) {
            throw new \RuntimeException('You must enable the openssl extension to download files via https');
        }
    ```
* I think not requiring `ext-openssl` is not wrong. But requiring `ext-openssl` is also fine. So I added it again.
* `openssl` extension is bundled into PHP, and I can't disable it to test
  * On mac/linux: `Could not disable openssl on PHP 8.3.3 as it not a shared extension`
  * On windows: Can disable, but can't verify that `composer install` will throw exception, because of this error `The composer.json file at './composer.json' does not validate; run 'composer validate' to check for errors` https://github.com/tienvx/pact-php/actions/runs/8277789711/job/22648837639