### PR TITLE
chore: Fix 'Match expression does not handle remaining value'

### DIFF
--- a/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Body/InteractionBodyDriverTest.php
@@ -138,15 +138,31 @@ class InteractionBodyDriverTest extends TestCase
     public function testRequestMultipartBody(bool $success): void
     {
         $this->interaction->getRequest()->setBody($this->multipart);
+        $matcher = $this->exactly(count($this->parts));
+        $calls = [
+            [
+                'args' => ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary],
+                'return' => (object) ['failed' => null],
+            ],
+            [
+                'args' => ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary],
+                'return' => (object) ['failed' => null],
+            ],
+            [
+                'args' => ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary],
+                'return' => (object) (['failed' => $success ? null : $this->failed]),
+            ]
+        ];
         $this->client
-            ->expects($this->exactly(count($this->parts)))
+            ->expects($matcher)
             ->method('call')
             ->willReturnCallback(
-                fn (string $method, int $interactionId, int $partId, string $contentType, string $path, string $name, string $boundary) =>
-                match([$method, $interactionId, $partId, $contentType, $path, $name, $boundary]) {
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) ['failed' => null],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) ['failed' => null],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->requestPartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) (['failed' => $success ? null : $this->failed]),
+                function (...$args) use ($calls, $matcher) {
+                    $index = $matcher->numberOfInvocations() - 1;
+                    $call = $calls[$index];
+                    $this->assertSame($call['args'], $args);
+
+                    return $call['return'];
                 }
             );
         if (!$success) {
@@ -161,15 +177,31 @@ class InteractionBodyDriverTest extends TestCase
     public function testResponseMultipartBody(bool $success): void
     {
         $this->interaction->getResponse()->setBody($this->multipart);
+        $matcher = $this->exactly(count($this->parts));
+        $calls = [
+            [
+                'args' => ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary],
+                'return' => (object) ['failed' => null],
+            ],
+            [
+                'args' => ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary],
+                'return' => (object) ['failed' => null],
+            ],
+            [
+                'args' => ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary],
+                'return' => (object) (['failed' => $success ? null : $this->failed]),
+            ]
+        ];
         $this->client
-            ->expects($this->exactly(count($this->parts)))
+            ->expects($matcher)
             ->method('call')
             ->willReturnCallback(
-                fn (string $method, int $interactionId, int $partId, string $contentType, string $path, string $name, string $boundary) =>
-                match([$method, $interactionId, $partId, $contentType, $path, $name, $boundary]) {
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[0]->getContentType(), $this->parts[0]->getPath(), $this->parts[0]->getName(), $this->boundary] => (object) ['failed' => null],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[1]->getContentType(), $this->parts[1]->getPath(), $this->parts[1]->getName(), $this->boundary] => (object) ['failed' => null],
-                    ['pactffi_with_multipart_file_v2', $this->interactionHandle, $this->responsePartId, $this->parts[2]->getContentType(), $this->parts[2]->getPath(), $this->parts[2]->getName(), $this->boundary] => (object) (['failed' => $success ? null : $this->failed]),
+                function (...$args) use ($calls, $matcher) {
+                    $index = $matcher->numberOfInvocations() - 1;
+                    $call = $calls[$index];
+                    $this->assertSame($call['args'], $args);
+
+                    return $call['return'];
                 }
             );
         if (!$success) {

--- a/tests/PhpPact/Consumer/Driver/InteractionPart/RequestDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/InteractionPart/RequestDriverTest.php
@@ -59,18 +59,26 @@ class RequestDriverTest extends TestCase
             ->method('get')
             ->with('InteractionPart_Request')
             ->willReturn($this->requestPartId);
+        $calls = [
+            ['pactffi_with_header_v2', $this->interactionHandle, $this->requestPartId, 'header1', 0, 'header-value-1'],
+            ['pactffi_with_header_v2', $this->interactionHandle, $this->requestPartId, 'header2', 0, 'header-value-2'],
+            ['pactffi_with_header_v2', $this->interactionHandle, $this->requestPartId, 'header2', 1, 'header-value-3'],
+            ['pactffi_with_query_parameter_v2', $this->interactionHandle, 'query1', 0, 'query-value-1'],
+            ['pactffi_with_query_parameter_v2', $this->interactionHandle, 'query1', 1, 'query-value-2'],
+            ['pactffi_with_query_parameter_v2', $this->interactionHandle, 'query2', 0, 'query-value-3'],
+            ['pactffi_with_request', $this->interactionHandle, $this->method, $this->path],
+        ];
+        $matcher = $this->exactly(count($calls));
         $this->client
-            ->expects($this->exactly(7))
+            ->expects($matcher)
             ->method('call')
             ->willReturnCallback(
-                fn (...$args) => match($args) {
-                    ['pactffi_with_request', $this->interactionHandle, $this->method, $this->path] => null,
-                    ['pactffi_with_query_parameter_v2', $this->interactionHandle, 'query1', 0, 'query-value-1'] => null,
-                    ['pactffi_with_query_parameter_v2', $this->interactionHandle, 'query1', 1, 'query-value-2'] => null,
-                    ['pactffi_with_query_parameter_v2', $this->interactionHandle, 'query2', 0, 'query-value-3'] => null,
-                    ['pactffi_with_header_v2', $this->interactionHandle, $this->requestPartId, 'header1', 0, 'header-value-1'] => null,
-                    ['pactffi_with_header_v2', $this->interactionHandle, $this->requestPartId, 'header2', 0, 'header-value-2'] => null,
-                    ['pactffi_with_header_v2', $this->interactionHandle, $this->requestPartId, 'header2', 1, 'header-value-3'] => null,
+                function (...$args) use ($calls, $matcher) {
+                    $index = $matcher->numberOfInvocations() - 1;
+                    $call = $calls[$index];
+                    $this->assertSame($call, $args);
+
+                    return null;
                 }
             );
         $this->bodyDriver


### PR DESCRIPTION
Fix errors like this:

```
Match expression does not handle remaining value: array{string, int, int,  
         string, string, string, string}
```

```
Match expression does not handle remaining value: mixed
```

For https://github.com/pact-foundation/pact-php/pull/564