### PR TITLE
fix: update pact-ffi to 0.4.22

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,12 +113,12 @@
     "extra": {
         "downloads": {
             "pact-ffi-headers": {
-                "version": "0.4.21",
+                "version": "0.4.22",
                 "url": "https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v{$version}/pact.h",
                 "path": "bin/pact-ffi-headers/pact.h"
             },
             "pact-ffi-lib": {
-                "version": "0.4.21",
+                "version": "0.4.22",
                 "variables": {
                     "{$prefix}": "PHP_OS_FAMILY === 'Windows' ? 'pact_ffi' : 'libpact_ffi'",
                     "{$os}": "PHP_OS === 'Darwin' ? 'macos' : strtolower(PHP_OS_FAMILY)",


### PR DESCRIPTION
Updates to [libpact_ffi 0.4.22](https://github.com/pact-foundation/pact-reference/releases/tag/libpact_ffi-v0.4.22)

Introduces failures in content-type detection possibly due to changes introduced in this [PR](https://github.com/pact-foundation/pact-reference/pull/456)
