### PR TITLE
docs: document multiple interactions

### DIFF
--- a/docs/consumer.md
+++ b/docs/consumer.md
@@ -94,6 +94,28 @@ $builder
     ->willRespondWith($response); // This has to be last. This is what makes FFI calls to register the interaction and start the mock server.
 ```
 
+### Multiple Interactions
+
+There might be cases where we need multiple interactions with the mock server to have a useful test. For that case we have to:
+1. Set the second parameter (`$startMockServer`) of `willRespondWith()` to `false` for every interaction, except the last one. Otherwise, the mock-server will be started already on the first interaction and there will be no way to register more interactions.
+2. Run `newInteraction()` on every interaction, except the first one.
+
+   Example:
+   ```php
+   $builder = new InteractionBuilder($config);
+   $builder
+       ->uponReceiving('a get request to /hello/{name}')
+       ->with($firstRequest)
+       ->willRespondWith($firstResponse, false); // set $startMockServer to 'false'
+   $builder->newInteraction(); // create a new interaction
+   $builder
+       ->uponReceiving('a get request to /goodbye/{name}')
+       ->with($secondRequest)
+       ->willRespondWith($secondResponse); // this will start the mock server
+   ```
+
+[Click here](../example/json/consumer/tests/Service/ConsumerServiceMultipleInteractionsTest.php) to see full sample file for multiple interactions.
+
 ## Make the Request
 
 ```php

--- a/example/json/consumer/tests/Service/ConsumerServiceMultipleInteractionsTest.php
+++ b/example/json/consumer/tests/Service/ConsumerServiceMultipleInteractionsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace JsonConsumer\Tests\Service;
+
+use JsonConsumer\Service\HttpClientService;
+use PhpPact\Consumer\InteractionBuilder;
+use PhpPact\Consumer\Matcher\Matcher;
+use PhpPact\Consumer\Model\ConsumerRequest;
+use PhpPact\Consumer\Model\ProviderResponse;
+use PhpPact\Standalone\MockService\MockServerConfig;
+use PHPUnit\Framework\TestCase;
+
+class ConsumerServiceMultipleInteractionsTest extends TestCase
+{
+    /**
+     * Example PACT test.
+     *
+     * @throws \Exception
+     */
+    public function testGetHelloString()
+    {
+        $matcher = new Matcher();
+
+        // Create your expected request from the consumer.
+        $request = new ConsumerRequest();
+        $request
+            ->setMethod('GET')
+            ->setPath('/hello/Bob')
+            ->addHeader('Content-Type', 'application/json');
+
+        // Create your expected response from the provider.
+        $response = new ProviderResponse();
+        $response
+            ->setStatus(200)
+            ->addHeader('Content-Type', 'application/json')
+            ->setBody([
+                'message' => $matcher->term('Hello, Bob', '(Hello, )[A-Za-z]+')
+            ]);
+
+        // Create a configuration that reflects the server that was started. You can create a custom MockServerConfigInterface if needed.
+        $config = new MockServerConfig();
+        $config
+            ->setConsumer('jsonConsumer')
+            ->setProvider('jsonProvider')
+            ->setPactDir(__DIR__.'/../../../pacts');
+        if ($logLevel = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($logLevel);
+        }
+        $builder = new InteractionBuilder($config);
+        $builder
+            ->uponReceiving('A get request to /hello/{name}')
+            ->with($request)
+            ->willRespondWith($response, false); // Don't start the mock server yet, because there will me more interactions.
+
+        $request = new ConsumerRequest();
+        $request
+            ->setMethod('GET')
+            ->setPath('/goodbye/Bob')
+            ->addHeader('Content-Type', 'application/json');
+
+        $response = new ProviderResponse();
+        $response
+            ->setStatus(200)
+            ->addHeader('Content-Type', 'application/json')
+            ->setBody([
+                'message' => 'Goodbye, Bob'
+            ]);
+
+        $builder->newInteraction(); // make sure we have a new interaction started and don't overwrite the old one
+        $builder
+            ->given('Get Goodbye')
+            ->uponReceiving('A get request to /goodbye/{name}')
+            ->with($request)
+            ->willRespondWith($response); // This has to be last. This is what makes FFI calls to register the final interaction and start the mock server.
+
+        $service = new HttpClientService($config->getBaseUri()); // Pass in the URL to the Mock Server.
+        $helloResult = $service->getHelloString('Bob'); // Make the first real API request against the Mock Server.
+        $goodbyeResult = $service->getGoodbyeString('Bob'); // Make the second real API request against the Mock Server.
+        $verifyResult = $builder->verify(); // This will verify that the interactions took place.
+        $this->assertTrue($verifyResult); // Make your assertions.
+        $this->assertEquals('Hello, Bob', $helloResult);
+        $this->assertEquals('Goodbye, Bob', $goodbyeResult);
+    }
+}

--- a/example/json/pacts/jsonConsumer-jsonProvider.json
+++ b/example/json/pacts/jsonConsumer-jsonProvider.json
@@ -4,6 +4,30 @@
   },
   "interactions": [
     {
+      "description": "A get request to /goodbye/{name}",
+      "providerStates": [
+        {
+          "name": "Get Goodbye"
+        }
+      ],
+      "request": {
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "GET",
+        "path": "/goodbye/Bob"
+      },
+      "response": {
+        "body": {
+          "message": "Goodbye, Bob"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "status": 200
+      }
+    },
+    {
       "description": "A get request to /hello/{name}",
       "request": {
         "headers": {
@@ -64,9 +88,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "mockserver": "1.2.5",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "3.0.0"


### PR DESCRIPTION
https://github.com/pact-foundation/pact-php/pull/508 added the support to have multiple independent interactions with one builder, but:
- it was not documented
- the examples in the PR did not work for me (maybe the code got changed since then) :man_shrugging: 

This PR adds documentation for this super useful feature and adds an example  