### PR TITLE
chore: Fix wrong type

### DIFF
--- a/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
@@ -20,7 +20,7 @@ class ResponseDriverTest extends TestCase
     private Interaction $interaction;
     private int $responsePartId = 2;
     private int $interactionHandle = 123;
-    private string $status = '400';
+    private int $status = 400;
     /**
      * @var array<string, string[]>
      */

--- a/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/InteractionPart/ResponseDriverTest.php
@@ -53,7 +53,7 @@ class ResponseDriverTest extends TestCase
             ['pactffi_with_header_v2', $this->interactionHandle, $this->responsePartId, 'header1', 0, 'header-value-1'],
             ['pactffi_with_header_v2', $this->interactionHandle, $this->responsePartId, 'header2', 0, 'header-value-2'],
             ['pactffi_with_header_v2', $this->interactionHandle, $this->responsePartId, 'header2', 1, 'header-value-3'],
-            ['pactffi_response_status_v2', $this->interactionHandle, $this->status],
+            ['pactffi_response_status_v2', $this->interactionHandle, (string) $this->status],
         ];
         $matcher = $this->exactly(count($calls));
         $this->client


### PR DESCRIPTION
Fix this error:

```
  40     Parameter #1 $status of method                                        
         PhpPact\Consumer\Model\ProviderResponse::setStatus() expects          
         int|PhpPact\Consumer\Matcher\Model\MatcherInterface, string given.
```

For https://github.com/pact-foundation/pact-php/pull/564