### PR TITLE
chore: Use intersection types feature

### DIFF
--- a/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
@@ -24,7 +24,7 @@ use PHPUnit\Framework\TestCase;
 class InteractionBodyDriverTest extends TestCase
 {
     private InteractionBodyDriverInterface $driver;
-    private ClientInterface|MockObject $client;
+    private ClientInterface&MockObject $client;
     private Interaction $interaction;
     private int $requestPartId = 1;
     private int $responsePartId = 2;

--- a/tests/PhpPact/Consumer/Driver/Body/MessageBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/MessageBodyDriverTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 class MessageBodyDriverTest extends TestCase
 {
     private MessageBodyDriverInterface $driver;
-    private ClientInterface|MockObject $client;
+    private ClientInterface&MockObject $client;
     private Message $message;
     private int $requestPartId = 1;
     private int $messageId = 123;

--- a/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
@@ -25,10 +25,10 @@ class InteractionDriverTest extends TestCase
     use ClientTrait;
 
     private InteractionDriverInterface $driver;
-    private MockServerInterface|MockObject $mockServer;
-    private PactDriverInterface|MockObject $pactDriver;
-    private RequestDriverInterface|MockObject $requestDriver;
-    private ResponseDriverInterface|MockObject $responseDriver;
+    private MockServerInterface&MockObject $mockServer;
+    private PactDriverInterface&MockObject $pactDriver;
+    private RequestDriverInterface&MockObject $requestDriver;
+    private ResponseDriverInterface&MockObject $responseDriver;
     private Interaction $interaction;
     private int $interactionHandle = 123;
     private int $pactHandle = 234;

--- a/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
@@ -22,8 +22,8 @@ class MessageDriverTest extends TestCase
     use ClientTrait;
 
     private MessageDriverInterface $driver;
-    private PactDriverInterface|MockObject $pactDriver;
-    private MessageBodyDriverInterface|MockObject $messageBodyDriver;
+    private PactDriverInterface&MockObject $pactDriver;
+    private MessageBodyDriverInterface&MockObject $messageBodyDriver;
     private Message $message;
     private int $messageHandle = 123;
     private int $pactHandle = 234;

--- a/tests/PhpPact/Consumer/Driver/InteractionPart/RequestDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/InteractionPart/RequestDriverTest.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\TestCase;
 class RequestDriverTest extends TestCase
 {
     private RequestDriverInterface $driver;
-    private ClientInterface|MockObject $client;
-    private InteractionBodyDriverInterface|MockObject $bodyDriver;
+    private ClientInterface&MockObject $client;
+    private InteractionBodyDriverInterface&MockObject $bodyDriver;
     private Interaction $interaction;
     private int $requestPartId = 1;
     private int $interactionHandle = 123;

--- a/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
@@ -15,8 +15,8 @@ use PHPUnit\Framework\TestCase;
 class ResponseDriverTest extends TestCase
 {
     private ResponseDriverInterface $driver;
-    private ClientInterface|MockObject $client;
-    private InteractionBodyDriverInterface|MockObject $bodyDriver;
+    private ClientInterface&MockObject $client;
+    private InteractionBodyDriverInterface&MockObject $bodyDriver;
     private Interaction $interaction;
     private int $responsePartId = 2;
     private int $interactionHandle = 123;

--- a/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
@@ -24,7 +24,7 @@ class PactDriverTest extends TestCase
     protected const SPEC_V3 = 4;
     protected const SPEC_V4 = 5;
     protected PactDriverInterface $driver;
-    protected PactConfigInterface|MockObject $config;
+    protected PactConfigInterface&MockObject $config;
     protected int $pactHandle = 123;
     protected string $consumer = 'consumer';
     protected string $provider = 'provider';

--- a/tests/PhpPact/Consumer/Factory/InteractionDriverFactoryTest.php
+++ b/tests/PhpPact/Consumer/Factory/InteractionDriverFactoryTest.php
@@ -17,7 +17,7 @@ class InteractionDriverFactoryTest extends TestCase
     use FactoryTrait;
 
     private InteractionDriverFactoryInterface $factory;
-    private MockServerConfigInterface|MockObject $config;
+    private MockServerConfigInterface&MockObject $config;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Consumer/Factory/MessageDriverFactoryTest.php
+++ b/tests/PhpPact/Consumer/Factory/MessageDriverFactoryTest.php
@@ -16,7 +16,7 @@ class MessageDriverFactoryTest extends TestCase
     use FactoryTrait;
 
     private MessageDriverFactoryInterface $factory;
-    private MockServerConfigInterface|MockObject $config;
+    private MockServerConfigInterface&MockObject $config;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Consumer/InteractionBuilderTest.php
+++ b/tests/PhpPact/Consumer/InteractionBuilderTest.php
@@ -19,9 +19,9 @@ use ReflectionProperty;
 class InteractionBuilderTest extends TestCase
 {
     private InteractionBuilder $builder;
-    private InteractionDriverInterface|MockObject $driver;
-    private MockServerConfigInterface|MockObject $config;
-    private InteractionDriverFactoryInterface|MockObject $driverFactory;
+    private InteractionDriverInterface&MockObject $driver;
+    private MockServerConfigInterface&MockObject $config;
+    private InteractionDriverFactoryInterface&MockObject $driverFactory;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Consumer/MessageBuilderTest.php
+++ b/tests/PhpPact/Consumer/MessageBuilderTest.php
@@ -21,9 +21,9 @@ use stdClass;
 class MessageBuilderTest extends TestCase
 {
     private MessageBuilder $builder;
-    private MessageDriverInterface|MockObject $driver;
-    private PactConfigInterface|MockObject $config;
-    private MessageDriverFactoryInterface|MockObject $driverFactory;
+    private MessageDriverInterface&MockObject $driver;
+    private PactConfigInterface&MockObject $config;
+    private MessageDriverFactoryInterface&MockObject $driverFactory;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Consumer/Service/MockServerTest.php
+++ b/tests/PhpPact/Consumer/Service/MockServerTest.php
@@ -23,7 +23,7 @@ class MockServerTest extends TestCase
     use ClientTrait;
 
     protected MockServerInterface $mockServer;
-    protected PactDriverInterface|MockObject $pactDriver;
+    protected PactDriverInterface&MockObject $pactDriver;
     protected MockServerConfigInterface $config;
     protected int $pactHandle = 123;
     protected string $host = 'example.test';

--- a/tests/PhpPact/Helper/FFI/ClientTrait.php
+++ b/tests/PhpPact/Helper/FFI/ClientTrait.php
@@ -9,7 +9,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 
 trait ClientTrait
 {
-    protected ClientInterface|MockObject $client;
+    protected ClientInterface&MockObject $client;
 
     protected function assertClientCalls(array $calls): void
     {

--- a/tests/PhpPact/Plugin/Driver/Body/PluginBodyDriverTest.php
+++ b/tests/PhpPact/Plugin/Driver/Body/PluginBodyDriverTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
 class PluginBodyDriverTest extends TestCase
 {
     private PluginBodyDriverInterface $driver;
-    private ClientInterface|MockObject $client;
+    private ClientInterface&MockObject $client;
     private Interaction $interaction;
     private int $requestPartId = 1;
     private int $responsePartId = 2;

--- a/tests/PhpPact/Plugins/Csv/Driver/Body/CsvBodyDriverTest.php
+++ b/tests/PhpPact/Plugins/Csv/Driver/Body/CsvBodyDriverTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 class CsvBodyDriverTest extends TestCase
 {
     private InteractionBodyDriverInterface $driver;
-    private PluginBodyDriverInterface|MockObject $decorated;
+    private PluginBodyDriverInterface&MockObject $decorated;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Csv/Factory/CsvInteractionDriverFactoryTest.php
@@ -29,7 +29,7 @@ class CsvInteractionDriverFactoryTest extends TestCase
     use FactoryTrait;
 
     private InteractionDriverFactoryInterface $factory;
-    private MockServerConfigInterface|MockObject $config;
+    private MockServerConfigInterface&MockObject $config;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Plugins/Protobuf/Driver/Body/ProtobufMessageBodyDriverTest.php
+++ b/tests/PhpPact/Plugins/Protobuf/Driver/Body/ProtobufMessageBodyDriverTest.php
@@ -14,7 +14,7 @@ use PHPUnit\Framework\TestCase;
 class ProtobufMessageBodyDriverTest extends TestCase
 {
     private MessageBodyDriverInterface $driver;
-    private PluginBodyDriverInterface|MockObject $decorated;
+    private PluginBodyDriverInterface&MockObject $decorated;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufMessageDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufMessageDriverFactoryTest.php
@@ -18,7 +18,7 @@ class ProtobufMessageDriverFactoryTest extends TestCase
     use FactoryTrait;
 
     private MessageDriverFactoryInterface $factory;
-    private MockServerConfigInterface|MockObject $config;
+    private MockServerConfigInterface&MockObject $config;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufSyncMessageDriverFactoryTest.php
+++ b/tests/PhpPact/Plugins/Protobuf/Factory/ProtobufSyncMessageDriverFactoryTest.php
@@ -19,7 +19,7 @@ class ProtobufSyncMessageDriverFactoryTest extends TestCase
     use FactoryTrait;
 
     private SyncMessageDriverFactoryInterface $factory;
-    private MockServerConfigInterface|MockObject $config;
+    private MockServerConfigInterface&MockObject $config;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -27,7 +27,7 @@ class VerifierTest extends TestCase
 
     private Verifier $verifier;
     private VerifierConfigInterface $config;
-    private LoggerInterface|MockObject $logger;
+    private LoggerInterface&MockObject $logger;
     private CData $handle;
     private array $calls;
 

--- a/tests/PhpPact/Standalone/StubServer/StubServerTest.php
+++ b/tests/PhpPact/Standalone/StubServer/StubServerTest.php
@@ -15,7 +15,7 @@ class StubServerTest extends TestCase
 {
     protected StubServer $server;
     protected StubServerConfigInterface $config;
-    protected Process|MockObject $process;
+    protected Process&MockObject $process;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
+++ b/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
@@ -24,9 +24,9 @@ class SyncMessageDriverTest extends TestCase
     use ClientTrait;
 
     private SyncMessageDriverInterface $driver;
-    private MockServerInterface|MockObject $mockServer;
-    private PactDriverInterface|MockObject $pactDriver;
-    private MessageBodyDriverInterface|MockObject $messageBodyDriver;
+    private MockServerInterface&MockObject $mockServer;
+    private PactDriverInterface&MockObject $pactDriver;
+    private MessageBodyDriverInterface&MockObject $messageBodyDriver;
     private Message $message;
     private int $messageHandle = 123;
     private int $pactHandle = 234;

--- a/tests/PhpPact/SyncMessage/Factory/SyncMessageDriverFactoryTest.php
+++ b/tests/PhpPact/SyncMessage/Factory/SyncMessageDriverFactoryTest.php
@@ -17,7 +17,7 @@ class SyncMessageDriverFactoryTest extends TestCase
     use FactoryTrait;
 
     private SyncMessageDriverFactoryInterface $factory;
-    private MockServerConfigInterface|MockObject $config;
+    private MockServerConfigInterface&MockObject $config;
 
     public function setUp(): void
     {

--- a/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
+++ b/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
@@ -19,9 +19,9 @@ use ReflectionProperty;
 class SyncMessageBuilderTest extends TestCase
 {
     private SyncMessageBuilder $builder;
-    private SyncMessageDriverInterface|MockObject $driver;
-    private MockServerConfigInterface|MockObject $config;
-    private SyncMessageDriverFactoryInterface|MockObject $driverFactory;
+    private SyncMessageDriverInterface&MockObject $driver;
+    private MockServerConfigInterface&MockObject $config;
+    private SyncMessageDriverFactoryInterface&MockObject $driverFactory;
 
     public function setUp(): void
     {


### PR DESCRIPTION
When running static code analysis on `tests/`, there will be a lot of errors like this:

```
Call to an undefined method PhpPact\SomeInterface|PHPUnit\Framework\MockObject\MockObject::expects().
```

This can be fixed by using `intersection types` instead of `union types`. This is a new feature from PHP 8.1 (lowest supported PHP version by Pact-PHP)

By doing this fix more than 110 errors (out of 218 errors) in https://github.com/pact-foundation/pact-php/pull/564
