### PR TITLE
chore: Fix wrong types

### DIFF
--- a/tests/PhpPact/Consumer/Matcher/Matchers/StatusCodeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/StatusCodeTest.php
@@ -27,15 +27,17 @@ class StatusCodeTest extends GeneratorAwareMatcherTestCase
      *           ["serverError", null,  "{\"pact:matcher:type\":\"statusCode\",\"pact:generator:type\":\"RandomInt\",\"status\":\"serverError\",\"min\":500,\"max\":599}"]
      *           ["nonError",    null,  "{\"pact:matcher:type\":\"statusCode\",\"pact:generator:type\":\"RandomInt\",\"status\":\"nonError\",\"min\":100,\"max\":399}"]
      *           ["error",       null,  "{\"pact:matcher:type\":\"statusCode\",\"pact:generator:type\":\"RandomInt\",\"status\":\"error\",\"min\":400,\"max\":599}"]
-     *           ["info",        "123", "{\"pact:matcher:type\":\"statusCode\",\"status\":\"info\",\"value\":123}"]
+     *           ["info",        123,   "{\"pact:matcher:type\":\"statusCode\",\"status\":\"info\",\"value\":123}"]
      */
-    public function testSerialize(string $status, ?string $value, ?string $json): void
+    public function testSerialize(string $status, ?int $value, ?string $json): void
     {
         if (!$json) {
             $this->expectException(InvalidHttpStatusException::class);
             $this->expectExceptionMessage("Status 'invalid' is not supported. Supported status are: info, success, redirect, clientError, serverError, nonError, error");
         }
         $matcher = new StatusCode($status, $value);
-        $this->assertSame($json, json_encode($matcher));
+        $jsonEncoded = json_encode($matcher);
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/StringValueTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/StringValueTest.php
@@ -7,20 +7,15 @@ use PHPUnit\Framework\TestCase;
 
 class StringValueTest extends TestCase
 {
-    protected StringValue $matcher;
-
-    protected function setUp(): void
-    {
-        $this->matcher = new StringValue();
-    }
-
     /**
      * @testWith [null,   "{\"pact:matcher:type\":\"type\",\"value\":\"some string\",\"pact:generator:type\":\"RandomString\",\"size\":10}"]
      *           ["test", "{\"pact:matcher:type\":\"type\",\"value\":\"test\"}"]
      */
     public function testSerialize(?string $value, string $json): void
     {
-        $this->matcher = new StringValue($value);
-        $this->assertJsonStringEqualsJsonString($json, json_encode($this->matcher));
+        $matcher = new StringValue($value);
+        $jsonEncoded = json_encode($matcher);
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
     }
 }


### PR DESCRIPTION
Fix these errors:

```
Parameter #2 $value of class PhpPact\Consumer\Matcher\Matchers\StatusCode constructor expects int|null,
         string|null given.
```

```
Parameter #2 $actualJson of method PHPUnit\Framework\Assert::assertJsonStringEqualsJsonString() expects string,  
         string|false given.
```

For https://github.com/pact-foundation/pact-php/pull/564