### PR TITLE
chore: Use class-string PHPdoc

### DIFF
--- a/tests/PhpPact/Consumer/MessageBuilderTest.php
+++ b/tests/PhpPact/Consumer/MessageBuilderTest.php
@@ -66,6 +66,9 @@ class MessageBuilderTest extends TestCase
         $this->assertSame($metadata, $message->getMetadata());
     }
 
+    /**
+     * @param null|class-string<Text> $contentClass
+     */
     #[TestWith([null                                          , null])]
     #[TestWith([new Text('example', 'text/plain')             , null])]
     #[TestWith([new Binary('/path/to/image.jpg', 'image/jpeg'), null])]

--- a/tests/PhpPact/Helper/FactoryTrait.php
+++ b/tests/PhpPact/Helper/FactoryTrait.php
@@ -7,7 +7,7 @@ use ReflectionProperty;
 trait FactoryTrait
 {
     /**
-     * @param array<string, string> $properties
+     * @param array<string, class-string<object>> $properties
      */
     private function assertPropertiesInstanceOf(object $object, ?string $class, array $properties): void
     {

--- a/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
+++ b/tests/PhpPact/SyncMessage/SyncMessageBuilderTest.php
@@ -64,6 +64,9 @@ class SyncMessageBuilderTest extends TestCase
         $this->assertSame($metadata, $message->getMetadata());
     }
 
+    /**
+     * @param null|class-string<Text> $contentClass
+     */
     #[TestWith([null                                          , null])]
     #[TestWith([new Text('example', 'text/plain')             , null])]
     #[TestWith([new Binary('/path/to/image.jpg', 'image/jpeg'), null])]


### PR DESCRIPTION
Fix these errors:

```
Parameter #1 $expected of method PHPUnit\Framework\Assert::assertInstanceOf()  
         expects class-string<object>, string given.
```

For https://github.com/pact-foundation/pact-php/pull/564