### PR TITLE
feat: Support 'arrayContains' matcher in query and header

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/ArrayContains.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/ArrayContains.php
@@ -2,7 +2,7 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Formatters\MinimalFormatter;
+use PhpPact\Consumer\Matcher\Formatters\ValueRequiredFormatter;
 
 /**
  * Checks if all the variants are present in an array.
@@ -14,7 +14,7 @@ class ArrayContains extends AbstractMatcher
      */
     public function __construct(private array $variants)
     {
-        $this->setFormatter(new MinimalFormatter());
+        $this->setFormatter(new ValueRequiredFormatter());
     }
 
     /**
@@ -22,15 +22,15 @@ class ArrayContains extends AbstractMatcher
      */
     protected function getAttributesData(): array
     {
-        return ['variants' => array_values($this->variants)];
+        return ['variants' => $this->getValue()];
     }
 
     /**
-     * @todo Change return type to `null`
+     * @return array<mixed>
      */
-    public function getValue(): mixed
+    public function getValue(): array
     {
-        return null;
+        return array_values($this->variants);
     }
 
     public function getType(): string

--- a/tests/PhpPact/Consumer/Matcher/Matchers/ArrayContainsTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/ArrayContainsTest.php
@@ -17,7 +17,7 @@ class ArrayContainsTest extends TestCase
         ];
         $array = new ArrayContains($variants);
         $this->assertSame(
-            '{"pact:matcher:type":"arrayContains","variants":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"integer","pact:generator:type":"RandomInt","min":0,"max":10}]}',
+            '{"pact:matcher:type":"arrayContains","variants":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"integer","pact:generator:type":"RandomInt","min":0,"max":10}],"value":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"integer","pact:generator:type":"RandomInt","min":0,"max":10}]}',
             json_encode($array)
         );
     }


### PR DESCRIPTION
Look like `value` is required if the `arrayContains` matcher is used with query and header.

Currently I set it exactly the same with `variants` and it works fine.

https://github.com/pact-foundation/pact-specification/tree/version-4?tab=readme-ov-file#supported-matching-rules