### PR TITLE
feat: Allow debug mock server in compatibility suites

### DIFF
--- a/compatibility-suite/tests/Service/Server.php
+++ b/compatibility-suite/tests/Service/Server.php
@@ -32,6 +32,10 @@ final class Server implements ServerInterface
             ->setPactSpecificationVersion($specificationVersion)
             ->setPactFileWriteMode(PactConfigInterface::MODE_OVERWRITE);
 
+        if ($level = \getenv('PACT_LOGLEVEL')) {
+            $this->config->setLogLevel($level);
+        }
+
         $this->driver = (new InteractionDriverFactory())->create($this->config);
     }
 


### PR DESCRIPTION
Currently running compatibility suites tests doesn't print out any mock server's log messages.  So it's hard to debug failed test like this:

```
Then a 200 success response is returned
      Failed asserting that 500 is identical to 200.
```

And there is no way to customize this.


This PR pass the `PACT_LOGLEVEL` env to mock server.  It allow me to run the `behat` command with custom (mock server) debug level:

```shell
env PACT_LOGLEVEL=debug vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V1/http_consumer.feature:204 --colors
```

Then it will print out useful log messages from mock server like this:

```
...
2024-08-29T05:41:00.882246Z DEBUG tokio-runtime-worker pact_matching: --> Mismatches: [HeaderMismatch { key: "Content-Type", expected: "text/plain", actual: "application/x-www-form-urlencoded", mismatch: "Mismatch with header 'Content-Type': Expected header 'Content-Type' to have value 'text/plain' but was 'application/x-www-form-urlencoded'" }, BodyTypeMismatch { expected: "text/plain", actual: "application/x-www-form-urlencoded", mismatch: "Expected a body of 'text/plain' but the actual content type was 'application/x-www-form-urlencoded'", expected_body: Some(b"a=1&b=2&c=3&d=4"), actual_body: Some(b"a=1&b=2&c=3&d=4") }]
2024-08-29T05:41:00.882281Z DEBUG tokio-runtime-worker pact_mock_server::hyper_server: Request did not match: Request did not match - HTTP Request ( method: PUT, path: /form, query: None, headers: Some({"Content-Type": ["text/plain"]}), body: Present(15 bytes) )    0) Mismatch with header 'Content-Type': Expected header 'Content-Type' to have value 'text/plain' but was 'application/x-www-form-urlencoded'    1) Expected a body of 'text/plain' but the actual content type was 'application/x-www-form-urlencoded'
...
```

If `PACT_LOGLEVEL` is not set, it will not print anything, just like before.