### PR TITLE
fix: Fix type error in PHPUnit's configuration registry (temporarily)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^10.1|^11",
+        "phpunit/phpunit": "^10.1.0|>=11.0 <11.3",
         "guzzlehttp/guzzle": "^7.8",
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",


### PR DESCRIPTION
Fix this error:

```
Type error: PHPUnit\TextUI\Configuration\Registry::get(): Return value must be of type PHPUnit\TextUI\Configuration\Configuration, null returned (Behat\Testwork\Call\Exception\FatalThrowableError)
```

This error is introduced by PHPUnit 11.3.0 and above. I don't know how to fix it properly, so I guess we postpone upgrading to that version for now.

Look like the first PR of this version https://github.com/sebastianbergmann/phpunit/releases/tag/11.3.0 causing this issue, but I'm not sure yet, because it's closed, not merged yet, but the code is already in the code base.