### PR TITLE
chore: Fix 'Variable $key might not be defined'

### DIFF
--- a/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/InteractionDriverTest.php
@@ -190,10 +190,10 @@ class InteractionDriverTest extends TestCase
         ];
         foreach ($comments as $key => $value) {
             $calls[] = ['pactffi_set_comment', $this->interactionHandle, $key, (is_string($value) || is_null($value)) ? $value : json_encode($value), $success];
-        }
-        if (!$success) {
-            $this->expectException(InteractionCommentNotSetException::class);
-            $this->expectExceptionMessage("Can not add comment '$key' to the interaction '{$this->description}'");
+            if (!$success) {
+                $this->expectException(InteractionCommentNotSetException::class);
+                $this->expectExceptionMessage("Can not add comment '$key' to the interaction '{$this->description}'");
+            }
         }
         $this->assertClientCalls($calls);
         $this->driver->registerInteraction($this->interaction, false);

--- a/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Interaction/MessageDriverTest.php
@@ -189,10 +189,10 @@ class MessageDriverTest extends TestCase
         ];
         foreach ($comments as $key => $value) {
             $calls[] = ['pactffi_set_comment', $this->messageHandle, $key, (is_string($value) || is_null($value)) ? $value : json_encode($value), $success];
-        }
-        if (!$success) {
-            $this->expectException(InteractionCommentNotSetException::class);
-            $this->expectExceptionMessage("Can not add comment '$key' to the interaction '{$this->description}'");
+            if (!$success) {
+                $this->expectException(InteractionCommentNotSetException::class);
+                $this->expectExceptionMessage("Can not add comment '$key' to the interaction '{$this->description}'");
+            }
         }
         $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);

--- a/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
+++ b/tests/PhpPact/SyncMessage/Driver/Interaction/SyncMessageDriverTest.php
@@ -191,10 +191,10 @@ class SyncMessageDriverTest extends TestCase
         ];
         foreach ($comments as $key => $value) {
             $calls[] = ['pactffi_set_comment', $this->messageHandle, $key, (is_string($value) || is_null($value)) ? $value : json_encode($value), $success];
-        }
-        if (!$success) {
-            $this->expectException(InteractionCommentNotSetException::class);
-            $this->expectExceptionMessage("Can not add comment '$key' to the interaction '{$this->description}'");
+            if (!$success) {
+                $this->expectException(InteractionCommentNotSetException::class);
+                $this->expectExceptionMessage("Can not add comment '$key' to the interaction '{$this->description}'");
+            }
         }
         $this->assertClientCalls($calls);
         $this->driver->registerMessage($this->message);


### PR DESCRIPTION
Fix this error:

```
Variable $key might not be defined.
```

For https://github.com/pact-foundation/pact-php/pull/564