### PR TITLE
chore: Fix copy paste issues in MinimalFormatterTest

### DIFF
--- a/tests/PhpPact/Consumer/Matcher/Formatters/MinimalFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/MinimalFormatterTest.php
@@ -3,7 +3,6 @@
 namespace PhpPactTest\Consumer\Matcher\Formatters;
 
 use PhpPact\Consumer\Matcher\Formatters\MinimalFormatter;
-use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\Date;
 use PHPUnit\Framework\TestCase;
 
@@ -17,12 +16,11 @@ class MinimalFormatterTest extends TestCase
      */
     public function testFormat(bool $hasGenerator, ?string $value): void
     {
-        $matcher = new Date('yyyy-MM-dd', 5);
-        $generator = $hasGenerator ? new RandomString(10) : null;
+        $matcher = new Date('yyyy-MM-dd', $value);
         $formatter = new MinimalFormatter();
         $this->assertSame([
             'pact:matcher:type' => 'date',
             'format' => 'yyyy-MM-dd',
-        ], $formatter->format($matcher, $generator, $value));
+        ], $formatter->format($matcher));
     }
 }


### PR DESCRIPTION
Fix these errors:

```
  20     Parameter #2 $value of class PhpPact\Consumer\Matcher\Matchers\Date constructor  
         expects string|null, int given.                                                  
  26     Method PhpPact\Consumer\Matcher\Formatters\MinimalFormatter::format() invoked    
         with 3 parameters, 1 required.
```

It's my bad. I copied pasted without modifying.

For https://github.com/pact-foundation/pact-php/pull/564