### PR TITLE
refactor: Apply Visitor pattern for EachValue/EachKey matchers

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
@@ -28,9 +28,6 @@ class PluginFormatter implements FormatterInterface
             throw new GeneratorNotRequiredException('Generator is not support in plugin');
         }
 
-        if ($matcher instanceof EachKey || $matcher instanceof EachValue) {
-            return $this->formatEachKeyAndEachValueMatchers($matcher);
-        }
         if ($matcher instanceof NullValue) {
             return $this->formatMatchersWithoutConfig(new Type(null));
         }
@@ -73,7 +70,7 @@ class PluginFormatter implements FormatterInterface
         return sprintf('notEmpty(%s)', $this->normalize($matcher->getValue()));
     }
 
-    private function formatEachKeyAndEachValueMatchers(EachKey|EachValue $matcher): string
+    private function formatMapMatchers(EachKey|EachValue $matcher): string
     {
         $rules = $matcher->getRules();
         if (count($rules) === 0 || count($rules) > 1) {
@@ -82,6 +79,16 @@ class PluginFormatter implements FormatterInterface
         $rule = reset($rules);
 
         return sprintf('%s(%s)', $matcher->getType(), $this->format($rule));
+    }
+
+    public function formatEachKeyMatcher(EachKey $matcher): string
+    {
+        return $this->formatMapMatchers($matcher);
+    }
+
+    public function formatEachValueMatcher(EachValue $matcher): string
+    {
+        return $this->formatMapMatchers($matcher);
     }
 
     private function normalize(mixed $value): string

--- a/src/PhpPact/Consumer/Matcher/Matchers/EachKey.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/EachKey.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 
 /**
@@ -45,5 +46,18 @@ class EachKey extends AbstractMatcher
     public function getRules(): array
     {
         return $this->rules;
+    }
+
+    /**
+     * @return string|array<string, mixed>
+     */
+    public function jsonSerialize(): string|array
+    {
+        $formatter = $this->getFormatter();
+        if ($formatter instanceof PluginFormatter) {
+            return $formatter->formatEachKeyMatcher($this);
+        }
+
+        return parent::jsonSerialize();
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/EachValue.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/EachValue.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 
 /**
@@ -45,5 +46,18 @@ class EachValue extends AbstractMatcher
     public function getRules(): array
     {
         return $this->rules;
+    }
+
+    /**
+     * @return string|array<string, mixed>
+     */
+    public function jsonSerialize(): string|array
+    {
+        $formatter = $this->getFormatter();
+        if ($formatter instanceof PluginFormatter) {
+            return $formatter->formatEachValueMatcher($this);
+        }
+
+        return parent::jsonSerialize();
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EachKeyTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EachKeyTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
 use PhpPact\Consumer\Matcher\Matchers\EachKey;
 use PhpPact\Consumer\Matcher\Matchers\Regex;
 use PhpPact\Consumer\Matcher\Matchers\Type;
@@ -28,6 +29,16 @@ class EachKeyTest extends TestCase
         $this->assertJsonStringEqualsJsonString(
             '{"pact:matcher:type":"eachKey","value":{"abc":123,"def":111,"ghi":{"test":"value"}},"rules":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"regex","pact:generator:type":"Regex","regex":"\\\\w{3}"}]}',
             $jsonEncoded
+        );
+    }
+
+    public function testSerializeIntoExpression(): void
+    {
+        $matcher = new EachKey(['abc' => 123], [new Regex('\w{3}', 'abc')]);
+        $matcher->setFormatter(new PluginFormatter());
+        $this->assertSame(
+            "\"eachKey(matching(regex, '\\\\w{3}', 'abc'))\"",
+            json_encode($matcher)
         );
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
 use PhpPact\Consumer\Matcher\Matchers\EachValue;
 use PhpPact\Consumer\Matcher\Matchers\Regex;
 use PhpPact\Consumer\Matcher\Matchers\Type;
@@ -26,6 +27,16 @@ class EachValueTest extends TestCase
         $this->assertJsonStringEqualsJsonString(
             '{"pact:matcher:type":"eachValue","value":["ab1","cd2","ef9"],"rules":[{"pact:matcher:type":"type","value":"string"},{"pact:matcher:type":"regex","pact:generator:type":"Regex","regex":"\\\\w{2}\\\\d"}]}',
             $jsonEncoded
+        );
+    }
+
+    public function testSerializeIntoExpression(): void
+    {
+        $matcher = new EachValue(['ab1', 'cd2'], [new Regex('\w{2}\d', 'xz3')]);
+        $matcher->setFormatter(new PluginFormatter());
+        $this->assertSame(
+            "\"eachValue(matching(regex, '\\\\w{2}\\\\d', 'xz3'))\"",
+            json_encode($matcher)
         );
     }
 }


### PR DESCRIPTION
There are a lot of `if` conditions in `PluginFormatter.` I think `Visitor` pattern can be applied to solve this.