### PR TITLE
chore: Add parameter type

### DIFF
--- a/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
@@ -111,7 +111,7 @@ class InteractionDriverTest extends TestCase
     #[TestWith([null, true])]
     #[TestWith(['123ABC', false])]
     #[TestWith(['123ABC', true])]
-    public function testSetKey(?string $key, $success): void
+    public function testSetKey(?string $key, bool $success): void
     {
         $this->interaction->setKey($key);
         $this->pactDriver
@@ -142,7 +142,7 @@ class InteractionDriverTest extends TestCase
     #[TestWith([true, true])]
     #[TestWith([false, false])]
     #[TestWith([false, true])]
-    public function testSetPending(?bool $pending, $success): void
+    public function testSetPending(?bool $pending, bool $success): void
     {
         $this->interaction->setPending($pending);
         $this->pactDriver
@@ -174,7 +174,7 @@ class InteractionDriverTest extends TestCase
     #[TestWith([['key2' => 'string value'], false])]
     #[TestWith([['key3' => ['value 1', 'value 2']], true])]
     #[TestWith([['key3' => ['value 1', 'value 2']], false])]
-    public function testSetComments(array $comments, $success): void
+    public function testSetComments(array $comments, bool $success): void
     {
         $this->interaction->setComments($comments);
         $this->pactDriver
@@ -201,7 +201,7 @@ class InteractionDriverTest extends TestCase
 
     #[TestWith(['comment 1', false])]
     #[TestWith(['comment 2', true])]
-    public function testAddTextComment(string $comment, $success): void
+    public function testAddTextComment(string $comment, bool $success): void
     {
         $this->interaction->addTextComment($comment);
         $this->pactDriver

--- a/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
@@ -104,7 +104,7 @@ class MessageDriverTest extends TestCase
     #[TestWith([null, true])]
     #[TestWith(['123ABC', false])]
     #[TestWith(['123ABC', true])]
-    public function testSetKey(?string $key, $success): void
+    public function testSetKey(?string $key, bool $success): void
     {
         $this->message->setKey($key);
         $this->pactDriver
@@ -137,7 +137,7 @@ class MessageDriverTest extends TestCase
     #[TestWith([true, true])]
     #[TestWith([false, false])]
     #[TestWith([false, true])]
-    public function testSetPending(?bool $pending, $success): void
+    public function testSetPending(?bool $pending, bool $success): void
     {
         $this->message->setPending($pending);
         $this->pactDriver
@@ -171,7 +171,7 @@ class MessageDriverTest extends TestCase
     #[TestWith([['key2' => 'string value'], false])]
     #[TestWith([['key3' => ['value 1', 'value 2']], true])]
     #[TestWith([['key3' => ['value 1', 'value 2']], false])]
-    public function testSetComments(array $comments, $success): void
+    public function testSetComments(array $comments, bool $success): void
     {
         $this->message->setComments($comments);
         $this->pactDriver
@@ -200,7 +200,7 @@ class MessageDriverTest extends TestCase
 
     #[TestWith(['comment 1', false])]
     #[TestWith(['comment 2', true])]
-    public function testAddTextComment(string $comment, $success): void
+    public function testAddTextComment(string $comment, bool $success): void
     {
         $this->message->addTextComment($comment);
         $this->pactDriver

--- a/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
+++ b/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
@@ -106,7 +106,7 @@ class SyncMessageDriverTest extends TestCase
     #[TestWith([null, true])]
     #[TestWith(['123ABC', false])]
     #[TestWith(['123ABC', true])]
-    public function testSetKey(?string $key, $success): void
+    public function testSetKey(?string $key, bool $success): void
     {
         $this->message->setKey($key);
         $this->pactDriver
@@ -139,7 +139,7 @@ class SyncMessageDriverTest extends TestCase
     #[TestWith([true, true])]
     #[TestWith([false, false])]
     #[TestWith([false, true])]
-    public function testSetPending(?bool $pending, $success): void
+    public function testSetPending(?bool $pending, bool $success): void
     {
         $this->message->setPending($pending);
         $this->pactDriver
@@ -173,7 +173,7 @@ class SyncMessageDriverTest extends TestCase
     #[TestWith([['key2' => 'string value'], false])]
     #[TestWith([['key3' => ['value 1', 'value 2']], true])]
     #[TestWith([['key3' => ['value 1', 'value 2']], false])]
-    public function testSetComments(array $comments, $success): void
+    public function testSetComments(array $comments, bool $success): void
     {
         $this->message->setComments($comments);
         $this->pactDriver
@@ -202,7 +202,7 @@ class SyncMessageDriverTest extends TestCase
 
     #[TestWith(['comment 1', false])]
     #[TestWith(['comment 2', true])]
-    public function testAddTextComment(string $comment, $success): void
+    public function testAddTextComment(string $comment, bool $success): void
     {
         $this->message->addTextComment($comment);
         $this->pactDriver


### PR DESCRIPTION
Fix errors like this:

```
Method PhpPactTest\SomeTest::testSomething() has parameter $success with no type specified.
```

in https://github.com/pact-foundation/pact-php/pull/564