### PR TITLE
chore: Use both pactffi_set_comment and pactffi_add_text_comment

### DIFF
--- a/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
@@ -77,7 +77,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheHttpInteraction(string $value): void
     {
-        $this->interaction->addComment($value);
+        $this->interaction->addTextComment($value);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Http/ConsumerContext.php
@@ -77,7 +77,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheHttpInteraction(string $value): void
     {
-        $this->interaction->setComments(['text' => json_encode([$value])]);
+        $this->interaction->addComment($value);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
@@ -67,7 +67,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheMessageInteraction(string $value): void
     {
-        $this->message->setComments(['text' => json_encode([$value])]);
+        $this->message->addComment($value);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/Message/ConsumerContext.php
@@ -67,7 +67,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheMessageInteraction(string $value): void
     {
-        $this->message->addComment($value);
+        $this->message->addTextComment($value);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
@@ -69,7 +69,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheSynchronousMessageInteraction(string $value): void
     {
-        $this->message->setComments(['text' => json_encode([$value])]);
+        $this->message->addComment($value);
     }
 
     /**

--- a/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V4/SyncMessage/ConsumerContext.php
@@ -69,7 +69,7 @@ final class ConsumerContext implements Context
      */
     public function aCommentIsAddedToTheSynchronousMessageInteraction(string $value): void
     {
-        $this->message->addComment($value);
+        $this->message->addTextComment($value);
     }
 
     /**

--- a/src/PhpPact/Consumer/AbstractMessageBuilder.php
+++ b/src/PhpPact/Consumer/AbstractMessageBuilder.php
@@ -78,13 +78,56 @@ abstract class AbstractMessageBuilder implements BuilderInterface
     }
 
     /**
-     * Add comments to the message interaction. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     * Set comments for the interaction.
      *
-     * @param array<string, string> $comments
+     * This is used by V4 interactions to set comments for the interaction. A
+     * comment consists of a key-value pair, where the key is a string and the
+     * value is anything that can be encoded as JSON.
+     *
+     * Args:
+     *     key:
+     *         Key for the comment.
+     *
+     *     value:
+     *         Value for the comment. This must be encodable using
+     *         `json_encode`, or an existing JSON string. The
+     *         value of `null` will remove the comment with the given key.
+     *
+     *  # Warning
+     *
+     *  This function will overwrite any existing comment with the same key. In
+     *  particular, the `text` key is used by {@see self::comment()}.
+     *
+     * @param array<string, mixed> $comments
      */
     public function comments(array $comments): self
     {
         $this->message->setComments($comments);
+
+        return $this;
+    }
+
+    /**
+     *  Add a text comment for the interaction.
+     *
+     *  This is used by V4 interactions to set arbitrary text comments for the
+     *  interaction.
+     *
+     *  Args:
+     *      comment:
+     *          Text of the comment.
+     *
+     *  # Warning
+     *
+     *  Internally, the comments are appended to an array under the `text`
+     *  comment key. Care should be taken to ensure that conflicts are not
+     *  introduced by {@see self::comments()}.
+     *
+     * @param string $comment
+     */
+    public function comment(string $comment): self
+    {
+        $this->message->addTextComment($comment);
 
         return $this;
     }

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
@@ -42,10 +42,10 @@ abstract class AbstractDriver
 
     protected function setComments(Interaction|Message $interaction): void
     {
-        foreach ($interaction->getComments() as $key => $value) {
-            $success = $this->client->call('pactffi_set_comment', $interaction->getHandle(), $key, $value);
+        foreach ($interaction->getComments() as $value) {
+            $success = $this->client->call('pactffi_add_text_comment', $interaction->getHandle(), $value);
             if (!$success) {
-                throw new InteractionCommentNotSetException(sprintf("Can add comment '%s' to the interaction '%s'", $key, $interaction->getDescription()));
+                throw new InteractionCommentNotSetException(sprintf("Can add comment '%s' to the interaction '%s'", $value, $interaction->getDescription()));
             }
         }
     }

--- a/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/AbstractDriver.php
@@ -42,10 +42,17 @@ abstract class AbstractDriver
 
     protected function setComments(Interaction|Message $interaction): void
     {
-        foreach ($interaction->getComments() as $value) {
+        foreach ($interaction->getComments() as $key => $value) {
+            $value = (is_string($value) || is_null($value)) ? $value : json_encode($value);
+            $success = $this->client->call('pactffi_set_comment', $interaction->getHandle(), $key, $value);
+            if (!$success) {
+                throw new InteractionCommentNotSetException(sprintf("Can not add comment '%s' to the interaction '%s'", $key, $interaction->getDescription()));
+            }
+        }
+        foreach ($interaction->getTextComments() as $value) {
             $success = $this->client->call('pactffi_add_text_comment', $interaction->getHandle(), $value);
             if (!$success) {
-                throw new InteractionCommentNotSetException(sprintf("Can add comment '%s' to the interaction '%s'", $value, $interaction->getDescription()));
+                throw new InteractionCommentNotSetException(sprintf("Can not add text comment '%s' to the interaction '%s'", $value, $interaction->getDescription()));
             }
         }
     }

--- a/src/PhpPact/Consumer/InteractionBuilder.php
+++ b/src/PhpPact/Consumer/InteractionBuilder.php
@@ -103,13 +103,56 @@ class InteractionBuilder implements BuilderInterface
     }
 
     /**
-     * Add comments to the interaction. This feature only work with specification v4. It doesn't affect pact file with specification <= v3.
+     * Set comments for the interaction.
      *
-     * @param array<string, string> $comments
+     * This is used by V4 interactions to set comments for the interaction. A
+     * comment consists of a key-value pair, where the key is a string and the
+     * value is anything that can be encoded as JSON.
+     *
+     * Args:
+     *     key:
+     *         Key for the comment.
+     *
+     *     value:
+     *         Value for the comment. This must be encodable using
+     *         `json_encode`, or an existing JSON string. The
+     *         value of `null` will remove the comment with the given key.
+     *
+     *  # Warning
+     *
+     *  This function will overwrite any existing comment with the same key. In
+     *  particular, the `text` key is used by {@see self::comment()}.
+     *
+     * @param array<string, mixed> $comments
      */
     public function comments(array $comments): self
     {
         $this->interaction->setComments($comments);
+
+        return $this;
+    }
+
+    /**
+     *  Add a text comment for the interaction.
+     *
+     *  This is used by V4 interactions to set arbitrary text comments for the
+     *  interaction.
+     *
+     *  Args:
+     *      comment:
+     *          Text of the comment.
+     *
+     *  # Warning
+     *
+     *  Internally, the comments are appended to an array under the `text`
+     *  comment key. Care should be taken to ensure that conflicts are not
+     *  introduced by {@see self::comments()}.
+     *
+     * @param string $comment
+     */
+    public function comment(string $comment): self
+    {
+        $this->interaction->addTextComment($comment);
 
         return $this;
     }

--- a/src/PhpPact/Consumer/Model/Interaction/CommentsTrait.php
+++ b/src/PhpPact/Consumer/Model/Interaction/CommentsTrait.php
@@ -5,12 +5,17 @@ namespace PhpPact\Consumer\Model\Interaction;
 trait CommentsTrait
 {
     /**
-     * @var string[]
+     * @var array<string, mixed>
      */
     private array $comments = [];
 
     /**
-     * @return string[]
+     * @var string[]
+     */
+    private array $textComments = [];
+
+    /**
+     * @return array<string, mixed>
      */
     public function getComments(): array
     {
@@ -18,20 +23,26 @@ trait CommentsTrait
     }
 
     /**
-     * @param string[] $comments
+     * @param array<string, mixed> $comments
      */
-    public function setComments(array $comments): self
+    public function setComments(array $comments): void
     {
-        $this->comments = [];
-        foreach ($comments as $value) {
-            $this->addComment($value);
-        }
-
-        return $this;
+        $this->comments = $comments;
     }
 
-    public function addComment(string $comment): void
+    /**
+     * @return string[]
+     */
+    public function getTextComments(): array
     {
-        $this->comments[] = $comment;
+        return $this->textComments;
+    }
+
+    /**
+     * @param string $comment
+     */
+    public function addTextComment(string $comment): void
+    {
+        $this->textComments[] = $comment;
     }
 }

--- a/src/PhpPact/Consumer/Model/Interaction/CommentsTrait.php
+++ b/src/PhpPact/Consumer/Model/Interaction/CommentsTrait.php
@@ -5,12 +5,12 @@ namespace PhpPact\Consumer\Model\Interaction;
 trait CommentsTrait
 {
     /**
-     * @var array<string, string>
+     * @var string[]
      */
     private array $comments = [];
 
     /**
-     * @return array<string, string>
+     * @return string[]
      */
     public function getComments(): array
     {
@@ -18,15 +18,20 @@ trait CommentsTrait
     }
 
     /**
-     * @param array<string, string> $comments
+     * @param string[] $comments
      */
     public function setComments(array $comments): self
     {
         $this->comments = [];
-        foreach ($comments as $key => $value) {
-            $this->comments[$key] = $value;
+        foreach ($comments as $value) {
+            $this->addComment($value);
         }
 
         return $this;
+    }
+
+    public function addComment(string $comment): void
+    {
+        $this->comments[] = $comment;
     }
 }

--- a/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
@@ -168,8 +168,8 @@ class InteractionDriverTest extends TestCase
     }
 
     #[TestWith([[], true])]
-    #[TestWith([['key1' => 'value1'], false])]
-    #[TestWith([['key2' => 'value2', 'key3' => 'value3'], true])]
+    #[TestWith([['comment 1'], false])]
+    #[TestWith([['comment 2', 'comment 3'], true])]
     public function testSetComments(array $comments, $success): void
     {
         $this->interaction->setComments($comments);
@@ -184,12 +184,12 @@ class InteractionDriverTest extends TestCase
             ['pactffi_given_with_param', $this->interactionHandle, 'item exist', 'name', 'abc', null],
             ['pactffi_upon_receiving', $this->interactionHandle, $this->description, null],
         ];
-        foreach ($comments as $key => $value) {
-            $calls[] = ['pactffi_set_comment', $this->interactionHandle, $key, $value, $success];
+        foreach ($comments as $value) {
+            $calls[] = ['pactffi_add_text_comment', $this->interactionHandle, $value, $success];
         }
         if (!$success) {
             $this->expectException(InteractionCommentNotSetException::class);
-            $this->expectExceptionMessage("Can add comment '$key' to the interaction '{$this->description}'");
+            $this->expectExceptionMessage("Can add comment '$value' to the interaction '{$this->description}'");
         }
         $this->assertClientCalls($calls);
         $this->driver->registerInteraction($this->interaction, false);

--- a/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
@@ -165,8 +165,12 @@ class MessageDriverTest extends TestCase
     }
 
     #[TestWith([[], true])]
-    #[TestWith([['comment 1'], false])]
-    #[TestWith([['comment 2', 'comment 3'], true])]
+    #[TestWith([['key1' => null], true])]
+    #[TestWith([['key1' => null], false])]
+    #[TestWith([['key2' => 'string value'], true])]
+    #[TestWith([['key2' => 'string value'], false])]
+    #[TestWith([['key3' => ['value 1', 'value 2']], true])]
+    #[TestWith([['key3' => ['value 1', 'value 2']], false])]
     public function testSetComments(array $comments, $success): void
     {
         $this->message->setComments($comments);
@@ -183,12 +187,39 @@ class MessageDriverTest extends TestCase
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
         ];
-        foreach ($comments as $value) {
-            $calls[] = ['pactffi_add_text_comment', $this->messageHandle, $value, $success];
+        foreach ($comments as $key => $value) {
+            $calls[] = ['pactffi_set_comment', $this->messageHandle, $key, (is_string($value) || is_null($value)) ? $value : json_encode($value), $success];
         }
         if (!$success) {
             $this->expectException(InteractionCommentNotSetException::class);
-            $this->expectExceptionMessage("Can add comment '$value' to the interaction '{$this->description}'");
+            $this->expectExceptionMessage("Can not add comment '$key' to the interaction '{$this->description}'");
+        }
+        $this->assertClientCalls($calls);
+        $this->driver->registerMessage($this->message);
+    }
+
+    #[TestWith(['comment 1', false])]
+    #[TestWith(['comment 2', true])]
+    public function testAddTextComment(string $comment, $success): void
+    {
+        $this->message->addTextComment($comment);
+        $this->pactDriver
+            ->expects($this->once())
+            ->method('getPact')
+            ->willReturn(new Pact($this->pactHandle));
+        $calls = [
+            ['pactffi_new_message_interaction', $this->pactHandle, $this->description, $this->messageHandle],
+            ['pactffi_message_given', $this->messageHandle, 'item exist', null],
+            ['pactffi_message_given_with_param', $this->messageHandle, 'item exist', 'id', '12', null],
+            ['pactffi_message_given_with_param', $this->messageHandle, 'item exist', 'name', 'abc', null],
+            ['pactffi_message_expects_to_receive', $this->messageHandle, $this->description, null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
+            ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
+            ['pactffi_add_text_comment', $this->messageHandle, $comment, $success],
+        ];
+        if (!$success) {
+            $this->expectException(InteractionCommentNotSetException::class);
+            $this->expectExceptionMessage("Can not add text comment '$comment' to the interaction '{$this->description}'");
         }
         $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);

--- a/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
@@ -165,8 +165,8 @@ class MessageDriverTest extends TestCase
     }
 
     #[TestWith([[], true])]
-    #[TestWith([['key1' => 'value1'], false])]
-    #[TestWith([['key2' => 'value2', 'key3' => 'value3'], true])]
+    #[TestWith([['comment 1'], false])]
+    #[TestWith([['comment 2', 'comment 3'], true])]
     public function testSetComments(array $comments, $success): void
     {
         $this->message->setComments($comments);
@@ -183,12 +183,12 @@ class MessageDriverTest extends TestCase
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
         ];
-        foreach ($comments as $key => $value) {
-            $calls[] = ['pactffi_set_comment', $this->messageHandle, $key, $value, $success];
+        foreach ($comments as $value) {
+            $calls[] = ['pactffi_add_text_comment', $this->messageHandle, $value, $success];
         }
         if (!$success) {
             $this->expectException(InteractionCommentNotSetException::class);
-            $this->expectExceptionMessage("Can add comment '$key' to the interaction '{$this->description}'");
+            $this->expectExceptionMessage("Can add comment '$value' to the interaction '{$this->description}'");
         }
         $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);

--- a/tests/PhpPact/Consumer/InteractionBuilderTest.php
+++ b/tests/PhpPact/Consumer/InteractionBuilderTest.php
@@ -120,12 +120,20 @@ class InteractionBuilderTest extends TestCase
     }
 
     #[TestWith([[]])]
-    #[TestWith([['comment 1', 'comment 2']])]
+    #[TestWith([['key1' => null, 'key2' => 'value', 'key3' => ['value']]])]
     public function testSetComments(array $comments): void
     {
         $this->assertSame($this->builder, $this->builder->comments($comments));
         $interaction = $this->getInteraction();
         $this->assertSame($comments, $interaction->getComments());
+    }
+
+    public function testAddTextComment(): void
+    {
+        $this->assertSame($this->builder, $this->builder->comment('comment 1'));
+        $this->assertSame($this->builder, $this->builder->comment('comment 2'));
+        $interaction = $this->getInteraction();
+        $this->assertSame(['comment 1', 'comment 2'], $interaction->getTextComments());
     }
 
     private function getInteraction(): Interaction

--- a/tests/PhpPact/Consumer/InteractionBuilderTest.php
+++ b/tests/PhpPact/Consumer/InteractionBuilderTest.php
@@ -120,7 +120,7 @@ class InteractionBuilderTest extends TestCase
     }
 
     #[TestWith([[]])]
-    #[TestWith([['key' => 'value']])]
+    #[TestWith([['comment 1', 'comment 2']])]
     public function testSetComments(array $comments): void
     {
         $this->assertSame($this->builder, $this->builder->comments($comments));

--- a/tests/PhpPact/Consumer/MessageBuilderTest.php
+++ b/tests/PhpPact/Consumer/MessageBuilderTest.php
@@ -102,7 +102,7 @@ class MessageBuilderTest extends TestCase
     }
 
     #[TestWith([[]])]
-    #[TestWith([['key' => 'value']])]
+    #[TestWith([['comment 1', 'comment 2']])]
     public function testSetComments(array $comments): void
     {
         $this->assertSame($this->builder, $this->builder->comments($comments));

--- a/tests/PhpPact/Consumer/MessageBuilderTest.php
+++ b/tests/PhpPact/Consumer/MessageBuilderTest.php
@@ -102,12 +102,20 @@ class MessageBuilderTest extends TestCase
     }
 
     #[TestWith([[]])]
-    #[TestWith([['comment 1', 'comment 2']])]
+    #[TestWith([['key1' => null, 'key2' => 'value', 'key3' => ['value']]])]
     public function testSetComments(array $comments): void
     {
         $this->assertSame($this->builder, $this->builder->comments($comments));
         $message = $this->getMessage();
         $this->assertSame($comments, $message->getComments());
+    }
+
+    public function testAddTextComment(): void
+    {
+        $this->assertSame($this->builder, $this->builder->comment('comment 1'));
+        $this->assertSame($this->builder, $this->builder->comment('comment 2'));
+        $message = $this->getMessage();
+        $this->assertSame(['comment 1', 'comment 2'], $message->getTextComments());
     }
 
     public function testSetSingleCallback(): void

--- a/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
+++ b/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
@@ -167,8 +167,8 @@ class SyncMessageDriverTest extends TestCase
     }
 
     #[TestWith([[], true])]
-    #[TestWith([['key1' => 'value1'], false])]
-    #[TestWith([['key2' => 'value2', 'key3' => 'value3'], true])]
+    #[TestWith([['comment 1'], false])]
+    #[TestWith([['comment 2', 'comment 3'], true])]
     public function testSetComments(array $comments, $success): void
     {
         $this->message->setComments($comments);
@@ -185,12 +185,12 @@ class SyncMessageDriverTest extends TestCase
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key1', 'value1', null],
             ['pactffi_message_with_metadata_v2', $this->messageHandle, 'key2', 'value2', null],
         ];
-        foreach ($comments as $key => $value) {
-            $calls[] = ['pactffi_set_comment', $this->messageHandle, $key, $value, $success];
+        foreach ($comments as $value) {
+            $calls[] = ['pactffi_add_text_comment', $this->messageHandle, $value, $success];
         }
         if (!$success) {
             $this->expectException(InteractionCommentNotSetException::class);
-            $this->expectExceptionMessage("Can add comment '$key' to the interaction '{$this->description}'");
+            $this->expectExceptionMessage("Can add comment '$value' to the interaction '{$this->description}'");
         }
         $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);

--- a/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
+++ b/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
@@ -100,12 +100,20 @@ class SyncMessageBuilderTest extends TestCase
     }
 
     #[TestWith([[]])]
-    #[TestWith([['comment 1', 'comment 2']])]
+    #[TestWith([['key1' => null, 'key2' => 'value', 'key3' => ['value']]])]
     public function testSetComments(array $comments): void
     {
         $this->assertSame($this->builder, $this->builder->comments($comments));
         $message = $this->getMessage();
         $this->assertSame($comments, $message->getComments());
+    }
+
+    public function testAddTextComment(): void
+    {
+        $this->assertSame($this->builder, $this->builder->comment('comment 1'));
+        $this->assertSame($this->builder, $this->builder->comment('comment 2'));
+        $message = $this->getMessage();
+        $this->assertSame(['comment 1', 'comment 2'], $message->getTextComments());
     }
 
     public function testRegisterMessage(): void

--- a/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
+++ b/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
@@ -100,7 +100,7 @@ class SyncMessageBuilderTest extends TestCase
     }
 
     #[TestWith([[]])]
-    #[TestWith([['key' => 'value']])]
+    #[TestWith([['comment 1', 'comment 2']])]
     public function testSetComments(array $comments): void
     {
         $this->assertSame($this->builder, $this->builder->comments($comments));


### PR DESCRIPTION
`pactffi_set_comment` does work, but there is a problem. `pactffi_add_text_comment` is a better replacement for it.

See these links for more information:
* https://github.com/pact-foundation/pact-compatibility-suite/pull/8
* https://github.com/pact-foundation/pact-specification/issues/45
* https://github.com/pact-foundation/pact-reference/pull/401