### PR TITLE
chore: Specify type of array

### DIFF
--- a/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
@@ -32,6 +32,9 @@ class InteractionBodyDriverTest extends TestCase
     private Binary $binary;
     private Text $text;
     private Multipart $multipart;
+    /**
+     * @var Part[]
+     */
     private array $parts;
     private string $boundary = 'abcde12345';
     private CData $failed;

--- a/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
@@ -33,6 +33,9 @@ class InteractionDriverTest extends TestCase
     private int $interactionHandle = 123;
     private int $pactHandle = 234;
     private string $description = 'Sending request receiving response';
+    /**
+     * @var array<string, array<string, mixed>>
+     */
     private array $providerStates = [
         'item exist' => [
             'id' => 12,
@@ -167,6 +170,9 @@ class InteractionDriverTest extends TestCase
         $this->driver->registerInteraction($this->interaction, false);
     }
 
+    /**
+     * @param array<string, mixed> $comments
+     */
     #[TestWith([[], true])]
     #[TestWith([['key1' => null], true])]
     #[TestWith([['key1' => null], false])]

--- a/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
@@ -28,12 +28,18 @@ class MessageDriverTest extends TestCase
     private int $messageHandle = 123;
     private int $pactHandle = 234;
     private string $description = 'Receiving message';
+    /**
+     * @var array<string, array<string, mixed>>
+     */
     private array $providerStates = [
         'item exist' => [
             'id' => 12,
             'name' => 'abc',
         ]
     ];
+    /**
+     * @var array<string, string>
+     */
     private array $metadata = [
         'key1' => 'value1',
         'key2' => 'value2',
@@ -164,6 +170,9 @@ class MessageDriverTest extends TestCase
         $this->driver->registerMessage($this->message);
     }
 
+    /**
+     * @param array<string, mixed> $comments
+     */
     #[TestWith([[], true])]
     #[TestWith([['key1' => null], true])]
     #[TestWith([['key1' => null], false])]

--- a/tests/PhpPact/Consumer/Driver/InteractionPart/RequestDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/InteractionPart/RequestDriverTest.php
@@ -22,10 +22,16 @@ class RequestDriverTest extends TestCase
     private int $interactionHandle = 123;
     private string $method = 'POST';
     private string $path = '/items/item';
+    /**
+     * @var array<string, string[]>
+     */
     private array $query = [
         'query1' => ['query-value-1', 'query-value-2'],
         'query2' => ['query-value-3'],
     ];
+    /**
+     * @var array<string, string[]>
+     */
     private array $headers = [
         'header1' => ['header-value-1'],
         'header2' => ['header-value-2', 'header-value-3'],

--- a/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
@@ -21,6 +21,9 @@ class ResponseDriverTest extends TestCase
     private int $responsePartId = 2;
     private int $interactionHandle = 123;
     private string $status = '400';
+    /**
+     * @var array<string, string[]>
+     */
     private array $headers = [
         'header1' => ['header-value-1'],
         'header2' => ['header-value-2', 'header-value-3'],

--- a/tests/PhpPact/Consumer/InteractionBuilderTest.php
+++ b/tests/PhpPact/Consumer/InteractionBuilderTest.php
@@ -119,6 +119,9 @@ class InteractionBuilderTest extends TestCase
         $this->assertSame($pending, $interaction->getPending());
     }
 
+    /**
+     * @param array<string, mixed> $comments
+     */
     #[TestWith([[]])]
     #[TestWith([['key1' => null, 'key2' => 'value', 'key3' => ['value']]])]
     public function testSetComments(array $comments): void

--- a/tests/PhpPact/Consumer/Matcher/Formatters/ValueOptionalFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/ValueOptionalFormatterTest.php
@@ -5,22 +5,23 @@ namespace PhpPactTest\Consumer\Matcher\Formatters;
 use PhpPact\Consumer\Matcher\Formatters\ValueOptionalFormatter;
 use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\Date;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class ValueOptionalFormatterTest extends TestCase
 {
-    /**
-     * @testWith [true,  "2001-01-02", {"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10}]
-     *           [false, "2002-02-03", {"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": "2002-02-03"}]
-     *           [true,  null,         {"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10}]
-     *           [false, null,         {"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": null}]
-     */
-    public function testFormat(bool $hasGenerator, ?string $value, array $result): void
+    #[TestWith([true, '2001-01-02', '{"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10}'])]
+    #[TestWith([false, '2002-02-03', '{"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": "2002-02-03"}'])]
+    #[TestWith([true, null, '{"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10}'])]
+    #[TestWith([false, null, '{"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": null}'])]
+    public function testFormat(bool $hasGenerator, ?string $value, string $result): void
     {
         $matcher = new Date('yyyy-MM-dd', $value);
         $generator = $hasGenerator ? new RandomString(10) : null;
         $matcher->setGenerator($generator);
         $formatter = new ValueOptionalFormatter();
-        $this->assertSame($result, $formatter->format($matcher));
+        $jsonEncoded = json_encode($formatter->format($matcher));
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($result, $jsonEncoded);
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/ValueRequiredFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/ValueRequiredFormatterTest.php
@@ -5,22 +5,23 @@ namespace PhpPactTest\Consumer\Matcher\Formatters;
 use PhpPact\Consumer\Matcher\Formatters\ValueRequiredFormatter;
 use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\Date;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class ValueRequiredFormatterTest extends TestCase
 {
-    /**
-     * @testWith [true,  "2001-01-02", {"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10, "value": "2001-01-02"}]
-     *           [false, "2002-02-03", {"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": "2002-02-03"}]
-     *           [true,  null,         {"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10, "value": null}]
-     *           [false, null,         {"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": null}]
-     */
-    public function testFormat(bool $hasGenerator, ?string $value, array $result): void
+    #[TestWith([true, '2001-01-02', '{"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10, "value": "2001-01-02"}'])]
+    #[TestWith([false, '2002-02-03', '{"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": "2002-02-03"}'])]
+    #[TestWith([true, null, '{"pact:matcher:type": "date", "pact:generator:type": "RandomString", "format": "yyyy-MM-dd", "size": 10, "value": null}'])]
+    #[TestWith([false, null, '{"pact:matcher:type": "date", "format": "yyyy-MM-dd", "value": null}'])]
+    public function testFormat(bool $hasGenerator, ?string $value, string $result): void
     {
         $matcher = new Date('yyyy-MM-dd', $value);
         $generator = $hasGenerator ? new RandomString(10) : null;
         $matcher->setGenerator($generator);
         $formatter = new ValueRequiredFormatter();
-        $this->assertSame($result, $formatter->format($matcher));
+        $jsonEncoded = json_encode($formatter->format($matcher));
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($result, $jsonEncoded);
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/XmlContentFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/XmlContentFormatterTest.php
@@ -5,20 +5,21 @@ namespace PhpPactTest\Consumer\Matcher\Formatters;
 use PhpPact\Consumer\Matcher\Formatters\XmlContentFormatter;
 use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\Date;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class XmlContentFormatterTest extends TestCase
 {
-    /**
-     * @testWith [true,  "2001-01-02", {"content": "2001-01-02", "matcher": {"pact:matcher:type": "date", "format": "yyyy-MM-dd", "size": 10}, "pact:generator:type": "RandomString"}]
-     *           [false, "2002-02-03", {"content": "2002-02-03", "matcher": {"pact:matcher:type": "date", "format": "yyyy-MM-dd"}}]
-     */
-    public function testFormat(bool $hasGenerator, ?string $value, array $result): void
+    #[TestWith([true, '2001-01-02', '{"content": "2001-01-02", "matcher": {"pact:matcher:type": "date", "format": "yyyy-MM-dd", "size": 10}, "pact:generator:type": "RandomString"}'])]
+    #[TestWith([false, '2002-02-03', '{"content": "2002-02-03", "matcher": {"pact:matcher:type": "date", "format": "yyyy-MM-dd"}}'])]
+    public function testFormat(bool $hasGenerator, ?string $value, string $result): void
     {
         $matcher = new Date('yyyy-MM-dd', $value);
         $generator = $hasGenerator ? new RandomString(10) : null;
         $matcher->setGenerator($generator);
         $formatter = new XmlContentFormatter();
-        $this->assertSame($result, $formatter->format($matcher));
+        $jsonEncoded = json_encode($formatter->format($matcher));
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($result, $jsonEncoded);
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/XmlElementFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/XmlElementFormatterTest.php
@@ -8,6 +8,7 @@ use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\StringValue;
 use PhpPact\Consumer\Matcher\Matchers\Type;
 use PhpPact\Xml\XmlElement;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class XmlElementFormatterTest extends TestCase
@@ -22,11 +23,9 @@ class XmlElementFormatterTest extends TestCase
         $formatter->format($matcher);
     }
 
-    /**
-     * @testWith [null, {"pact:matcher:type": "type", "value": {"name": "test", "children": [], "attributes": []}}]
-     *           [123,  {"pact:matcher:type": "type", "value": {"name": "test", "children": [], "attributes": []}, "examples": 123}]
-     */
-    public function testFormat(?int $examples, array $result): void
+    #[TestWith([null, '{"pact:matcher:type": "type", "value": {"name": "test", "children": [], "attributes": []}}'])]
+    #[TestWith([123, '{"pact:matcher:type": "type", "value": {"name": "test", "children": [], "attributes": []}, "examples": 123}'])]
+    public function testFormat(?int $examples, string $result): void
     {
         $value = new XmlElement(
             fn (XmlElement $element) => $element->setName('test'),
@@ -34,6 +33,8 @@ class XmlElementFormatterTest extends TestCase
         );
         $matcher = new Type($value);
         $formatter = new XmlElementFormatter();
-        $this->assertSame(json_encode($result), json_encode($formatter->format($matcher)));
+        $jsonEncoded = json_encode($formatter->format($matcher));
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($result, $jsonEncoded);
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Generators/DateTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Generators/DateTest.php
@@ -3,6 +3,7 @@
 namespace PhpPactTest\Consumer\Matcher\Generators;
 
 use PhpPact\Consumer\Matcher\Generators\Date;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class DateTest extends TestCase
@@ -14,11 +15,12 @@ class DateTest extends TestCase
     }
 
     /**
-     * @testWith [null,         null,     []]
-     *           ["yyyy-MM-dd", null,     {"format":"yyyy-MM-dd"}]
-     *           [null,         "+1 day", {"expression":"+1 day"}]
-     *           ["yyyy-MM-dd", "+1 day", {"format":"yyyy-MM-dd","expression":"+1 day"}]
+     * @param array<string, string> $data
      */
+    #[TestWith([null, null, []])]
+    #[TestWith(['yyyy-MM-dd', null, ['format' => 'yyyy-MM-dd']])]
+    #[TestWith([null, '+1 day', ['expression' => '+1 day']])]
+    #[TestWith(['yyyy-MM-dd', '+1 day', ['format' => 'yyyy-MM-dd', 'expression' => '+1 day']])]
     public function testAttributes(?string $format, ?string $expression, array $data): void
     {
         $generator = new Date($format, $expression);

--- a/tests/PhpPact/Consumer/Matcher/Generators/DateTimeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Generators/DateTimeTest.php
@@ -3,6 +3,7 @@
 namespace PhpPactTest\Consumer\Matcher\Generators;
 
 use PhpPact\Consumer\Matcher\Generators\DateTime;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class DateTimeTest extends TestCase
@@ -14,11 +15,12 @@ class DateTimeTest extends TestCase
     }
 
     /**
-     * @testWith [null,                    null,     []]
-     *           ["yyyy-MM-dd'T'HH:mm:ss", null,     {"format":"yyyy-MM-dd'T'HH:mm:ss"}]
-     *           [null,                    "+1 day", {"expression":"+1 day"}]
-     *           ["yyyy-MM-dd'T'HH:mm:ss", "+1 day", {"format":"yyyy-MM-dd'T'HH:mm:ss","expression":"+1 day"}]
+     * @param array<string, string> $data
      */
+    #[TestWith([null, null, []])]
+    #[TestWith(["yyyy-MM-dd'T'HH:mm:ss", null, ['format' => "yyyy-MM-dd'T'HH:mm:ss"]])]
+    #[TestWith([null, '+1 day', ['expression' => '+1 day']])]
+    #[TestWith(["yyyy-MM-dd'T'HH:mm:ss", '+1 day', ['format' => "yyyy-MM-dd'T'HH:mm:ss", 'expression' => '+1 day']])]
     public function testAttributes(?string $format, ?string $expression, array $data): void
     {
         $generator = new DateTime($format, $expression);

--- a/tests/PhpPact/Consumer/Matcher/Generators/TimeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Generators/TimeTest.php
@@ -3,6 +3,7 @@
 namespace PhpPactTest\Consumer\Matcher\Generators;
 
 use PhpPact\Consumer\Matcher\Generators\Time;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class TimeTest extends TestCase
@@ -14,11 +15,12 @@ class TimeTest extends TestCase
     }
 
     /**
-     * @testWith [null,       null,      []]
-     *           ["HH:mm:ss", null,      {"format":"HH:mm:ss"}]
-     *           [null,       "+1 hour", {"expression":"+1 hour"}]
-     *           ["HH:mm:ss", "+1 hour", {"format":"HH:mm:ss","expression":"+1 hour"}]
+     * @param array<string, string> $data
      */
+    #[TestWith([null, null, []])]
+    #[TestWith(['HH:mm:ss', null, ['format' => 'HH:mm:ss']])]
+    #[TestWith([null, '+1 hour', ['expression' => '+1 hour']])]
+    #[TestWith(['HH:mm:ss', '+1 hour', ['format' => 'HH:mm:ss', 'expression' => '+1 hour']])]
     public function testAttributes(?string $format, ?string $expression, array $data): void
     {
         $generator = new Time($format, $expression);

--- a/tests/PhpPact/Consumer/Matcher/Generators/UuidTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Generators/UuidTest.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\Consumer\Matcher\Generators;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidUuidFormatException;
 use PhpPact\Consumer\Matcher\Generators\Uuid;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class UuidTest extends TestCase
@@ -15,13 +16,14 @@ class UuidTest extends TestCase
     }
 
     /**
-     * @testWith [null,                    []]
-     *           ["simple",                {"format":"simple"}]
-     *           ["lower-case-hyphenated", {"format":"lower-case-hyphenated"}]
-     *           ["upper-case-hyphenated", {"format":"upper-case-hyphenated"}]
-     *           ["URN",                   {"format":"URN"}]
-     *           ["invalid",               null]
+     * @param null|array<string, string> $data
      */
+    #[TestWith([null, []])]
+    #[TestWith(['simple', ['format' => 'simple']])]
+    #[TestWith(['lower-case-hyphenated', ['format' => 'lower-case-hyphenated']])]
+    #[TestWith(['upper-case-hyphenated', ['format' => 'upper-case-hyphenated']])]
+    #[TestWith(['URN', ['format' => 'URN']])]
+    #[TestWith(['invalid', null])]
     public function testAttributes(?string $format, ?array $data): void
     {
         if (null === $data) {

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -37,6 +37,7 @@ use PhpPact\Consumer\Matcher\Matchers\StringValue;
 use PhpPact\Consumer\Matcher\Matchers\Time;
 use PhpPact\Consumer\Matcher\Matchers\Type;
 use PhpPact\Consumer\Matcher\Matchers\Values;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class MatcherTest extends TestCase
@@ -109,81 +110,45 @@ class MatcherTest extends TestCase
         $this->assertInstanceOf(Regex::class, $this->matcher->dateISO8601('2010-01-17'));
     }
 
-    /**
-     * @dataProvider dataProviderForTimeTest
-     */
+    #[TestWith(['T22:44:30.652Z'])]
+    #[TestWith(['T22:44:30Z'])]
+    #[TestWith(['T22:44Z'])]
+    #[TestWith(['T22:44:30+01:00'])]
+    #[TestWith(['T22:44:30+0100'])]
+    #[TestWith(['T22:44:30+01'])]
+    #[TestWith(['T22:44:30'])]
+    #[TestWith(['T22:44:30-12:00'])]
+    #[TestWith(['T22:44:30+0545'])]
+    #[TestWith(['T22:44:30+14'])]
     public function testTimeISO8601(string $time): void
     {
         $this->assertInstanceOf(Regex::class, $this->matcher->timeISO8601($time));
     }
 
-    /**
-     * @return string[]
-     */
-    public static function dataProviderForTimeTest(): array
-    {
-        return [
-            ['T22:44:30.652Z'],
-            ['T22:44:30Z'],
-            ['T22:44Z'],
-            ['T22:44:30+01:00'],
-            ['T22:44:30+0100'],
-            ['T22:44:30+01'],
-            ['T22:44:30'],
-            ['T22:44:30-12:00'],
-            ['T22:44:30+0545'],
-            ['T22:44:30+14'],
-        ];
-    }
-
-    /**
-     * @dataProvider dataProviderForDateTimeTest
-     */
+    #[TestWith(['2015-08-06T16:53:10+01:00'])]
+    #[TestWith(['2015-08-06T16:53:10+0100'])]
+    #[TestWith(['2015-08-06T16:53:10+01'])]
+    #[TestWith(['2015-08-06T16:53:10Z'])]
+    #[TestWith(['2015-08-06T16:53:10'])]
+    #[TestWith(['2015-08-06T16:53:10-12:00'])]
+    #[TestWith(['2015-08-06T16:53:10+0545'])]
+    #[TestWith(['2015-08-06T16:53:10+14'])]
     public function testDateTimeISO8601(string $dateTime): void
     {
         $this->assertInstanceOf(Regex::class, $this->matcher->dateTimeISO8601($dateTime));
     }
 
-    /**
-     * @return string[]
-     */
-    public static function dataProviderForDateTimeTest(): array
-    {
-        return [
-            ['2015-08-06T16:53:10+01:00'],
-            ['2015-08-06T16:53:10+0100'],
-            ['2015-08-06T16:53:10+01'],
-            ['2015-08-06T16:53:10Z'],
-            ['2015-08-06T16:53:10'],
-            ['2015-08-06T16:53:10-12:00'],
-            ['2015-08-06T16:53:10+0545'],
-            ['2015-08-06T16:53:10+14'],
-        ];
-    }
-
-    /**
-     * @dataProvider dataProviderForDateTimeWithMillisTest
-     */
+    #[TestWith(['2015-08-06T16:53:10.123+01:00'])]
+    #[TestWith(['2015-08-06T16:53:10.123+0100'])]
+    #[TestWith(['2015-08-06T16:53:10.123+01'])]
+    #[TestWith(['2015-08-06T16:53:10.123Z'])]
+    #[TestWith(['2015-08-06T16:53:10.123'])]
+    #[TestWith(['2015-08-06T16:53:10.123-12:00'])]
+    #[TestWith(['2015-08-06T16:53:10.123+0545'])]
+    #[TestWith(['2015-08-06T16:53:10.123+14'])]
     public function testDateTimeWithMillisISO8601(string $dateTime): void
     {
         $this->assertInstanceOf(Regex::class, $this->matcher->dateTimeWithMillisISO8601($dateTime));
-    }
-
-    /**
-     * @return string[]
-     */
-    public static function dataProviderForDateTimeWithMillisTest(): array
-    {
-        return [
-            ['2015-08-06T16:53:10.123+01:00'],
-            ['2015-08-06T16:53:10.123+0100'],
-            ['2015-08-06T16:53:10.123+01'],
-            ['2015-08-06T16:53:10.123Z'],
-            ['2015-08-06T16:53:10.123'],
-            ['2015-08-06T16:53:10.123-12:00'],
-            ['2015-08-06T16:53:10.123+0545'],
-            ['2015-08-06T16:53:10.123+14'],
-        ];
     }
 
     public function testTimestampRFC3339(): void
@@ -221,10 +186,8 @@ class MatcherTest extends TestCase
         $this->assertInstanceOf(Decimal::class, $this->matcher->decimalV3(13.01));
     }
 
-    /**
-     * @testWith [null, true]
-     *           ["3F", false]
-     */
+    #[TestWith([null, true])]
+    #[TestWith(['3F', false])]
     public function testHexadecimal(?string $value, bool $hasGenerator): void
     {
         $hexadecimal = $this->matcher->hexadecimal($value);
@@ -236,10 +199,8 @@ class MatcherTest extends TestCase
         }
     }
 
-    /**
-     * @testWith [null,                                   true]
-     *           ["ce118b6e-d8e1-11e7-9296-cec278b6b50a", false]
-     */
+    #[TestWith([null, true])]
+    #[TestWith(['ce118b6e-d8e1-11e7-9296-cec278b6b50a', false])]
     public function testUuid(?string $value, bool $hasGenerator): void
     {
         $uuid = $this->matcher->uuid($value);
@@ -383,10 +344,8 @@ class MatcherTest extends TestCase
         $this->assertInstanceOf(EachValue::class, $this->matcher->eachValue($values, $rules));
     }
 
-    /**
-     * @testWith [true, true]
-     *           [false, false]
-     */
+    #[TestWith([true, true])]
+    #[TestWith([false, false])]
     public function testUrl(bool $useMockServerBasePath, bool $hasGenerator): void
     {
         $url = $this->matcher->url('http://localhost:1234/path', '.*(/path)$', $useMockServerBasePath);

--- a/tests/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcherTestCase.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/GeneratorAwareMatcherTestCase.php
@@ -18,6 +18,7 @@ use PhpPact\Consumer\Matcher\Generators\Time;
 use PhpPact\Consumer\Matcher\Generators\Uuid;
 use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 abstract class GeneratorAwareMatcherTestCase extends TestCase
@@ -31,9 +32,18 @@ abstract class GeneratorAwareMatcherTestCase extends TestCase
         json_encode($matcher);
     }
 
-    /**
-     * @dataProvider generatorProvider
-     */
+    #[TestWith([new Date()])]
+    #[TestWith([new DateTime()])]
+    #[TestWith([new MockServerURL('.*(/\d+)$', 'http://example.com/123')])]
+    #[TestWith([new ProviderState('${key}')])]
+    #[TestWith([new RandomBoolean()])]
+    #[TestWith([new RandomDecimal()])]
+    #[TestWith([new RandomHexadecimal()])]
+    #[TestWith([new RandomInt()])]
+    #[TestWith([new RandomString()])]
+    #[TestWith([new Regex('\w')])]
+    #[TestWith([new Time()])]
+    #[TestWith([new Uuid()])]
     public function testGeneratorNotRequired(GeneratorInterface $generator): void
     {
         $matcher = $this->getMatcherWithExampleValue();
@@ -41,27 +51,6 @@ abstract class GeneratorAwareMatcherTestCase extends TestCase
         $this->expectExceptionMessage(sprintf("Generator '%s' is not required for matcher '%s' when example value is set", $generator->getType(), $matcher->getType()));
         $matcher->setGenerator($generator);
         json_encode($matcher);
-    }
-
-    /**
-     * @return GeneratorInterface[]
-     */
-    public static function generatorProvider(): array
-    {
-        return [
-            [new Date()],
-            [new DateTime()],
-            [new MockServerURL('.*(/\d+)$', 'http://example.com/123')],
-            [new ProviderState('${key}')],
-            [new RandomBoolean()],
-            [new RandomDecimal()],
-            [new RandomHexadecimal()],
-            [new RandomInt()],
-            [new RandomString()],
-            [new Regex('\w')],
-            [new Time()],
-            [new Uuid()],
-        ];
     }
 
     abstract protected function getMatcherWithExampleValue(): GeneratorAwareMatcher;

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MatchingFieldTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MatchingFieldTest.php
@@ -10,14 +10,14 @@ use PhpPact\Consumer\Matcher\Formatters\ValueRequiredFormatter;
 use PhpPact\Consumer\Matcher\Formatters\XmlContentFormatter;
 use PhpPact\Consumer\Matcher\Formatters\XmlElementFormatter;
 use PhpPact\Consumer\Matcher\Matchers\MatchingField;
+use PhpPact\Consumer\Matcher\Model\FormatterInterface;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class MatchingFieldTest extends TestCase
 {
-    /**
-     * @testWith ["person",                "\"matching($'person')\""]
-     *           ["probably doesn't work", "\"matching($'probably doesn\\\\'t work')\""]
-     */
+    #[TestWith(['person', "\"matching($'person')\""])]
+    #[TestWith(["probably doesn't work", "\"matching($'probably doesn\\\\'t work')\""])]
     public function testSerialize(string $fieldName, string $json): void
     {
         $matcher = new MatchingField($fieldName);
@@ -28,26 +28,17 @@ class MatchingFieldTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider formatterProvider
-     */
-    public function testNotSupportedFormatter(string $formatterClassName): void
+    #[TestWith([new MinimalFormatter()])]
+    #[TestWith([new ValueOptionalFormatter()])]
+    #[TestWith([new ValueRequiredFormatter()])]
+    #[TestWith([new XmlContentFormatter()])]
+    #[TestWith([new XmlElementFormatter()])]
+    public function testNotSupportedFormatter(FormatterInterface $formatter): void
     {
         $this->expectException(MatcherNotSupportedException::class);
         $this->expectExceptionMessage('MatchingField matcher only work with plugin');
         $matcher = new MatchingField('person');
-        $matcher->setFormatter(new $formatterClassName());
+        $matcher->setFormatter($formatter);
         json_encode($matcher);
-    }
-
-    public static function formatterProvider(): array
-    {
-        return [
-            [MinimalFormatter::class],
-            [ValueOptionalFormatter::class],
-            [ValueRequiredFormatter::class],
-            [XmlContentFormatter::class],
-            [XmlElementFormatter::class],
-        ];
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/RegexTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/RegexTest.php
@@ -5,6 +5,7 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 use PhpPact\Consumer\Matcher\Exception\InvalidRegexException;
 use PhpPact\Consumer\Matcher\Matchers\GeneratorAwareMatcher;
 use PhpPact\Consumer\Matcher\Matchers\Regex;
+use PHPUnit\Framework\Attributes\TestWith;
 
 class RegexTest extends GeneratorAwareMatcherTestCase
 {
@@ -21,12 +22,13 @@ class RegexTest extends GeneratorAwareMatcherTestCase
     }
 
     /**
-     * @testWith [null,            "{\"pact:matcher:type\":\"regex\",\"pact:generator:type\":\"Regex\",\"regex\":\"\\\\d+\"}"]
-     *           ["number",        null]
-     *           [["integer"],     null]
-     *           ["12+",           "{\"pact:matcher:type\":\"regex\",\"regex\":\"\\\\d+\",\"value\":\"12+\"}"]
-     *           [["12.3", "456"], "{\"pact:matcher:type\":\"regex\",\"regex\":\"\\\\d+\",\"value\":[\"12.3\",\"456\"]}"]
+     * @param string|string[]|null $values
      */
+    #[TestWith([null, '{"pact:matcher:type":"regex","pact:generator:type":"Regex","regex":"\\\\d+"}'])]
+    #[TestWith(['number', null])]
+    #[TestWith([['integer'], null])]
+    #[TestWith(['12+', '{"pact:matcher:type":"regex","regex":"\\\\d+","value":"12+"}'])]
+    #[TestWith([['12.3', '456'], '{"pact:matcher:type":"regex","regex":"\\\\d+","value":["12.3","456"]}'])]
     public function testSerialize(string|array|null $values, ?string $json): void
     {
         if (!$json && $values) {

--- a/tests/PhpPact/Consumer/Matcher/Matchers/ValuesTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/ValuesTest.php
@@ -3,14 +3,16 @@
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Matchers\Values;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class ValuesTest extends TestCase
 {
     /**
-     * @testWith [["value 1", "value 2"],                   "{\"pact:matcher:type\":\"values\",\"value\":[\"value 1\",\"value 2\"]}"]
-     *           [{"key 1": "value 1", "key 2": "value 2"}, "{\"pact:matcher:type\":\"values\",\"value\":{\"key 1\":\"value 1\",\"key 2\":\"value 2\"}}"]
+     * @param string[] $values
      */
+    #[TestWith([['value 1', 'value 2'], '{"pact:matcher:type":"values","value":["value 1","value 2"]}'])]
+    #[TestWith([['key 1' => 'value 1', 'key 2' => 'value 2'], '{"pact:matcher:type":"values","value":{"key 1":"value 1","key 2":"value 2"}}'])]
     public function testSerialize(array $values, string $json): void
     {
         $array = new Values($values);

--- a/tests/PhpPact/Consumer/MessageBuilderTest.php
+++ b/tests/PhpPact/Consumer/MessageBuilderTest.php
@@ -101,6 +101,9 @@ class MessageBuilderTest extends TestCase
         $this->assertSame($pending, $message->getPending());
     }
 
+    /**
+     * @param array<string, mixed> $comments
+     */
     #[TestWith([[]])]
     #[TestWith([['key1' => null, 'key2' => 'value', 'key3' => ['value']]])]
     public function testSetComments(array $comments): void
@@ -227,6 +230,9 @@ class MessageBuilderTest extends TestCase
         return $reflection->getValue($this->builder);
     }
 
+    /**
+     * @return array<string, callable>
+     */
     private function getCallbacks(): array
     {
         $reflection = new ReflectionProperty($this->builder, 'callback');

--- a/tests/PhpPact/Helper/FFI/ClientTrait.php
+++ b/tests/PhpPact/Helper/FFI/ClientTrait.php
@@ -11,6 +11,9 @@ trait ClientTrait
 {
     protected ClientInterface&MockObject $client;
 
+    /**
+     * @param mixed[][] $calls
+     */
     protected function assertClientCalls(array $calls): void
     {
         $this->client

--- a/tests/PhpPact/Plugin/Driver/Body/PluginBodyDriverTest.php
+++ b/tests/PhpPact/Plugin/Driver/Body/PluginBodyDriverTest.php
@@ -131,7 +131,14 @@ class PluginBodyDriverTest extends TestCase
         };
     }
 
-    #[DataProvider('errorProvider')]
+    #[TestWith([0])]
+    #[TestWith([1])]
+    #[TestWith([2])]
+    #[TestWith([3])]
+    #[TestWith([4])]
+    #[TestWith([5])]
+    #[TestWith([6])]
+    #[TestWith([7])]
     public function testRequestJsonBody(int $error): void
     {
         $this->interaction->getRequest()->setBody($this->json);
@@ -147,7 +154,14 @@ class PluginBodyDriverTest extends TestCase
         $this->driver->registerBody($this->interaction, InteractionPart::REQUEST);
     }
 
-    #[DataProvider('errorProvider')]
+    #[TestWith([0])]
+    #[TestWith([1])]
+    #[TestWith([2])]
+    #[TestWith([3])]
+    #[TestWith([4])]
+    #[TestWith([5])]
+    #[TestWith([6])]
+    #[TestWith([7])]
     public function testResponseJsonBody(int $error): void
     {
         $this->interaction->getResponse()->setBody($this->json);
@@ -163,7 +177,14 @@ class PluginBodyDriverTest extends TestCase
         $this->driver->registerBody($this->interaction, InteractionPart::RESPONSE);
     }
 
-    #[DataProvider('errorProvider')]
+    #[TestWith([0])]
+    #[TestWith([1])]
+    #[TestWith([2])]
+    #[TestWith([3])]
+    #[TestWith([4])]
+    #[TestWith([5])]
+    #[TestWith([6])]
+    #[TestWith([7])]
     public function testMessageJsonBody(int $error): void
     {
         $this->message->setContents($this->json);
@@ -177,20 +198,6 @@ class PluginBodyDriverTest extends TestCase
             $this->expectExceptionMessage($this->getPluginBodyErrorMessage($error));
         }
         $this->driver->registerBody($this->message, InteractionPart::REQUEST);
-    }
-
-    public static function errorProvider(): array
-    {
-        return [
-            [0],
-            [1],
-            [2],
-            [3],
-            [4],
-            [5],
-            [6],
-            [7],
-        ];
     }
 
     #[TestWith([InteractionPart::REQUEST])]

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectorsTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/ConsumerVersionSelectorsTest.php
@@ -4,27 +4,19 @@ namespace PhpPactTest\Standalone\ProviderVerifier\Model;
 
 use PhpPact\Standalone\ProviderVerifier\Model\ConsumerVersionSelectors;
 use PhpPact\Standalone\ProviderVerifier\Model\Selector\Selector;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class ConsumerVersionSelectorsTest extends TestCase
 {
     /**
-     * @dataProvider selectorsProvider
+     * @param string[] $result
      */
-    public function testJsonSerialize(array $selectors, array $result): void
+    #[TestWith([new ConsumerVersionSelectors(['{ "mainBranch": true }', '{ "deployedOrReleased": true }']), ['{ "mainBranch": true }', '{ "deployedOrReleased": true }']])]
+    #[TestWith([new ConsumerVersionSelectors([new Selector(matchingBranch: true), '{ "mainBranch": true }', new Selector(deployedOrReleased: true)]), ['{"matchingBranch":true}', '{ "mainBranch": true }', '{"deployedOrReleased":true}']])]
+    #[TestWith([new ConsumerVersionSelectors([new Selector(mainBranch: true)]), ['{"mainBranch":true}']])]
+    public function testJsonSerialize(ConsumerVersionSelectors $selectors, array $result): void
     {
-        static::assertSame($result, iterator_to_array(new ConsumerVersionSelectors($selectors)));
-    }
-
-    /**
-     * @return array<int, array<mixed>>
-     */
-    public static function selectorsProvider(): array
-    {
-        return [
-            [['{ "mainBranch": true }', '{ "deployedOrReleased": true }'], ['{ "mainBranch": true }', '{ "deployedOrReleased": true }']],
-            [[new Selector(matchingBranch: true), '{ "mainBranch": true }', new Selector(deployedOrReleased: true)], ['{"matchingBranch":true}', '{ "mainBranch": true }', '{"deployedOrReleased":true}']],
-            [[new Selector(mainBranch: true)], ['{"mainBranch":true}']],
-        ];
+        static::assertSame($result, iterator_to_array($selectors));
     }
 }

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/Selector/SelectorTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/Selector/SelectorTest.php
@@ -4,17 +4,16 @@ namespace PhpPactTest\Standalone\ProviderVerifier\Model\Selector;
 
 use PhpPact\Standalone\ProviderVerifier\Exception\InvalidSelectorValueException;
 use PhpPact\Standalone\ProviderVerifier\Model\Selector\Selector;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class SelectorTest extends TestCase
 {
-    /**
-     * @testWith ["mainBranch"]
-     *           ["matchingBranch"]
-     *           ["deployed"]
-     *           ["released"]
-     *           ["deployedOrReleased"]
-     */
+    #[TestWith(['mainBranch'])]
+    #[TestWith(['matchingBranch'])]
+    #[TestWith(['deployed'])]
+    #[TestWith(['released'])]
+    #[TestWith(['deployedOrReleased'])]
     public function testInvalidSelectorValue(string $key): void
     {
         $values = [$key => false];
@@ -23,15 +22,13 @@ class SelectorTest extends TestCase
         new Selector(...$values);
     }
 
-    /**
-     * @testWith [{ "mainBranch": true }, "{\"mainBranch\":true}"]
-     *           [{ "branch": "feat-xxx" }, "{\"branch\":\"feat-xxx\"}"]
-     *           [{ "deployedOrReleased": true }, "{\"deployedOrReleased\":true}"]
-     *           [{ "matchingBranch": true }, "{\"matchingBranch\":true}"]
-     *           [{ "mainBranch": null, "branch": "fix-yyy", "fallbackBranch": null, "matchingBranch": null, "tag": null, "fallbackTag": null, "deployed": null, "released": null, "deployedOrReleased": null, "environment": null, "latest": null, "consumer": "my-consumer" }, "{\"branch\":\"fix-yyy\",\"consumer\":\"my-consumer\"}"]
-     */
-    public function testJsonSerialize(array $values, string $json): void
+    #[TestWith([new Selector(mainBranch: true), '{"mainBranch":true}'])]
+    #[TestWith([new Selector(branch: 'feat-xxx'), '{"branch":"feat-xxx"}'])]
+    #[TestWith([new Selector(deployedOrReleased: true), '{"deployedOrReleased":true}'])]
+    #[TestWith([new Selector(matchingBranch: true), '{"matchingBranch":true}'])]
+    #[TestWith([new Selector(mainBranch: null, branch: 'fix-yyy', fallbackBranch: null, matchingBranch: null, tag: null, fallbackTag: null, deployed: null, released: null, deployedOrReleased: null, environment: null, latest: null, consumer: 'my-consumer'), '{"branch":"fix-yyy","consumer":"my-consumer"}'])]
+    public function testJsonSerialize(Selector $selector, string $json): void
     {
-        static::assertSame($json, json_encode(new Selector(...$values)));
+        static::assertSame($json, json_encode($selector));
     }
 }

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -29,6 +29,9 @@ class VerifierTest extends TestCase
     private VerifierConfigInterface $config;
     private LoggerInterface&MockObject $logger;
     private CData $handle;
+    /**
+     * @var mixed[][]
+     */
     private array $calls;
 
     protected function setUp(): void

--- a/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
+++ b/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
@@ -31,12 +31,18 @@ class SyncMessageDriverTest extends TestCase
     private int $messageHandle = 123;
     private int $pactHandle = 234;
     private string $description = 'Receiving message';
+    /**
+     * @var array<string, mixed>
+     */
     private array $providerStates = [
         'item exist' => [
             'id' => 12,
             'name' => 'abc',
         ]
     ];
+    /**
+     * @var array<string, string>
+     */
     private array $metadata = [
         'key1' => 'value1',
         'key2' => 'value2',
@@ -166,6 +172,9 @@ class SyncMessageDriverTest extends TestCase
         $this->driver->registerMessage($this->message);
     }
 
+    /**
+     * @param array<string, mixed> $comments
+     */
     #[TestWith([[], true])]
     #[TestWith([['key1' => null], true])]
     #[TestWith([['key1' => null], false])]

--- a/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
+++ b/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
@@ -99,6 +99,9 @@ class SyncMessageBuilderTest extends TestCase
         $this->assertSame($pending, $message->getPending());
     }
 
+    /**
+     * @param array<string, mixed> $comments
+     */
     #[TestWith([[]])]
     #[TestWith([['key1' => null, 'key2' => 'value', 'key3' => ['value']]])]
     public function testSetComments(array $comments): void


### PR DESCRIPTION
Fix these errors:

```
Method PhpPactTest\SomeTest::testSomething() has         
         parameter $data with no value type specified in iterable type array.
```

```
Method                                                                                      
         PhpPactTest\SomeTest::someProvider()              
         return type has no value type specified in iterable type array.
```

```
Property                                                                              
         PhpPactTest\SomeTest::$something type         
         has no value type specified in iterable type array.
```

For https://github.com/pact-foundation/pact-php/pull/564