### PR TITLE
chore: Remove unused Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,0 @@
-FROM php:8.3-alpine
-RUN apk add --no-cache linux-headers libffi-dev protoc protobuf-dev musl-dev autoconf gcc g++ make
-COPY --from=composer/composer:2-bin /composer /usr/local/bin/composer
-RUN docker-php-ext-install sockets
-RUN docker-php-ext-install ffi
-RUN pecl install grpc
-RUN echo 'extension=grpc.so' >> /usr/local/etc/php/conf.d/grpc.ini


### PR DESCRIPTION
This file come from https://github.com/pact-foundation/pact-php/pull/613, which is no longer needed because of installing packages directly