### PR TITLE
fix(compatibility suites): Fix mismatch content type

### DIFF
--- a/compatibility-suite/tests/Service/RequestBuilder.php
+++ b/compatibility-suite/tests/Service/RequestBuilder.php
@@ -36,6 +36,9 @@ final class RequestBuilder implements RequestBuilderInterface
 
                 case 'body':
                     $request->setBody($this->parser->parseBody($data['body'], $request->getBody()?->getContentType()));
+                    if ($contentType = $request->getBody()?->getContentType()) {
+                        $request->addHeader('Content-Type', $contentType);
+                    }
                     break;
 
                 case 'content type':

--- a/compatibility-suite/tests/Service/ResponseBuilder.php
+++ b/compatibility-suite/tests/Service/ResponseBuilder.php
@@ -24,6 +24,9 @@ final class ResponseBuilder implements ResponseBuilderInterface
 
                 case 'body':
                     $response->setBody($this->parser->parseBody($data['body'], $response->getBody()?->getContentType()));
+                    if ($contentType = $response->getBody()?->getContentType()) {
+                        $response->addHeader('Content-Type', $contentType);
+                    }
                     break;
 
                 case 'content-type':


### PR DESCRIPTION
Pact-PHP has mismatch content type failed tests in compatibility suites when using `0.4.22`:

Here is the trace log:

```
2024-08-29T18:36:27.996937Z TRACE ThreadId(01) pact_ffi::mock_server::handles: >>> pactffi_with_body(InteractionHandle { interaction_ref: 2818375681 }, Request, 0x7f974d3c8058, 0x7f974d3c5d88)
2024-08-29T18:36:27.996961Z TRACE ThreadId(01) pact_ffi::mock_server::handles: content_type=Some(ContentType { main_type: "application", sub_type: "x-www-form-urlencoded", attributes: {}, suffix: None })
2024-08-29T18:36:27.996969Z TRACE ThreadId(01) pact_ffi::mock_server::handles: with_interaction - index = 43005, interaction = 1
2024-08-29T18:36:27.996972Z TRACE ThreadId(01) pact_ffi::mock_server::handles: with_interaction - keys = [43005]
2024-08-29T18:36:27.996976Z TRACE ThreadId(01) pact_ffi::mock_server::handles: with_interaction - inner = PactHandleInner { pact: V4Pact { consumer: Consumer { name: "server_specification_1.0.0" }, provider: Provider { name: "p" }, interactions: [SynchronousHttp { id: None, key: None, description: "Interaction 8", provider_states: [], request: HttpRequest { method: "GET", path: "/", query: None, headers: None, body: Missing, matching_rules: MatchingRules { rules: {} }, generators: Generators { categories: {} } }, response: HttpResponse { status: 200, headers: None, body: Missing, matching_rules: MatchingRules { rules: {} }, generators: Generators { categories: {} } }, comments: {}, pending: false, plugin_config: {}, interaction_markup: InteractionMarkup { markup: "", markup_type: "" }, transport: None }], metadata: {"pactRust": Object {"ffi": String("0.4.22")}}, plugin_data: [] }, mock_server_started: false, specification_version: V1 }
2024-08-29T18:36:27.996987Z TRACE ThreadId(01) pact_ffi::mock_server::handles: Processing HTTP request body
2024-08-29T18:36:27.996991Z TRACE ThreadId(01) pact_ffi::mock_server::handles: >>> process_body("a=1&b=2&c=3&d=4", Some(ContentType { main_type: "application", sub_type: "x-www-form-urlencoded", attributes: {}, suffix: None }), None, MatchingRules { rules: {} }, Generators { categories: {} })
2024-08-29T18:36:27.996998Z DEBUG ThreadId(01) pact_models::content_types: Detecting content type from contents: 'a=1&b=2&c=3&d=4'
2024-08-29T18:36:28.001187Z TRACE ThreadId(01) pact_ffi::mock_server::handles: Detected content type: Some(ContentType { main_type: "text", sub_type: "plain", attributes: {}, suffix: None }); Resulting content type: Some(ContentType { main_type: "application", sub_type: "x-www-form-urlencoded", attributes: {}, suffix: None })
2024-08-29T18:36:28.001201Z TRACE ThreadId(01) pact_ffi::mock_server::handles: Raw body
2024-08-29T18:36:28.001210Z DEBUG ThreadId(01) pact_models::content_types: Detecting content type from byte contents
2024-08-29T18:36:28.001217Z TRACE ThreadId(01) pact_ffi::mock_server::handles: Setting request content type header to 'text/plain' (if not already set)
```

At the beginning, I already set the correct content type for `pactffi_with_body` (`x-www-form-urlencoded`), but at the end, content type header was set to `text/plain`

This result mismatches from mock server:

```
2024-08-29T18:36:28.006850Z DEBUG tokio-runtime-worker pact_mock_server::hyper_server: Request did not match: Request did not match - HTTP Request ( method: PUT, path: /form, query: None, headers: Some({"Content-Type": ["text/plain"]}), body: Present(15 bytes) )    0) Mismatch with header 'Content-Type': Expected header 'Content-Type' to have value 'text/plain' but was 'application/x-www-form-urlencoded'    1) Expected a body of 'text/plain' but the actual content type was 'application/x-www-form-urlencoded'
```


Not sure this is a bug from pact-reference or not, but I can solve it from Pact-PHP's compatibility suites implementation by setting content type header immediately after the body is parsed.