### PR TITLE
refactor: Apply Visitor pattern for NotEmpty matcher

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
@@ -28,9 +28,6 @@ class PluginFormatter implements FormatterInterface
             throw new GeneratorNotRequiredException('Generator is not support in plugin');
         }
 
-        if ($matcher instanceof NotEmpty) {
-            return $this->formatNotEmptyMatcher($matcher);
-        }
         if ($matcher instanceof EachKey || $matcher instanceof EachValue) {
             return $this->formatEachKeyAndEachValueMatchers($matcher);
         }
@@ -71,7 +68,7 @@ class PluginFormatter implements FormatterInterface
         return sprintf("matching(%s, %s, %s)", $matcher->getType(), $this->normalize($config), $this->normalize($matcher->getValue()));
     }
 
-    private function formatNotEmptyMatcher(NotEmpty $matcher): string
+    public function formatNotEmptyMatcher(NotEmpty $matcher): string
     {
         return sprintf('notEmpty(%s)', $this->normalize($matcher->getValue()));
     }

--- a/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
@@ -2,6 +2,8 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
+
 /**
  * Value must be present and not empty (not null or the empty string)
  */
@@ -31,5 +33,18 @@ class NotEmpty extends AbstractMatcher
     public function getType(): string
     {
         return 'notEmpty';
+    }
+
+    /**
+     * @return string|array<string, mixed>
+     */
+    public function jsonSerialize(): string|array
+    {
+        $formatter = $this->getFormatter();
+        if ($formatter instanceof PluginFormatter) {
+            return $formatter->formatNotEmptyMatcher($this);
+        }
+
+        return parent::jsonSerialize();
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/PluginFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/PluginFormatterTest.php
@@ -78,6 +78,7 @@ class PluginFormatterTest extends TestCase
     }
 
     #[TestWith([new MatchingField('product')])]
+    #[TestWith([new NotEmpty('test')])]
     #[TestWith([new Values([1, 2, 3])])]
     #[TestWith([new ArrayContains([new Equality(1)])])]
     #[TestWith([new StatusCode('clientError', 405)])]
@@ -88,7 +89,6 @@ class PluginFormatterTest extends TestCase
         $this->formatter->format($matcher);
     }
 
-    #[TestWith([new NotEmpty('test'), '"notEmpty(\'test\')"'])]
     #[TestWith([new EachKey(["doesn't matter"], [new Regex('\$(\.\w+)+', '$.test.one')]), '"eachKey(matching(regex, \'\\\\$(\\\\.\\\\w+)+\', \'$.test.one\'))"'])]
     #[TestWith([new EachValue(["doesn't matter"], [new Type(100)]), '"eachValue(matching(type, 100))"'])]
     #[TestWith([new Equality('Example value'), '"matching(equalTo, \'Example value\')"'])]
@@ -115,6 +115,14 @@ class PluginFormatterTest extends TestCase
         $this->assertSame(
             "matching($'product')",
             $this->formatter->formatMatchingFieldMatcher(new MatchingField('product'))
+        );
+    }
+
+    public function testFormatNotEmptyMatcher(): void
+    {
+        $this->assertSame(
+            "notEmpty('simple text')",
+            $this->formatter->formatNotEmptyMatcher(new NotEmpty('simple text'))
         );
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/NotEmptyTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/NotEmptyTest.php
@@ -2,17 +2,29 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
 use PhpPact\Consumer\Matcher\Matchers\NotEmpty;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class NotEmptyTest extends TestCase
 {
     public function testSerialize(): void
     {
-        $array = new NotEmpty(['some text']);
+        $matcher = new NotEmpty(['some text']);
         $this->assertSame(
             '{"pact:matcher:type":"notEmpty","value":["some text"]}',
-            json_encode($array)
+            json_encode($matcher)
+        );
+    }
+
+    public function testSerializeIntoExpression(): void
+    {
+        $matcher = new NotEmpty('some text');
+        $matcher->setFormatter(new PluginFormatter());
+        $this->assertSame(
+            "\"notEmpty('some text')\"",
+            json_encode($matcher)
         );
     }
 }


### PR DESCRIPTION
There are a lot of `if` conditions in `PluginFormatter`. I think `Visitor` pattern can be applied to solve this.
