### PR TITLE
refactor: Add formatters for Min/Max Type matchers

### DIFF
--- a/compatibility-suite/tests/Service/MatchingRuleConverter.php
+++ b/compatibility-suite/tests/Service/MatchingRuleConverter.php
@@ -34,14 +34,14 @@ final class MatchingRuleConverter implements MatchingRuleConverterInterface
             case 'type':
                 $min = $rule->getMatcherAttribute('min');
                 $max = $rule->getMatcherAttribute('max');
-                if (null !== $min && null !== $max) {
-                    return new MinMaxType($value, $min, $max);
+                if (null !== $min && null !== $max && is_array($value)) {
+                    return new MinMaxType(reset($value), $min, $max);
                 }
-                if (null !== $min) {
-                    return new MinType($value, $min);
+                if (null !== $min && is_array($value)) {
+                    return new MinType(reset($value), $min);
                 }
-                if (null !== $max) {
-                    return new MaxType($value, $max);
+                if (null !== $max && is_array($value)) {
+                    return new MaxType(reset($value), $max);
                 }
                 return new Type($value);
 

--- a/example/matchers/consumer/tests/Service/MatchersTest.php
+++ b/example/matchers/consumer/tests/Service/MatchersTest.php
@@ -129,6 +129,9 @@ class MatchersTest extends TestCase
                         ),
                         $this->matcher->atLeast(2),
                         $this->matcher->atMost(3),
+                        // These matchers are allowed, but are not recommend
+                        // $this->matcher->atLeastLike('any thing, will be ignored', 2),
+                        // $this->matcher->atMostLike('any thing, will be ignored, 3),
                     ],
                 ),
                 'atLeast' => $this->matcher->atLeast(2), // Not useful when outside of `matchAll`

--- a/src/PhpPact/Consumer/Matcher/Formatters/Expression/MaxTypeFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/Expression/MaxTypeFormatter.php
@@ -12,6 +12,9 @@ class MaxTypeFormatter extends AbstractExpressionFormatter
         if (!$matcher instanceof MaxType) {
             throw $this->getMatcherNotSupportedException($matcher);
         }
+        if ($matcher->isMatchingType()) {
+            return sprintf('atMost(%u), eachValue(matching(type, %s)', $matcher->getMax(), $this->normalize($matcher->getValue()));
+        }
 
         return sprintf('atMost(%u)', $matcher->getMax());
     }

--- a/src/PhpPact/Consumer/Matcher/Formatters/Expression/MinMaxTypeFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/Expression/MinMaxTypeFormatter.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Formatters\Expression;
+
+use PhpPact\Consumer\Matcher\Matchers\MinMaxType;
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+class MinMaxTypeFormatter extends AbstractExpressionFormatter
+{
+    public function format(MatcherInterface $matcher): string
+    {
+        if (!$matcher instanceof MinMaxType) {
+            throw $this->getMatcherNotSupportedException($matcher);
+        }
+
+        return sprintf('atLeast(%u), atMost(%u), eachValue(matching(type, %s)', $matcher->getMin(), $matcher->getMax(), $this->normalize($matcher->getValue()));
+    }
+}

--- a/src/PhpPact/Consumer/Matcher/Formatters/Expression/MinTypeFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/Expression/MinTypeFormatter.php
@@ -12,6 +12,9 @@ class MinTypeFormatter extends AbstractExpressionFormatter
         if (!$matcher instanceof MinType) {
             throw $this->getMatcherNotSupportedException($matcher);
         }
+        if ($matcher->isMatchingType()) {
+            return sprintf('atLeast(%u), eachValue(matching(type, %s)', $matcher->getMin(), $this->normalize($matcher->getValue()));
+        }
 
         return sprintf('atLeast(%u)', $matcher->getMin());
     }

--- a/src/PhpPact/Consumer/Matcher/Formatters/Json/MaxTypeFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/Json/MaxTypeFormatter.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Formatters\Json;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Matchers\MaxType;
+use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+class MaxTypeFormatter implements JsonFormatterInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function format(MatcherInterface $matcher): array
+    {
+        if (!$matcher instanceof MaxType) {
+            throw new MatcherNotSupportedException(sprintf('Matcher %s is not supported by %s', $matcher->getType(), self::class));
+        }
+
+        return [
+            'pact:matcher:type' => $matcher->getType(),
+            'max' => $matcher->getMax(),
+            'value' => [$matcher->getValue()],
+        ];
+    }
+}

--- a/src/PhpPact/Consumer/Matcher/Formatters/Json/MinMaxTypeFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/Json/MinMaxTypeFormatter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Formatters\Json;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Matchers\MinMaxType;
+use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+class MinMaxTypeFormatter implements JsonFormatterInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function format(MatcherInterface $matcher): array
+    {
+        if (!$matcher instanceof MinMaxType) {
+            throw new MatcherNotSupportedException(sprintf('Matcher %s is not supported by %s', $matcher->getType(), self::class));
+        }
+        $examples = max($matcher->getMin(), 1); // Min can be zero, but number of examples must be at least 1
+
+        return [
+            'pact:matcher:type' => $matcher->getType(),
+            'min' => $matcher->getMin(),
+            'max' => $matcher->getMax(),
+            'value' => array_fill(0, $examples, $matcher->getValue()),
+        ];
+    }
+}

--- a/src/PhpPact/Consumer/Matcher/Formatters/Json/MinTypeFormatter.php
+++ b/src/PhpPact/Consumer/Matcher/Formatters/Json/MinTypeFormatter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Formatters\Json;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Matchers\MinType;
+use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
+use PhpPact\Consumer\Matcher\Model\MatcherInterface;
+
+class MinTypeFormatter implements JsonFormatterInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function format(MatcherInterface $matcher): array
+    {
+        if (!$matcher instanceof MinType) {
+            throw new MatcherNotSupportedException(sprintf('Matcher %s is not supported by %s', $matcher->getType(), self::class));
+        }
+        $examples = max($matcher->getMin(), 1); // Min can be zero, but number of examples must be at least 1
+
+        return [
+            'pact:matcher:type' => $matcher->getType(),
+            'min' => $matcher->getMin(),
+            'value' => array_fill(0, $examples, $matcher->getValue()),
+        ];
+    }
+}

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -74,7 +74,7 @@ class Matcher
     }
 
     /**
-     * Expect an array of similar data as the value passed in.
+     * Array where each element must match the given value
      */
     public function eachLike(mixed $value): MatcherInterface
     {
@@ -82,45 +82,35 @@ class Matcher
     }
 
     /**
-     * @param mixed $value example of what the expected data would be
-     * @param int   $min   minimum number of objects to verify against
+     * An array that has to have at least one element and each element must match the given value
      */
-    public function atLeastLike(mixed $value, int $min): MatcherInterface
+    public function atLeastOneLike(mixed $value): MatcherInterface
     {
-        return $this->withFormatter(new MinType(array_fill(0, $min, $value), $min));
-    }
-
-    public function atMostLike(mixed $value, int $max): MatcherInterface
-    {
-        return $this->withFormatter(new MaxType([$value], $max));
+        return $this->atLeastLike($value, 1);
     }
 
     /**
-     * @param mixed    $value example of what the expected data would be
-     * @param int      $min   minimum number of objects to verify against
-     * @param int      $max   maximum number of objects to verify against
-     * @param int|null $count number of examples to generate, defaults to one
-     *
-     * @throws MatcherException
+     * An array that has to have at least the required number of elements and each element must match the given value
      */
-    public function constrainedArrayLike(mixed $value, int $min, int $max, ?int $count = null): MatcherInterface
+    public function atLeastLike(mixed $value, int $min): MatcherInterface
     {
-        $elements = $count ?? $min;
-        if ($count !== null) {
-            if ($count < $min) {
-                throw new MatcherException(
-                    "constrainedArrayLike has a minimum of {$min} but {$count} elements where requested." .
-                    ' Make sure the count is greater than or equal to the min.'
-                );
-            } elseif ($count > $max) {
-                throw new MatcherException(
-                    "constrainedArrayLike has a maximum of {$max} but {$count} elements where requested." .
-                    ' Make sure the count is less than or equal to the max.'
-                );
-            }
-        }
+        return $this->withFormatter(new MinType($value, $min));
+    }
 
-        return $this->withFormatter(new MinMaxType(array_fill(0, $elements, $value), $min, $max));
+    /**
+     * An array that has to have at most the required number of elements and each element must match the given value
+     */
+    public function atMostLike(mixed $value, int $max): MatcherInterface
+    {
+        return $this->withFormatter(new MaxType($value, $max));
+    }
+
+    /**
+     * An array whose size is constrained to the minimum and maximum number of elements and each element must match the given value
+     */
+    public function constrainedArrayLike(mixed $value, int $min, int $max): MatcherInterface
+    {
+        return $this->withFormatter(new MinMaxType($value, $min, $max));
     }
 
     /**
@@ -473,14 +463,20 @@ class Matcher
         return $this->withFormatter(new MatchAll($value, $matchers));
     }
 
+    /**
+     * An array that has to have at least the required number of elements
+     */
     public function atLeast(int $min): MatcherInterface
     {
-        return $this->atLeastLike(null, $min);
+        return $this->withFormatter(new MinType(null, $min, false));
     }
 
+    /**
+     * An array that has to have at most the required number of elements
+     */
     public function atMost(int $max): MatcherInterface
     {
-        return $this->atMostLike(null, $max);
+        return $this->withFormatter(new MaxType(null, $max, false));
     }
 
     private function withFormatter(MatcherInterface $matcher): MatcherInterface

--- a/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
@@ -2,8 +2,8 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Formatters\Expression\MaxTypeFormatter;
-use PhpPact\Consumer\Matcher\Formatters\Json\NoGeneratorFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Expression\MaxTypeFormatter as ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Json\MaxTypeFormatter as JsonFormatter;
 use PhpPact\Consumer\Matcher\Model\ExpressionFormatterInterface;
 use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
 
@@ -13,13 +13,15 @@ use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
  */
 class MaxType extends AbstractMatcher
 {
-    /**
-     * @param array<mixed> $values
-     */
     public function __construct(
-        private array $values,
+        private mixed $value,
         private int $max,
+        private bool $matchingType = true
     ) {
+        if ($max < 0) {
+            trigger_error("[WARN] max value to an array matcher can't be less than zero", E_USER_WARNING);
+            $this->max = 0;
+        }
         parent::__construct();
     }
 
@@ -31,12 +33,9 @@ class MaxType extends AbstractMatcher
         return ['max' => $this->max];
     }
 
-    /**
-     * @return array<int, mixed>
-     */
-    public function getValue(): array
+    public function getValue(): mixed
     {
-        return array_values($this->values);
+        return $this->value;
     }
 
     public function getType(): string
@@ -49,13 +48,18 @@ class MaxType extends AbstractMatcher
         return $this->max;
     }
 
+    public function isMatchingType(): bool
+    {
+        return $this->matchingType;
+    }
+
     public function createJsonFormatter(): JsonFormatterInterface
     {
-        return new NoGeneratorFormatter();
+        return new JsonFormatter();
     }
 
     public function createExpressionFormatter(): ExpressionFormatterInterface
     {
-        return new MaxTypeFormatter();
+        return new ExpressionFormatter();
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/MinMaxType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MinMaxType.php
@@ -2,8 +2,8 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
-use PhpPact\Consumer\Matcher\Formatters\Json\NoGeneratorFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Expression\MinMaxTypeFormatter as ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Json\MinMaxTypeFormatter as JsonFormatter;
 use PhpPact\Consumer\Matcher\Model\ExpressionFormatterInterface;
 use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
 
@@ -13,14 +13,19 @@ use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
  */
 class MinMaxType extends AbstractMatcher
 {
-    /**
-     * @param array<mixed> $values
-     */
     public function __construct(
-        private array $values,
+        private mixed $value,
         private int $min,
         private int $max,
     ) {
+        if ($min < 0) {
+            trigger_error("[WARN] min value to an array matcher can't be less than zero", E_USER_WARNING);
+            $this->min = 0;
+        }
+        if ($max < 0) {
+            trigger_error("[WARN] max value to an array matcher can't be less than zero", E_USER_WARNING);
+            $this->max = 0;
+        }
         parent::__construct();
     }
 
@@ -35,12 +40,9 @@ class MinMaxType extends AbstractMatcher
         ];
     }
 
-    /**
-     * @return array<int, mixed>
-     */
-    public function getValue(): array
+    public function getValue(): mixed
     {
-        return array_values($this->values);
+        return $this->value;
     }
 
     public function getType(): string
@@ -48,13 +50,23 @@ class MinMaxType extends AbstractMatcher
         return 'type';
     }
 
+    public function getMin(): int
+    {
+        return $this->min;
+    }
+
+    public function getMax(): int
+    {
+        return $this->max;
+    }
+
     public function createJsonFormatter(): JsonFormatterInterface
     {
-        return new NoGeneratorFormatter();
+        return new JsonFormatter();
     }
 
     public function createExpressionFormatter(): ExpressionFormatterInterface
     {
-        throw new MatcherNotSupportedException("MinMaxType matcher doesn't support expression formatter");
+        return new ExpressionFormatter();
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
@@ -2,8 +2,8 @@
 
 namespace PhpPact\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Formatters\Expression\MinTypeFormatter;
-use PhpPact\Consumer\Matcher\Formatters\Json\NoGeneratorFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Expression\MinTypeFormatter as ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Json\MinTypeFormatter as JsonFormatter;
 use PhpPact\Consumer\Matcher\Model\ExpressionFormatterInterface;
 use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
 
@@ -13,13 +13,15 @@ use PhpPact\Consumer\Matcher\Model\JsonFormatterInterface;
  */
 class MinType extends AbstractMatcher
 {
-    /**
-     * @param array<mixed> $values
-     */
     public function __construct(
-        private array $values,
+        private mixed $value,
         private int $min,
+        private bool $matchingType = true
     ) {
+        if ($min < 0) {
+            trigger_error("[WARN] min value to an array matcher can't be less than zero", E_USER_WARNING);
+            $this->min = 0;
+        }
         parent::__construct();
     }
 
@@ -36,12 +38,9 @@ class MinType extends AbstractMatcher
         return ['min' => $this->min];
     }
 
-    /**
-     * @return array<int, mixed>
-     */
-    public function getValue(): array
+    public function getValue(): mixed
     {
-        return array_values($this->values);
+        return $this->value;
     }
 
     public function getMin(): int
@@ -49,13 +48,18 @@ class MinType extends AbstractMatcher
         return $this->min;
     }
 
+    public function isMatchingType(): bool
+    {
+        return $this->matchingType;
+    }
+
     public function createJsonFormatter(): JsonFormatterInterface
     {
-        return new NoGeneratorFormatter();
+        return new JsonFormatter();
     }
 
     public function createExpressionFormatter(): ExpressionFormatterInterface
     {
-        return new MinTypeFormatter();
+        return new ExpressionFormatter();
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Formatters/Expression/MatchAllFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/Expression/MatchAllFormatterTest.php
@@ -44,8 +44,8 @@ class MatchAllFormatterTest extends TestCase
         $this->formatter->format($matcher);
     }
 
-    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType([null], 2)]), '"atLeast(2)"'])]
-    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType([null], 1), new MaxType([null], 2), new EachKey(["doesn't matter"], [new Regex('\w+', 'abc')]), new EachValue(["doesn't matter"], [new Type(100)])]), '"atLeast(1), atMost(2), eachKey(matching(regex, \'\\\\w+\', \'abc\')), eachValue(matching(type, 100))"'])]
+    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType(null, 2, false)]), '"atLeast(2)"'])]
+    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType(null, 1, false), new MaxType(null, 2, false), new EachKey(["doesn't matter"], [new Regex('\w+', 'abc')]), new EachValue(["doesn't matter"], [new Type(100)])]), '"atLeast(1), atMost(2), eachKey(matching(regex, \'\\\\w+\', \'abc\')), eachValue(matching(type, 100))"'])]
     public function testFormat(MatcherInterface $matcher, string $expression): void
     {
         $this->assertSame($expression, json_encode($this->formatter->format($matcher)));

--- a/tests/PhpPact/Consumer/Matcher/Formatters/Expression/MaxTypeFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/Expression/MaxTypeFormatterTest.php
@@ -28,8 +28,10 @@ class MaxTypeFormatterTest extends TestCase
         $this->formatter->format($matcher);
     }
 
-    #[TestWith([new MaxType([], 2), '"atMost(2)"'])]
-    #[TestWith([new MaxType(['example value'], 2), '"atMost(2)"'])]
+    #[TestWith([new MaxType(null, 2, false), '"atMost(2)"'])]
+    #[TestWith([new MaxType('example value', 2, false), '"atMost(2)"'])]
+    #[TestWith([new MaxType(null, 2), '"atMost(2), eachValue(matching(type, null)"'])]
+    #[TestWith([new MaxType('example value', 2), '"atMost(2), eachValue(matching(type, \'example value\')"'])]
     public function testFormat(MatcherInterface $matcher, string $expression): void
     {
         $this->assertSame($expression, json_encode($this->formatter->format($matcher)));

--- a/tests/PhpPact/Consumer/Matcher/Formatters/Expression/MinMaxTypeFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/Expression/MinMaxTypeFormatterTest.php
@@ -3,21 +3,21 @@
 namespace PhpPactTest\Consumer\Matcher\Formatters\Expression;
 
 use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
-use PhpPact\Consumer\Matcher\Formatters\Expression\MinTypeFormatter;
-use PhpPact\Consumer\Matcher\Matchers\MinType;
+use PhpPact\Consumer\Matcher\Formatters\Expression\MinMaxTypeFormatter;
+use PhpPact\Consumer\Matcher\Matchers\MinMaxType;
 use PhpPact\Consumer\Matcher\Matchers\NullValue;
 use PhpPact\Consumer\Matcher\Model\FormatterInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
-class MinTypeFormatterTest extends TestCase
+class MinMaxTypeFormatterTest extends TestCase
 {
     private FormatterInterface $formatter;
 
     protected function setUp(): void
     {
-        $this->formatter = new MinTypeFormatter();
+        $this->formatter = new MinMaxTypeFormatter();
     }
 
     public function testNotSupportedMatcher(): void
@@ -28,10 +28,8 @@ class MinTypeFormatterTest extends TestCase
         $this->formatter->format($matcher);
     }
 
-    #[TestWith([new MinType(null, 1, false), '"atLeast(1)"'])]
-    #[TestWith([new MinType('example value', 1, false), '"atLeast(1)"'])]
-    #[TestWith([new MinType(null, 1), '"atLeast(1), eachValue(matching(type, null)"'])]
-    #[TestWith([new MinType('example value', 1), '"atLeast(1), eachValue(matching(type, \'example value\')"'])]
+    #[TestWith([new MinMaxType(null, 2, 3), '"atLeast(2), atMost(3), eachValue(matching(type, null)"'])]
+    #[TestWith([new MinMaxType('example value', 2, 3), '"atLeast(2), atMost(3), eachValue(matching(type, \'example value\')"'])]
     public function testFormat(MatcherInterface $matcher, string $expression): void
     {
         $this->assertSame($expression, json_encode($this->formatter->format($matcher)));

--- a/tests/PhpPact/Consumer/Matcher/Formatters/Json/MatchAllFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/Json/MatchAllFormatterTest.php
@@ -34,13 +34,14 @@ class MatchAllFormatterTest extends TestCase
         $this->formatter->format($matcher);
     }
 
-    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType([null], 2)]), <<<JSON
+    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType(null, 2)]), <<<JSON
         {
             "pact:matcher:type": [
                 {
                     "min": 2,
                     "pact:matcher:type": "type",
                     "value": [
+                        null,
                         null
                     ]
                 }
@@ -52,7 +53,7 @@ class MatchAllFormatterTest extends TestCase
         }
         JSON
     ])]
-    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType([null], 1), new MaxType([null], 2), new EachKey(["doesn't matter"], [new Regex('\w+', 'abc')]), new EachValue(["doesn't matter"], [new Type(100)])]), <<<JSON
+    #[TestWith([new MatchAll(['abc' => 1, 'def' => 234], [new MinType(null, 1), new MaxType(null, 2), new EachKey(["doesn't matter"], [new Regex('\w+', 'abc')]), new EachValue(["doesn't matter"], [new Type(100)])]), <<<JSON
         {
             "pact:matcher:type": [
                 {

--- a/tests/PhpPact/Consumer/Matcher/Formatters/Json/MaxTypeFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/Json/MaxTypeFormatterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Formatters\Json;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Formatters\Json\MaxTypeFormatter;
+use PhpPact\Consumer\Matcher\Matchers\MaxType;
+use PhpPact\Consumer\Matcher\Matchers\NullValue;
+use PhpPact\Consumer\Matcher\Model\FormatterInterface;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class MaxTypeFormatterTest extends TestCase
+{
+    private FormatterInterface $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new MaxTypeFormatter();
+    }
+
+    public function testNotSupportedMatcher(): void
+    {
+        $matcher = new NullValue();
+        $this->expectException(MatcherNotSupportedException::class);
+        $this->expectExceptionMessage(sprintf('Matcher %s is not supported by %s', $matcher->getType(), $this->formatter::class));
+        $this->formatter->format($matcher);
+    }
+
+    #[TestWith([new MaxType('example text', 2, true), '{"pact:matcher:type": "type", "value": ["example text"], "max": 2}'])]
+    #[TestWith([new MaxType('example text', -2, true), '{"pact:matcher:type": "type", "value": ["example text"], "max": 0}'])]
+    #[TestWith([new MaxType('example text', 2, false), '{"pact:matcher:type": "type", "value": ["example text"], "max": 2}'])]
+    #[TestWith([new MaxType('example text', -2, false), '{"pact:matcher:type": "type", "value": ["example text"], "max": 0}'])]
+    public function testFormat(MaxType $matcher, string $json): void
+    {
+        $jsonEncoded = json_encode($this->formatter->format($matcher));
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Formatters/Json/MinMaxTypeFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/Json/MinMaxTypeFormatterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Formatters\Json;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Formatters\Json\MinMaxTypeFormatter;
+use PhpPact\Consumer\Matcher\Matchers\MinMaxType;
+use PhpPact\Consumer\Matcher\Matchers\NullValue;
+use PhpPact\Consumer\Matcher\Model\FormatterInterface;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class MinMaxTypeFormatterTest extends TestCase
+{
+    private FormatterInterface $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new MinMaxTypeFormatter();
+    }
+
+    public function testNotSupportedMatcher(): void
+    {
+        $matcher = new NullValue();
+        $this->expectException(MatcherNotSupportedException::class);
+        $this->expectExceptionMessage(sprintf('Matcher %s is not supported by %s', $matcher->getType(), $this->formatter::class));
+        $this->formatter->format($matcher);
+    }
+
+    #[TestWith([new MinMaxType('example text', 2, 3), '{"pact:matcher:type": "type", "value": ["example text", "example text"], "min": 2, "max": 3}'])]
+    #[TestWith([new MinMaxType('example text', -2, 3), '{"pact:matcher:type": "type", "value": ["example text"], "min": 0, "max": 3}'])]
+    #[TestWith([new MinMaxType('example text', 2, -3), '{"pact:matcher:type": "type", "value": ["example text", "example text"], "min": 2, "max": 0}'])]
+    #[TestWith([new MinMaxType('example text', -2, -3), '{"pact:matcher:type": "type", "value": ["example text"], "min": 0, "max": 0}'])]
+    public function testFormat(MinMaxType $matcher, string $json): void
+    {
+        $jsonEncoded = json_encode($this->formatter->format($matcher));
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Formatters/Json/MinTypeFormatterTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Formatters/Json/MinTypeFormatterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace PhpPactTest\Consumer\Matcher\Formatters\Json;
+
+use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
+use PhpPact\Consumer\Matcher\Formatters\Json\MinTypeFormatter;
+use PhpPact\Consumer\Matcher\Matchers\MinType;
+use PhpPact\Consumer\Matcher\Matchers\NullValue;
+use PhpPact\Consumer\Matcher\Model\FormatterInterface;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class MinTypeFormatterTest extends TestCase
+{
+    private FormatterInterface $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new MinTypeFormatter();
+    }
+
+    public function testNotSupportedMatcher(): void
+    {
+        $matcher = new NullValue();
+        $this->expectException(MatcherNotSupportedException::class);
+        $this->expectExceptionMessage(sprintf('Matcher %s is not supported by %s', $matcher->getType(), $this->formatter::class));
+        $this->formatter->format($matcher);
+    }
+
+    #[TestWith([new MinType('example text', 2, true), '{"pact:matcher:type": "type", "value": ["example text", "example text"], "min": 2}'])]
+    #[TestWith([new MinType('example text', -2, true), '{"pact:matcher:type": "type", "value": ["example text"], "min": 0}'])]
+    #[TestWith([new MinType('example text', 2, false), '{"pact:matcher:type": "type", "value": ["example text", "example text"], "min": 2}'])]
+    #[TestWith([new MinType('example text', -2, false), '{"pact:matcher:type": "type", "value": ["example text"], "min": 0}'])]
+    public function testFormat(MinType $matcher, string $json): void
+    {
+        $jsonEncoded = json_encode($this->formatter->format($matcher));
+        $this->assertIsString($jsonEncoded);
+        $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -62,38 +62,38 @@ class MatcherTest extends TestCase
 
     public function testEachLike(): void
     {
-        $this->assertInstanceOf(MinType::class, $this->matcher->eachLike('test'));
+        $this->assertInstanceOf(MinType::class, $result = $this->matcher->eachLike('test'));
+        $this->assertSame('test', $result->getValue());
+        $this->assertSame(1, $result->getMin());
+    }
+
+    public function testAtLeastOneLike(): void
+    {
+        $this->assertInstanceOf(MinType::class, $result = $this->matcher->atLeastOneLike('test'));
+        $this->assertSame('test', $result->getValue());
+        $this->assertSame(1, $result->getMin());
     }
 
     public function testAtLeastLike(): void
     {
-        $this->assertInstanceOf(MinType::class, $this->matcher->atLeastLike('test', 2));
+        $this->assertInstanceOf(MinType::class, $result = $this->matcher->atLeastLike('test', 2));
+        $this->assertSame('test', $result->getValue());
+        $this->assertSame(2, $result->getMin());
     }
 
     public function testAtMostLike(): void
     {
-        $this->assertInstanceOf(MaxType::class, $this->matcher->atMostLike('test', 2));
-    }
-
-    public function testConstrainedArrayLikeCountLessThanMin(): void
-    {
-        $this->expectException(MatcherException::class);
-        $this->expectExceptionMessage('constrainedArrayLike has a minimum of 2 but 1 elements where requested.' .
-        ' Make sure the count is greater than or equal to the min.');
-        $this->matcher->constrainedArrayLike('text', 2, 4, 1);
-    }
-
-    public function testConstrainedArrayLikeCountLargerThanMax(): void
-    {
-        $this->expectException(MatcherException::class);
-        $this->expectExceptionMessage('constrainedArrayLike has a maximum of 5 but 7 elements where requested.' .
-        ' Make sure the count is less than or equal to the max.');
-        $this->matcher->constrainedArrayLike('text', 3, 5, 7);
+        $this->assertInstanceOf(MaxType::class, $result = $this->matcher->atMostLike('test', 2));
+        $this->assertSame('test', $result->getValue());
+        $this->assertSame(2, $result->getMax());
     }
 
     public function testConstrainedArrayLike(): void
     {
-        $this->assertInstanceOf(MinMaxType::class, $this->matcher->constrainedArrayLike('test', 2, 4, 3));
+        $this->assertInstanceOf(MinMaxType::class, $result = $this->matcher->constrainedArrayLike('test', 2, 4));
+        $this->assertSame('test', $result->getValue());
+        $this->assertSame(2, $result->getMin());
+        $this->assertSame(4, $result->getMax());
     }
 
     public function testTerm(): void

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MatchAllTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MatchAllTest.php
@@ -24,8 +24,8 @@ class MatchAllTest extends TestCase
 
     public function testSerialize(): void
     {
-        $matcher = new MatchAll(['key' => 123], [new MinType([], 1), new MaxType([], 2), new EachKey([], [new Type('test')]), new EachValue([], [new Type(123)])]);
-        $this->assertSame('{"pact:matcher:type":[{"pact:matcher:type":"type","min":1,"value":[]},{"pact:matcher:type":"type","max":2,"value":[]},{"pact:matcher:type":"eachKey","rules":[{"pact:matcher:type":"type","value":"test"}],"value":[]},{"pact:matcher:type":"eachValue","rules":[{"pact:matcher:type":"type","value":123}],"value":[]}],"value":{"key":123}}', json_encode($matcher));
+        $matcher = new MatchAll(['key' => 123], [new MinType(null, 1), new MaxType(null, 2), new EachKey([], [new Type('test')]), new EachValue([], [new Type(123)])]);
+        $this->assertSame('{"pact:matcher:type":[{"pact:matcher:type":"type","min":1,"value":[null]},{"pact:matcher:type":"type","max":2,"value":[null]},{"pact:matcher:type":"eachKey","rules":[{"pact:matcher:type":"type","value":"test"}],"value":[]},{"pact:matcher:type":"eachValue","rules":[{"pact:matcher:type":"type","value":123}],"value":[]}],"value":{"key":123}}', json_encode($matcher));
     }
 
     public function testCreateJsonFormatter(): void

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MaxTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MaxTypeTest.php
@@ -2,34 +2,31 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Formatters\Expression\MaxTypeFormatter;
-use PhpPact\Consumer\Matcher\Formatters\Json\NoGeneratorFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Expression\MaxTypeFormatter as ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Json\MaxTypeFormatter as JsonFormatter;
 use PhpPact\Consumer\Matcher\Matchers\MaxType;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class MaxTypeTest extends TestCase
 {
-    public function testSerialize(): void
+    #[TestWith([-3, '{"pact:matcher:type":"type","max":0,"value":["string value"]}'])]
+    #[TestWith([3, '{"pact:matcher:type":"type","max":3,"value":["string value"]}'])]
+    public function testSerialize(int $max, string $json): void
     {
-        $values = [
-            'string value',
-        ];
-        $array = new MaxType($values, 3);
-        $this->assertSame(
-            '{"pact:matcher:type":"type","max":3,"value":["string value"]}',
-            json_encode($array)
-        );
+        $matcher = new MaxType('string value', $max);
+        $this->assertSame($json, json_encode($matcher));
     }
 
     public function testCreateJsonFormatter(): void
     {
-        $matcher = new MaxType([], 0);
-        $this->assertInstanceOf(NoGeneratorFormatter::class, $matcher->createJsonFormatter());
+        $matcher = new MaxType(null, 0);
+        $this->assertInstanceOf(JsonFormatter::class, $matcher->createJsonFormatter());
     }
 
     public function testCreateExpressionFormatter(): void
     {
-        $matcher = new MaxType([], 0);
-        $this->assertInstanceOf(MaxTypeFormatter::class, $matcher->createExpressionFormatter());
+        $matcher = new MaxType(null, 0);
+        $this->assertInstanceOf(ExpressionFormatter::class, $matcher->createExpressionFormatter());
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MinMaxTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MinMaxTypeTest.php
@@ -2,36 +2,33 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
-use PhpPact\Consumer\Matcher\Formatters\Json\NoGeneratorFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Expression\MinMaxTypeFormatter as ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Json\MinMaxTypeFormatter as JsonFormatter;
 use PhpPact\Consumer\Matcher\Matchers\MinMaxType;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class MinMaxTypeTest extends TestCase
 {
-    public function testSerialize(): void
+    #[TestWith([-2, 5, '{"pact:matcher:type":"type","min":0,"max":5,"value":[1.23]}'])]
+    #[TestWith([-2, -5, '{"pact:matcher:type":"type","min":0,"max":0,"value":[1.23]}'])]
+    #[TestWith([2, 5, '{"pact:matcher:type":"type","min":2,"max":5,"value":[1.23,1.23]}'])]
+    #[TestWith([2, -5, '{"pact:matcher:type":"type","min":2,"max":0,"value":[1.23,1.23]}'])]
+    public function testSerialize(int $min, int $max, string $json): void
     {
-        $values = [
-            1.23,
-            2.34,
-        ];
-        $array = new MinMaxType($values, 2, 5);
-        $this->assertSame(
-            '{"pact:matcher:type":"type","min":2,"max":5,"value":[1.23,2.34]}',
-            json_encode($array)
-        );
+        $matcher = new MinMaxType(1.23, $min, $max);
+        $this->assertSame($json, json_encode($matcher));
     }
 
     public function testCreateJsonFormatter(): void
     {
-        $matcher = new MinMaxType([], 0, 1);
-        $this->assertInstanceOf(NoGeneratorFormatter::class, $matcher->createJsonFormatter());
+        $matcher = new MinMaxType(null, 0, 1);
+        $this->assertInstanceOf(JsonFormatter::class, $matcher->createJsonFormatter());
     }
 
     public function testCreateExpressionFormatter(): void
     {
-        $matcher = new MinMaxType([], 0, 1);
-        $this->expectExceptionObject(new MatcherNotSupportedException("MinMaxType matcher doesn't support expression formatter"));
-        $matcher->createExpressionFormatter();
+        $matcher = new MinMaxType(null, 0, 1);
+        $this->assertInstanceOf(ExpressionFormatter::class, $matcher->createExpressionFormatter());
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MinTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MinTypeTest.php
@@ -2,36 +2,31 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Formatters\Expression\MinTypeFormatter;
-use PhpPact\Consumer\Matcher\Formatters\Json\NoGeneratorFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Expression\MinTypeFormatter as ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Formatters\Json\MinTypeFormatter as JsonFormatter;
 use PhpPact\Consumer\Matcher\Matchers\MinType;
+use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
 
 class MinTypeTest extends TestCase
 {
-    public function testSerialize(): void
+    #[TestWith([-3, '{"pact:matcher:type":"type","min":0,"value":[123]}'])]
+    #[TestWith([3, '{"pact:matcher:type":"type","min":3,"value":[123,123,123]}'])]
+    public function testSerialize(int $min, string $json): void
     {
-        $values = [
-            123,
-            34,
-            5,
-        ];
-        $array = new MinType($values, 3);
-        $this->assertSame(
-            '{"pact:matcher:type":"type","min":3,"value":[123,34,5]}',
-            json_encode($array)
-        );
+        $matcher = new MinType(123, $min);
+        $this->assertSame($json, json_encode($matcher));
     }
 
     public function testCreateJsonFormatter(): void
     {
-        $matcher = new MinType([], 0);
-        $this->assertInstanceOf(NoGeneratorFormatter::class, $matcher->createJsonFormatter());
+        $matcher = new MinType(null, 0);
+        $this->assertInstanceOf(JsonFormatter::class, $matcher->createJsonFormatter());
     }
 
     public function testCreateExpressionFormatter(): void
     {
-        $matcher = new MinType([], 0);
-        $this->assertInstanceOf(MinTypeFormatter::class, $matcher->createExpressionFormatter());
+        $matcher = new MinType(null, 0);
+        $this->assertInstanceOf(ExpressionFormatter::class, $matcher->createExpressionFormatter());
     }
 }


### PR DESCRIPTION
* Value for MinType/MaxType/MinMaxType matchers now is not array
* Add expression/json formatters for MinType/MaxType/MinMaxType matchers
* Remove ability to set number of examples. I don't think it's important.
  * Pact-JS has this ability
  * Pact-GO doesn't have this ability (https://github.com/pact-foundation/pact-go/blob/master/matchers/matcher_v3.go#L190-L193)
  * Pact-PHP is mixed . 1 matcher has (`constrainedArrayLike`). others don't
    * Now it's just like Pact-GO