### PR TITLE
chore: Fix variable not callable

### DIFF
--- a/tests/PhpPact/Consumer/MessageBuilderTest.php
+++ b/tests/PhpPact/Consumer/MessageBuilderTest.php
@@ -182,6 +182,9 @@ class MessageBuilderTest extends TestCase
     public function testVerifyMessage(bool $callbackThrowException): void
     {
         $jsonMessage = '{"key": "value"}';
+        /**
+         * @var MockObject&callable
+         */
         $callback = $this->getMockBuilder(stdClass::class)
             ->addMethods(['__invoke'])
             ->getMock();
@@ -206,6 +209,9 @@ class MessageBuilderTest extends TestCase
     public function testVerify(bool $callbackThrowException): void
     {
         $jsonMessage = '{"key": "value"}';
+        /**
+         * @var MockObject&callable
+         */
         $callback = $this->getMockBuilder(stdClass::class)
             ->addMethods(['__invoke'])
             ->getMock();


### PR DESCRIPTION
Fix these errors:

```
  201    Parameter #1 $callback of method                                                 
         PhpPact\Consumer\MessageBuilder::verifyMessage() expects callable(): mixed,      
         PHPUnit\Framework\MockObject\MockObject&stdClass given.                          
  225    Parameter #1 $callback of method PhpPact\Consumer\MessageBuilder::setCallback()  
         expects callable(): mixed, PHPUnit\Framework\MockObject\MockObject&stdClass      
         given.
```

For https://github.com/pact-foundation/pact-php/pull/564