### PR TITLE
chore: Add void return type to tests

### DIFF
--- a/tests/PhpPact/Consumer/Model/ConsumerRequestTest.php
+++ b/tests/PhpPact/Consumer/Model/ConsumerRequestTest.php
@@ -19,7 +19,7 @@ class ConsumerRequestTest extends TestCase
         $this->request = new ConsumerRequest();
     }
 
-    public function testSerializing()
+    public function testSerializing(): void
     {
         $model = new ConsumerRequest();
         $model
@@ -42,7 +42,7 @@ class ConsumerRequestTest extends TestCase
         $this->assertEquals('application/json', $body->getContentType());
     }
 
-    public function testSerializingWhenPathUsingMatcher()
+    public function testSerializingWhenPathUsingMatcher(): void
     {
         $matcher = new Matcher();
         $pathVariable = '474d610b-c6e3-45bd-9f70-529e7ad21df0';

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/Source/BrokerTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/Source/BrokerTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class BrokerTest extends TestCase
 {
-    public function testSetters()
+    public function testSetters(): void
     {
         $enablePending            = true;
         $wipPactSince             = '2020-01-30';

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/Source/UrlTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/Source/UrlTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class UrlTest extends TestCase
 {
-    public function testSetters()
+    public function testSetters(): void
     {
         $url      = new Uri('http://example.com/path/to/pact.json');
         $token    = 'test-123';

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
 
 class VerifierConfigTest extends TestCase
 {
-    public function testSetters()
+    public function testSetters(): void
     {
         $callingApp = new CallingApp();
         $providerInfo = new ProviderInfo();

--- a/tests/PhpPact/Standalone/StubServer/StubServerConfigTest.php
+++ b/tests/PhpPact/Standalone/StubServer/StubServerConfigTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class StubServerConfigTest extends TestCase
 {
-    public function testSetters()
+    public function testSetters(): void
     {
         $brokerUrl               = new Uri('http://localhost');
         $port                    = 1234;


### PR DESCRIPTION
This change fix errors like this:

```
Method PhpPactTest\SomeTest::testSomething() has  no return type specified.
```

in https://github.com/pact-foundation/pact-php/pull/564