### PR TITLE
refactor: Apply Visitor pattern for ContentType matcher

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/PluginFormatter.php
@@ -38,7 +38,7 @@ class PluginFormatter implements FormatterInterface
         if (in_array($matcher->getType(), self::MATCHERS_WITHOUT_CONFIG)) {
             return $this->formatMatchersWithoutConfig($matcher);
         }
-        if ($matcher instanceof AbstractDateTime || $matcher instanceof Regex || $matcher instanceof ContentType) {
+        if ($matcher instanceof AbstractDateTime || $matcher instanceof Regex) {
             return $this->formatMatchersWithConfig($matcher);
         }
 
@@ -94,5 +94,12 @@ class PluginFormatter implements FormatterInterface
             'NULL' => 'null',
             default => throw new MatchingExpressionException(sprintf("Plugin formatter doesn't support value of type %s", gettype($value))),
         };
+    }
+
+    public function formatContentTypeMatcher(ContentType $matcher): string
+    {
+        $value = $this->normalize($matcher->getValue());
+
+        return sprintf("matching(%s, %s, %s)", $matcher->getType(), $value, $value);
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/ContentType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/ContentType.php
@@ -2,6 +2,8 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
+
 /**
  * Match binary data by its content type (magic file check)
  */
@@ -25,5 +27,18 @@ class ContentType extends AbstractMatcher
     public function getType(): string
     {
         return 'contentType';
+    }
+
+    /**
+     * @return string|array<string, mixed>
+     */
+    public function jsonSerialize(): string|array
+    {
+        $formatter = $this->getFormatter();
+        if ($formatter instanceof PluginFormatter) {
+            return $formatter->formatContentTypeMatcher($this);
+        }
+
+        return parent::jsonSerialize();
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/PluginFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/PluginFormatterTest.php
@@ -79,6 +79,7 @@ class PluginFormatterTest extends TestCase
 
     #[TestWith([new MatchingField('product')])]
     #[TestWith([new NotEmpty('test')])]
+    #[TestWith([new ContentType('application/xml')])]
     #[TestWith([new Values([1, 2, 3])])]
     #[TestWith([new ArrayContains([new Equality(1)])])]
     #[TestWith([new StatusCode('clientError', 405)])]
@@ -103,7 +104,6 @@ class PluginFormatterTest extends TestCase
     #[TestWith([new Date('yyyy-MM-dd', '2012-04-12'), '"matching(date, \'yyyy-MM-dd\', \'2012-04-12\')"'])]
     #[TestWith([new Time('HH:mm', '22:04'), '"matching(time, \'HH:mm\', \'22:04\')"'])]
     #[TestWith([new Regex('\\w{3}\\d+', 'abc123'), '"matching(regex, \'\\\\w{3}\\\\d+\', \'abc123\')"'])]
-    #[TestWith([new ContentType('application/xml'), '"matching(contentType, \'application\/xml\', \'application\/xml\')"'])]
     #[TestWith([new NullValue(), '"matching(type, null)"'])]
     public function testFormat(MatcherInterface $matcher, string $json): void
     {
@@ -123,6 +123,14 @@ class PluginFormatterTest extends TestCase
         $this->assertSame(
             "notEmpty('simple text')",
             $this->formatter->formatNotEmptyMatcher(new NotEmpty('simple text'))
+        );
+    }
+
+    public function testFormatContentTypeMatcher(): void
+    {
+        $this->assertSame(
+            "matching(contentType, 'application/xml', 'application/xml')",
+            $this->formatter->formatContentTypeMatcher(new ContentType('application/xml'))
         );
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/ContentTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/ContentTypeTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
+use PhpPact\Consumer\Matcher\Formatters\PluginFormatter;
 use PhpPact\Consumer\Matcher\Matchers\ContentType;
 use PHPUnit\Framework\TestCase;
 
@@ -15,6 +16,16 @@ class ContentTypeTest extends TestCase
         $this->assertJsonStringEqualsJsonString(
             '{"value":"text\/csv","pact:matcher:type":"contentType"}',
             $jsonEncoded
+        );
+    }
+
+    public function testSerializeIntoExpression(): void
+    {
+        $matcher = new ContentType('text/csv');
+        $matcher->setFormatter(new PluginFormatter());
+        $this->assertSame(
+            '"matching(contentType, \'text\/csv\', \'text\/csv\')"',
+            json_encode($matcher)
         );
     }
 }


### PR DESCRIPTION
There are a lot of`if` conditions in `PluginFormatter`. I think `Visitor` pattern can be applied to solve this.