### PR TITLE
docs(chore): remove erroneous span closing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 
 #### Fast, easy and reliable testing for your APIs and microservices.
 
-</span>
-
 **Pact** is the de-facto API contract testing tool. Replace expensive and brittle end-to-end integration tests with fast, reliable and easy to debug unit tests.
 
 - ⚡ Lightning fast


### PR DESCRIPTION
Just working on a docs sync job to pact-docs site and this throws an error because there isn't an opening tag