### PR TITLE
feat: Allow add custom provider headers

### DIFF
--- a/UPGRADE-10.0.md
+++ b/UPGRADE-10.0.md
@@ -45,6 +45,7 @@ This migrates from a CLI driven process for the Pact Framework, to an FFI proces
       - `addUrl` - Verify Provider by Pact Url retrieved by Broker (Webhooks)
       - `addBroker` Verify Provider by dynamically fetched Pacts (Provider change)
       - `addFile` / `addDir` - Verify Provider by local file or directory
+  - `$config->addCustomProviderHeader("headerName", "headerValue")` is now available via `$config->getCustomHeaders()->addHeader("headerName", "headerValue")`
 
   Example Usage:
 

--- a/compatibility-suite/tests/Service/HttpClient.php
+++ b/compatibility-suite/tests/Service/HttpClient.php
@@ -41,7 +41,7 @@ final class HttpClient implements HttpClientInterface
     {
         $result = [];
 
-        foreach($query as $key => $values) {
+        foreach ($query as $key => $values) {
             foreach ($values as $value) {
                 $result[] = urlencode($key) . '=' . urlencode($value);
             }

--- a/docs/provider.md
+++ b/docs/provider.md
@@ -60,6 +60,22 @@ public function testPactVerifyConsumers(): void
 }
 ```
 
+## Add Custom Headers Prior to Verification
+
+Sometimes you may need to add custom headers to the requests that can't be persisted in a pact file.
+e.g. an OAuth bearer token: `Authorization: Bearer 1a2b3c4d5e6f7g8h9i0k`
+
+```php
+$config->getCustomHeaders()
+    ->addHeader('Authorization', 'Bearer 1a2b3c4d5e6f7g8h9i0k');
+```
+
+The requests will have custom headers added before being sent to the Provider API.
+
+> Note: Custom headers are not the only approach for authentication and authorization. For other approaches, please refer to this [documentation](https://docs.pact.io/provider/handling_auth#4-modify-the-request-to-use-real-credentials).
+
+> **Important Note:** You should only use this feature for headers that can not be persisted in the pact file. By modifying the request, you are potentially modifying the contract from the consumer tests!
+
 ## Verification Sources
 
 There are four ways to verify Pact files. See the examples below.

--- a/src/PhpPact/Consumer/Driver/Interaction/InteractionDriverInterface.php
+++ b/src/PhpPact/Consumer/Driver/Interaction/InteractionDriverInterface.php
@@ -3,7 +3,6 @@
 namespace PhpPact\Consumer\Driver\Interaction;
 
 use PhpPact\Consumer\Model\Interaction;
-
 use PhpPact\Standalone\MockService\Model\VerifyResult;
 
 interface InteractionDriverInterface extends DriverInterface

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/Config/CustomHeaders.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/Config/CustomHeaders.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier\Model\Config;
+
+class CustomHeaders implements CustomHeadersInterface
+{
+    /**
+     * @var array<string, string>
+     */
+    private array $headers = [];
+
+    /**
+     * @param array<string, string> $headers
+     */
+    public function setHeaders(array $headers): self
+    {
+        $this->headers = [];
+        foreach ($headers as $name => $value) {
+            $this->addHeader($name, $value);
+        }
+
+        return $this;
+    }
+
+    public function addHeader(string $name, string $value): self
+    {
+        $this->headers[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+}

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/Config/CustomHeadersInterface.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/Config/CustomHeadersInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpPact\Standalone\ProviderVerifier\Model\Config;
+
+interface CustomHeadersInterface
+{
+    /**
+     * @param array<string, string> $headers
+     */
+    public function setHeaders(array $headers): self;
+
+    public function addHeader(string $name, string $value): self;
+
+    /**
+     * @return array<string, string>
+     */
+    public function getHeaders(): array;
+}

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfig.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfig.php
@@ -7,6 +7,8 @@ use PhpPact\Standalone\ProviderVerifier\Model\Config\CallingApp;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\CallingAppInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ConsumerFilters;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ConsumerFiltersInterface;
+use PhpPact\Standalone\ProviderVerifier\Model\Config\CustomHeaders;
+use PhpPact\Standalone\ProviderVerifier\Model\Config\CustomHeadersInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\FilterInfo;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\FilterInfoInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ProviderInfo;
@@ -35,6 +37,7 @@ class VerifierConfig implements VerifierConfigInterface
     private VerificationOptionsInterface $verificationOptions;
     private ?PublishOptionsInterface $publishOptions = null;
     private ConsumerFiltersInterface $consumerFilters;
+    private CustomHeadersInterface $customHeaders;
 
     public function __construct()
     {
@@ -44,6 +47,7 @@ class VerifierConfig implements VerifierConfigInterface
         $this->providerState = new ProviderState();
         $this->verificationOptions = new VerificationOptions();
         $this->consumerFilters = new ConsumerFilters();
+        $this->customHeaders = new CustomHeaders();
     }
 
     public function setCallingApp(CallingAppInterface $callingApp): self
@@ -161,5 +165,17 @@ class VerifierConfig implements VerifierConfigInterface
     public function getVerificationOptions(): VerificationOptionsInterface
     {
         return $this->verificationOptions;
+    }
+
+    public function setCustomHeaders(CustomHeadersInterface $customHeaders): self
+    {
+        $this->customHeaders = $customHeaders;
+
+        return $this;
+    }
+
+    public function getCustomHeaders(): CustomHeadersInterface
+    {
+        return $this->customHeaders;
     }
 }

--- a/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigInterface.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigInterface.php
@@ -4,6 +4,7 @@ namespace PhpPact\Standalone\ProviderVerifier\Model;
 
 use PhpPact\Standalone\ProviderVerifier\Model\Config\CallingAppInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ConsumerFiltersInterface;
+use PhpPact\Standalone\ProviderVerifier\Model\Config\CustomHeadersInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\FilterInfoInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ProviderInfoInterface;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ProviderStateInterface;
@@ -58,4 +59,8 @@ interface VerifierConfigInterface
     public function getLogLevel(): ?string;
 
     public function setLogLevel(string $logLevel): self;
+
+    public function setCustomHeaders(CustomHeadersInterface $customHeaders): self;
+
+    public function getCustomHeaders(): CustomHeadersInterface;
 }

--- a/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
+++ b/src/PhpPact/Standalone/ProviderVerifier/Verifier.php
@@ -27,6 +27,7 @@ class Verifier
         $this->setVerificationOptions($config);
         $this->setPublishOptions($config);
         $this->setConsumerFilters($config);
+        $this->setCustomHeaders($config);
         $this->setLogLevel($config);
     }
 
@@ -123,6 +124,18 @@ class Verifier
             $filterConsumerNames?->getItems(),
             $filterConsumerNames?->getSize()
         );
+    }
+
+    private function setCustomHeaders(VerifierConfigInterface $config): void
+    {
+        foreach ($config->getCustomHeaders()->getHeaders() as $name => $value) {
+            $this->client->call(
+                'pactffi_verifier_add_custom_header',
+                $this->handle,
+                $name,
+                $value
+            );
+        }
     }
 
     private function setLogLevel(VerifierConfigInterface $config): void

--- a/tests/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/Model/VerifierConfigTest.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\Standalone\ProviderVerifier\Model;
 
 use PhpPact\Standalone\ProviderVerifier\Model\Config\CallingApp;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ConsumerFilters;
+use PhpPact\Standalone\ProviderVerifier\Model\Config\CustomHeaders;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\FilterInfo;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ProviderInfo;
 use PhpPact\Standalone\ProviderVerifier\Model\Config\ProviderState;
@@ -29,6 +30,7 @@ class VerifierConfigTest extends TestCase
             new ProviderTransport(),
             new ProviderTransport(),
         ];
+        $customHeaders = new CustomHeaders();
 
         $subject = new VerifierConfig();
         $subject->setCallingApp($callingApp);
@@ -39,6 +41,7 @@ class VerifierConfigTest extends TestCase
         $subject->setPublishOptions($publishOptions);
         $subject->setConsumerFilters($consumerFilters);
         $subject->setProviderTransports($providerTransports);
+        $subject->setCustomHeaders($customHeaders);
 
         $this->assertSame($callingApp, $subject->getCallingApp());
         $this->assertSame($providerInfo, $subject->getProviderInfo());
@@ -49,5 +52,6 @@ class VerifierConfigTest extends TestCase
         $this->assertSame($publishOptions, $subject->getPublishOptions());
         $this->assertSame($consumerFilters, $subject->getConsumerFilters());
         $this->assertSame($providerTransports, $subject->getProviderTransports());
+        $this->assertSame($customHeaders, $subject->getCustomHeaders());
     }
 }

--- a/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
+++ b/tests/PhpPact/Standalone/ProviderVerifier/VerifierTest.php
@@ -79,6 +79,8 @@ class VerifierTest extends TestCase
         $this->config->setPublishOptions($publishOptions);
         $this->config->getConsumerFilters()
             ->setFilterConsumerNames($filterConsumerNames = $hasFilterConsumerNames ? ['http-consumer-1', 'http-consumer-2', 'message-consumer-2'] : []);
+        $this->config->getCustomHeaders()
+            ->setHeaders($customHeaders = ['name-1' => 'value-1', 'name-2' => 'value-2']);
         $this->config->setLogLevel($logLevel = 'info');
         $this->calls = [
             ['pactffi_verifier_new_for_application', $callingAppName, $callingAppVersion, $this->handle],
@@ -103,6 +105,20 @@ class VerifierTest extends TestCase
                 $hasFilterConsumerNames ? $this->isInstanceOf(CData::class) : null,
                 $hasFilterConsumerNames ? count($filterConsumerNames) : null,
                 null
+            ],
+            [
+                'pactffi_verifier_add_custom_header',
+                $this->handle,
+                'name-1',
+                $customHeaders['name-1'],
+                null,
+            ],
+            [
+                'pactffi_verifier_add_custom_header',
+                $this->handle,
+                'name-2',
+                $customHeaders['name-2'],
+                null,
             ],
             ['pactffi_init_with_log_level', strtoupper($logLevel), null],
         ];


### PR DESCRIPTION
Add ability to add custom provider headers to v10. Somehow I didn't notice this feature is available in v9 and FFI at the same time.