### PR TITLE
chore: Assert variable is string

### DIFF
--- a/tests/PhpPact/FFI/Model/BinaryDataTest.php
+++ b/tests/PhpPact/FFI/Model/BinaryDataTest.php
@@ -19,6 +19,7 @@ class BinaryDataTest extends TestCase
     {
         $path = __DIR__ . '/../../../_resources/image.jpg';
         $contents = file_get_contents($path);
+        $this->assertIsString($contents);
         $length = \strlen($contents);
 
         $binaryData = BinaryData::createFrom($contents);


### PR DESCRIPTION
Fix these errors:

```
  22     Parameter #1 $string of function strlen expects string, string|false given.     
  24     Parameter #1 $contents of static method                                         
         PhpPact\FFI\Model\BinaryData::createFrom() expects string, string|false given.
```

For https://github.com/pact-foundation/pact-php/pull/564