### PR TITLE
chore: Fix bool to int casting errors

### DIFF
--- a/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
@@ -101,7 +101,7 @@ class InteractionDriverTest extends TestCase
         ];
         $this->assertClientCalls($calls);
         $this->mockServer
-            ->expects($this->exactly($startMockServer))
+            ->expects($startMockServer ? $this->once() : $this->never())
             ->method('start');
         $this->assertTrue($this->driver->registerInteraction($this->interaction, $startMockServer));
         $this->assertSame($this->interactionHandle, $this->interaction->getHandle());

--- a/tests/PhpPact/Consumer/MessageBuilderTest.php
+++ b/tests/PhpPact/Consumer/MessageBuilderTest.php
@@ -190,7 +190,7 @@ class MessageBuilderTest extends TestCase
             ->method('reify')
             ->willReturn($jsonMessage);
         $this->driver
-            ->expects($this->exactly(!$callbackThrowException))
+            ->expects($callbackThrowException ? $this->never() : $this->once())
             ->method('writePactAndCleanUp');
         $this->assertSame(!$callbackThrowException, $this->builder->verifyMessage($callback, 'a callback'));
     }
@@ -214,7 +214,7 @@ class MessageBuilderTest extends TestCase
             ->method('reify')
             ->willReturn($jsonMessage);
         $this->driver
-            ->expects($this->exactly(!$callbackThrowException))
+            ->expects($callbackThrowException ? $this->never() : $this->once())
             ->method('writePactAndCleanUp');
         $this->builder->setCallback($callback);
         $this->assertSame(!$callbackThrowException, $this->builder->verify());

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -210,7 +210,7 @@ class VerifierTest extends TestCase
         $json = '{"key": "value"}';
         $this->calls[] = ['pactffi_verifier_execute', $this->handle, $error];
         $this->logger
-            ->expects($this->exactly($hasLogger))
+            ->expects($hasLogger ? $this->once() : $this->never())
             ->method('log')
             ->with($json);
         if ($hasLogger) {


### PR DESCRIPTION
Fix errors like:

```
Parameter #1 $count of method PHPUnit\Framework\TestCase::exactly() expects int, bool given.
```

in https://github.com/pact-foundation/pact-php/pull/564