### PR TITLE
Fix wrong content type in protobuf plugin 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^10.1|^11",
+        "phpunit/phpunit": "^10.1.0|>=11.0 <11.3",
         "guzzlehttp/guzzle": "^7.8",
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",

--- a/example/binary/pacts/binaryConsumer-binaryProvider.json
+++ b/example/binary/pacts/binaryConsumer-binaryProvider.json
@@ -43,9 +43,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "mockserver": "1.2.5",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/example/csv/pacts/csvConsumer-csvProvider.json
+++ b/example/csv/pacts/csvConsumer-csvProvider.json
@@ -87,9 +87,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "mockserver": "1.2.5",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "4.0"
@@ -98,7 +98,7 @@
       {
         "configuration": {},
         "name": "csv",
-        "version": "0.0.5"
+        "version": "0.0.6"
       }
     ]
   },

--- a/example/generators/pacts/generatorsConsumer-generatorsProvider.json
+++ b/example/generators/pacts/generatorsConsumer-generatorsProvider.json
@@ -261,9 +261,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "mockserver": "1.2.5",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "4.0"

--- a/example/matchers/pacts/matchersConsumer-matchersProvider.json
+++ b/example/matchers/pacts/matchersConsumer-matchersProvider.json
@@ -726,9 +726,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.19",
-      "mockserver": "1.2.6",
-      "models": "1.1.19"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "4.0"

--- a/example/message/pacts/messageConsumer-messageProvider.json
+++ b/example/message/pacts/messageConsumer-messageProvider.json
@@ -63,8 +63,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/example/multipart/pacts/multipartConsumer-multipartProvider.json
+++ b/example/multipart/pacts/multipartConsumer-multipartProvider.json
@@ -116,9 +116,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "mockserver": "1.2.5",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/example/protobuf-async-message/pacts/protobufAsyncMessageConsumer-protobufAsyncMessageProvider.json
+++ b/example/protobuf-async-message/pacts/protobufAsyncMessageConsumer-protobufAsyncMessageProvider.json
@@ -6,7 +6,7 @@
     {
       "contents": {
         "content": "CiRkMWYwNzdiNS0wZjkxLTQwYWEtYjhmOS01NjhiNTBlZTRkZDkSEAoFR2l2ZW4SB1N1cm5hbWU=",
-        "contentType": "application/protobuf;message=Person",
+        "contentType": "application/protobuf;message=.library.Person",
         "contentTypeHint": "BINARY",
         "encoded": "base64"
       },
@@ -45,13 +45,13 @@
         }
       },
       "metadata": {
-        "contentType": "application/protobuf;message=Person"
+        "contentType": "application/protobuf;message=.library.Person"
       },
       "pending": false,
       "pluginConfiguration": {
         "protobuf": {
           "descriptorKey": "f77f40284a5ed1f38188ed943aca6938",
-          "message": "Person"
+          "message": ".library.Person"
         }
       },
       "providerStates": [
@@ -68,8 +68,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "4.0"
@@ -83,7 +83,7 @@
           }
         },
         "name": "protobuf",
-        "version": "0.3.13"
+        "version": "0.5.2"
       }
     ]
   },

--- a/example/protobuf-async-message/provider/public/index.php
+++ b/example/protobuf-async-message/provider/public/index.php
@@ -23,7 +23,7 @@ $app->post('/', function (Request $request, Response $response) {
         $response->getBody()->write($person->serializeToString());
 
         return $response
-            ->withHeader('Content-Type', 'application/protobuf;message=Person')
+            ->withHeader('Content-Type', 'application/protobuf;message=.library.Person')
             ->withHeader('Pact-Message-Metadata', \base64_encode(\json_encode([])));
     }
 

--- a/example/protobuf-sync-message/pacts/protobufSyncMessageConsumer-protobufSyncMessageProvider.json
+++ b/example/protobuf-sync-message/pacts/protobufSyncMessageConsumer-protobufSyncMessageProvider.json
@@ -13,13 +13,13 @@
       "pluginConfiguration": {
         "protobuf": {
           "descriptorKey": "6b90c212dfe22dc3c119d1c3fe42b5e1",
-          "service": "Calculator/calculate"
+          "service": ".plugins.Calculator/calculate"
         }
       },
       "request": {
         "contents": {
           "content": "EgoNAABAQBUAAIBA",
-          "contentType": "application/protobuf;message=ShapeMessage",
+          "contentType": "application/protobuf;message=.plugins.ShapeMessage",
           "contentTypeHint": "BINARY",
           "encoded": "base64"
         },
@@ -44,14 +44,14 @@
           }
         },
         "metadata": {
-          "contentType": "application/protobuf;message=ShapeMessage"
+          "contentType": "application/protobuf;message=.plugins.ShapeMessage"
         }
       },
       "response": [
         {
           "contents": {
             "content": "DQAAQEE=",
-            "contentType": "application/protobuf;message=AreaResponse",
+            "contentType": "application/protobuf;message=.plugins.AreaResponse",
             "contentTypeHint": "BINARY",
             "encoded": "base64"
           },
@@ -68,7 +68,7 @@
             }
           },
           "metadata": {
-            "contentType": "application/protobuf;message=AreaResponse"
+            "contentType": "application/protobuf;message=.plugins.AreaResponse"
           }
         }
       ],
@@ -78,9 +78,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "mockserver": "1.2.5",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "4.0"
@@ -94,7 +94,7 @@
           }
         },
         "name": "protobuf",
-        "version": "0.3.13"
+        "version": "0.5.2"
       }
     ]
   },

--- a/example/xml/pacts/xmlConsumer-xmlProvider.json
+++ b/example/xml/pacts/xmlConsumer-xmlProvider.json
@@ -138,9 +138,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.4.14",
-      "mockserver": "1.2.5",
-      "models": "1.1.17"
+      "ffi": "0.4.21",
+      "mockserver": "1.2.8",
+      "models": "1.2.2"
     },
     "pactSpecification": {
       "version": "3.0.0"


### PR DESCRIPTION
Fix this error if using protobuf plugin version 0.5 (not sure about 0.4)

```
expected a body of 'application/protobuf;message=.library.Person' but the actual content type was 'application/protobuf;message=Person'
```

I guess the `.library.` and `.plugins.` prefixes come from the `package library;` and `package plugins;` in proto files.

Depend on https://github.com/pact-foundation/pact-php/pull/622