### PR TITLE
ci: Upgrade PHP to 8.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,46 +44,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        php: [8.3]
+        os: [ubuntu-latest, macos-12, macos-14]
         include:
-          - os: ubuntu-latest
-            php: 8.1
-          - os: macos-12
-            php: 8.3
-          - os: macos-14
-            php: 8.2
           - os: windows-latest
             example: 'json'
-            php: 8.2
           - os: windows-latest
             example: 'binary'
-            php: 8.2
           - os: windows-latest
             example: 'multipart'
-            php: 8.2
           - os: windows-latest
             example: 'xml'
-            php: 8.2
           - os: windows-latest
             example: 'message'
-            php: 8.2
           - os: windows-latest
             example: 'matchers'
-            php: 8.2
           - os: windows-latest
             example: 'generators'
-            php: 8.2
           - os: windows-latest
             example: 'csv'
-            php: 8.2
           - os: windows-latest
             example: 'protobuf-sync-message'
-            php: 8.1
           - os: windows-latest
             example: 'protobuf-async-message'
-            php: 8.2
           - os: windows-latest
             example: 'stub-server'
-            php: 8.2
     timeout-minutes: 5
 
     steps:


### PR DESCRIPTION
* I'm not sure why setting up PHP 8.1 on Ubuntu 22.04 taking so long, probably because it need to compile grpc extension from source code. I think the default PHP version changed to 8.3, but the [document](https://github.com/shivammathur/setup-php?tab=readme-ov-file#github-hosted-runners) is not updated.
  * Solution: Upgrade PHP to 8.3
* Look like grpc extension is available for PHP 8.3 on Windows https://pecl.php.net/package/gRPC
  * Change: Upgrade PHP to 8.3 to make tests run faster, since PHP 8.3 is default version on Windows
* There are no default version of PHP installed on macos-14 https://github.com/shivammathur/setup-php?tab=readme-ov-file#github-hosted-runners
  * So upgrade PHP from 8.2 to `8.3` doesn't make the tests run slower