### PR TITLE
fix: Fix 'Exception: String could not be parsed as XML' in xml's consumer test

### DIFF
--- a/example/xml/consumer/tests/Service/HttpClientServiceTest.php
+++ b/example/xml/consumer/tests/Service/HttpClientServiceTest.php
@@ -3,6 +3,7 @@
 namespace XmlConsumer\Tests\Service;
 
 use PhpPact\Consumer\Matcher\Matcher;
+use PhpPact\Consumer\Model\Body\Text;
 use PhpPact\Xml\XmlBuilder;
 use XmlConsumer\Service\HttpClientService;
 use PhpPact\Consumer\InteractionBuilder;
@@ -83,9 +84,7 @@ class HttpClientServiceTest extends TestCase
         $response
             ->setStatus(200)
             ->addHeader('Content-Type', $matcher->regex('application/xml', 'application\/.*xml'))
-            ->setBody(
-                json_encode($xmlBuilder)
-            );
+            ->setBody(new Text(json_encode($xmlBuilder), 'application/xml'));
 
         $config = new MockServerConfig();
         $config

--- a/src/PhpPact/Consumer/Driver/InteractionPart/ResponseDriver.php
+++ b/src/PhpPact/Consumer/Driver/InteractionPart/ResponseDriver.php
@@ -9,10 +9,8 @@ class ResponseDriver extends AbstractInteractionPartDriver implements ResponseDr
 {
     public function registerResponse(Interaction $interaction): void
     {
-        // @todo Fix 'Exception: String could not be parsed as XML' in xml's consumer test
-        // when calling `withBody` before `withHeaders`
-        $this->withHeaders($interaction, InteractionPart::RESPONSE);
         $this->withBody($interaction, InteractionPart::RESPONSE);
+        $this->withHeaders($interaction, InteractionPart::RESPONSE);
         $this->withResponse($interaction);
     }
 


### PR DESCRIPTION
The reason is:

```php
->setBody(
    json_encode($xmlBuilder)
);
```

This code set body's content type to `text/plain`. I need to set the content type to the correct one (`application/xml`)

cc @JP-Ellis 

Link to related issue/comment:
* https://github.com/pact-foundation/pact-php/pull/619
* https://github.com/pact-foundation/pact-reference/pull/456#issuecomment-2240815563