### PR TITLE
chore: Assert json encoded value is string

### DIFF
--- a/tests/PhpPact/Consumer/Matcher/Matchers/ContentTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/ContentTypeTest.php
@@ -9,10 +9,12 @@ class ContentTypeTest extends TestCase
 {
     public function testSerialize(): void
     {
-        $contentType = new ContentType('text/csv');
+        $matcher = new ContentType('text/csv');
+        $jsonEncoded = json_encode($matcher);
+        $this->assertIsString($jsonEncoded);
         $this->assertJsonStringEqualsJsonString(
             '{"value":"text\/csv","pact:matcher:type":"contentType"}',
-            json_encode($contentType)
+            $jsonEncoded
         );
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EachKeyTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EachKeyTest.php
@@ -22,10 +22,12 @@ class EachKeyTest extends TestCase
             new Type('string'),
             new Regex('\w{3}'),
         ];
-        $eachKey = new EachKey($value, $rules);
+        $matcher = new EachKey($value, $rules);
+        $jsonEncoded = json_encode($matcher);
+        $this->assertIsString($jsonEncoded);
         $this->assertJsonStringEqualsJsonString(
             '{"pact:matcher:type":"eachKey","value":{"abc":123,"def":111,"ghi":{"test":"value"}},"rules":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"regex","pact:generator:type":"Regex","regex":"\\\\w{3}"}]}',
-            json_encode($eachKey)
+            $jsonEncoded
         );
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
@@ -20,10 +20,12 @@ class EachValueTest extends TestCase
             new Type('string'),
             new Regex('\w{2}\d'),
         ];
-        $eachValue = new EachValue($value, $rules);
+        $matcher = new EachValue($value, $rules);
+        $jsonEncoded = json_encode($matcher);
+        $this->assertIsString($jsonEncoded);
         $this->assertJsonStringEqualsJsonString(
             '{"pact:matcher:type":"eachValue","value":["ab1","cd2","ef9"],"rules":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"regex","pact:generator:type":"Regex","regex":"\\\\w{2}\\\\d"}]}',
-            json_encode($eachValue)
+            $jsonEncoded
         );
     }
 }


### PR DESCRIPTION
Fix errors like this:

```
Parameter #2 $actualJson of method                                            
         PHPUnit\Framework\Assert::assertJsonStringEqualsJsonString() expects string,  
         string|false given.
```

For https://github.com/pact-foundation/pact-php/pull/564