### PR TITLE
docs(ci): add trigger update to docs.pact.io

### DIFF
--- a/.github/workflows/trigger_pact_docs_update.yml
+++ b/.github/workflows/trigger_pact_docs_update.yml
@@ -1,0 +1,22 @@
+name: Trigger update to docs.pact.io
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - '**.md'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger docs.pact.io update workflow
+        run: |
+          curl -X POST https://api.github.com/repos/pact-foundation/docs.pact.io/dispatches \
+                -H 'Accept: application/vnd.github.everest-preview+json' \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -d '{"event_type": "pact-php-docs-updated"}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GHTOKENFORTRIGGERINGPACTDOCSUPDATE }}


### PR DESCRIPTION
sync job not currently present in docs.pact.io repo on master, but will be later today 