### PR TITLE
docs: Add PHP Compatibility column to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Table of contents
 - [Pact PHP](#pact-php)
 - [Table of contents](#table-of-contents)
   - [Versions](#versions)
-  - [Specifications](#specifications)
+  - [Supported Platforms](#supported-platforms)
   - [Installation](#installation)
   - [Basic Consumer Usage](#basic-consumer-usage)
     - [Create Consumer Unit Test](#create-consumer-unit-test)

--- a/README.md
+++ b/README.md
@@ -47,37 +47,18 @@ Table of contents
 
 ## Versions
 
-10.X updates internal dependencies and libraries + adds support for pact specification 3.X & 4.X via Pact FFI.
-
-9.X updates internal dependencies and libraries including pact-ruby-standalone v2.x which adds support for ARM64 CPU's for Linux/MacOS and providing x86 and x86_64 Windows via pact-ruby-standalone v2.x.   This results in dropping PHP 7.4
-
-8.X updates internal dependencies and libraries.   This results in dropping PHP 7.3
-
-7.x updates internal dependencies and libraries, mostly to Guzzle 7.X.  This results in dropping support for PHP 7.2.
-6.x updates internal dependencies, mostly surrounding the Amp library.  This results in dropping support for PHP 7.1.
-
-5.X adds preliminary support for async messages and pact specification 3.X.  This does not yet support the full pact specification 3.X as the backend implementations are incomplete. However, pact-messages are supported.
-
-The 4.X tags are accompany changes in PHPUnit 7.X which requires a PHP 7.1 or higher.  Thus, 4.X drops support for PHP 7.0.
-
-The 3.X tags are a major breaking change to the 2.X versions.   To be similar to the rest of the Pact ecosystem, Pact-PHP migrated to leverage the Ruby backend.  This mirrors the .Net, JS, Python, and Go implementations.
-
-If you wish to stick with the 2.X implementation, you can continue to pull from the [latest 2.X.X tag](https://github.com/pact-foundation/pact-php/tree/2.2.1).
-
-## Specifications
-
-| Version | Status     | [Spec] Compatibility | Install            |
-| ------- | ---------- | -------------------- | ------------------ |
-| 10.x    | Alpha      | 1, 1.1, 2, 3, 4      | See [installation] |
-| 9.x     | Stable     | 1, 1.1, 2, 3\*       | [9xx]              |
-| 8.x     | Deprecated | 1, 1.1, 2, 3\*       |                    |
-| 7.x     | Deprecated | 1, 1.1, 2, 3\*       |                    |
-| 6.x     | Deprecated | 1, 1.1, 2, 3\*       |                    |
-| 5.x     | Deprecated | 1, 1.1, 2, 3\*       |                    |
-| 4.x     | Deprecated | 1, 1.1, 2            |                    |
-| 3.x     | Deprecated | 1, 1.1, 2            |                    |
-| 2.x     | Deprecated | 1, 1.1, 2            |                    |
-| 1.x     | Deprecated | 1, 1.1               |                    |
+| Version | Status     | [Spec] Compatibility | PHP Compatibility | Install            |
+| ------- | ---------- | -------------------- | ----------------- | ------------------ |
+| 10.x    | Alpha      | 1, 1.1, 2, 3, 4      | ^8.1              | See [installation] |
+| 9.x     | Stable     | 1, 1.1, 2, 3\*       | ^8.0              | [9xx]              |
+| 8.x     | Deprecated | 1, 1.1, 2, 3\*       | ^7.4|^8.0         |                    |
+| 7.x     | Deprecated | 1, 1.1, 2, 3\*       | ^7.3              |                    |
+| 6.x     | Deprecated | 1, 1.1, 2, 3\*       | ^7.2              |                    |
+| 5.x     | Deprecated | 1, 1.1, 2, 3\*       | ^7.1              |                    |
+| 4.x     | Deprecated | 1, 1.1, 2            | ^7.1              |                    |
+| 3.x     | Deprecated | 1, 1.1, 2            | ^7.0              |                    |
+| 2.x     | Deprecated | 1, 1.1, 2            | >=7               |                    |
+| 1.x     | Deprecated | 1, 1.1               | >=7               |                    |
 
 _\*_ v3 support is limited to the subset of functionality required to enable language inter-operable [Message support].
 

--- a/docs/SOFTWARE-HISTORY.md
+++ b/docs/SOFTWARE-HISTORY.md
@@ -1,0 +1,18 @@
+# Pact-PHP Software History
+
+10.X updates internal dependencies and libraries + adds support for pact specification 3.X & 4.X via Pact FFI.
+
+9.X updates internal dependencies and libraries including pact-ruby-standalone v2.x which adds support for ARM64 CPU's for Linux/MacOS and providing x86 and x86_64 Windows via pact-ruby-standalone v2.x.   This results in dropping PHP 7.4
+
+8.X updates internal dependencies and libraries.   This results in dropping PHP 7.3
+
+7.x updates internal dependencies and libraries, mostly to Guzzle 7.X.  This results in dropping support for PHP 7.2.
+6.x updates internal dependencies, mostly surrounding the Amp library.  This results in dropping support for PHP 7.1.
+
+5.X adds preliminary support for async messages and pact specification 3.X.  This does not yet support the full pact specification 3.X as the backend implementations are incomplete. However, pact-messages are supported.
+
+The 4.X tags are accompany changes in PHPUnit 7.X which requires a PHP 7.1 or higher.  Thus, 4.X drops support for PHP 7.0.
+
+The 3.X tags are a major breaking change to the 2.X versions.   To be similar to the rest of the Pact ecosystem, Pact-PHP migrated to leverage the Ruby backend.  This mirrors the .Net, JS, Python, and Go implementations.
+
+If you wish to stick with the 2.X implementation, you can continue to pull from the [latest 2.X.X tag](https://github.com/pact-foundation/pact-php/tree/2.2.1).


### PR DESCRIPTION
* Merge `#Versions` and `#Specifications` by just adding a single column to the table, making `Readme.md` a lot shorter
* I think most of `updating dependencies and libraries` information can be removed
* `ARM64` support on Linux and Mac is already in the table below `#Supported Platforms`