### PR TITLE
chore: PHPStan ignore line

### DIFF
--- a/tests/PhpPact/FFI/Model/ArrayDataTest.php
+++ b/tests/PhpPact/FFI/Model/ArrayDataTest.php
@@ -20,7 +20,7 @@ class ArrayDataTest extends TestCase
 
         $this->assertSame(count($branches), $arrayData->getSize());
         foreach ($branches as $index => $branch) {
-            $this->assertSame($branch, FFI::string($arrayData->getItems()[$index]));
+            $this->assertSame($branch, FFI::string($arrayData->getItems()[$index])); // @phpstan-ignore-line
         }
     }
 }


### PR DESCRIPTION
Ignore this error:

```
Cannot access offset 0|1|2|3 on FFI\CData.
```

For https://github.com/pact-foundation/pact-php/pull/564