### PR TITLE
deps: Use pact-foundation/composer-downloads-plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "composer/semver": "^1.4.0|^3.2.0",
         "symfony/process": "^5.4|^6.0|^7.0",
         "guzzlehttp/psr7": "^2.4.5",
-        "tienvx/composer-downloads-plugin": "^1.2.0"
+        "pact-foundation/composer-downloads-plugin": "^1.0.0"
     },
     "require-dev": {
         "ext-sockets": "*",
@@ -143,10 +143,14 @@
     },
     "config": {
         "allow-plugins": {
-            "tienvx/composer-downloads-plugin": true
+            "pact-foundation/composer-downloads-plugin": true
         }
     },
     "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/pact-foundation/composer-downloads-plugin"
+        },
         {
             "type": "path",
             "url": "example/protobuf-sync-message/provider"

--- a/example/protobuf-sync-message/provider/composer.json
+++ b/example/protobuf-sync-message/provider/composer.json
@@ -3,7 +3,7 @@
     "require": {
         "grpc/grpc": "^1.57",
         "spiral/roadrunner-grpc": "^3.2",
-        "tienvx/composer-downloads-plugin": "^1.2"
+        "pact-foundation/composer-downloads-plugin": "^1.0"
     },
     "require-dev": {
         "ext-grpc": "*"
@@ -27,7 +27,7 @@
     },
     "config": {
         "allow-plugins": {
-            "tienvx/composer-downloads-plugin": true
+            "pact-foundation/composer-downloads-plugin": true
         }
     }
 }


### PR DESCRIPTION
I can't wait for the package `pact-foundation/composer-downloads-plugin` to be submitted into packagist. So I use composer's `repositories` feature for now. We can remove it when the package is submitted.