### PR TITLE
feat: Add graphql example

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,8 @@
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",
         "ramsey/uuid": "^4.7",
-        "pact-foundation/example-protobuf-sync-message-provider": "@dev"
+        "pact-foundation/example-protobuf-sync-message-provider": "@dev",
+        "webonyx/graphql-php": "^15.14"
     },
     "autoload": {
         "psr-4": {
@@ -70,7 +71,8 @@
             "composer run-example:protobuf-async-message",
             "composer run-example:protobuf-sync-message",
             "composer run-example:stub-server",
-            "composer run-example:xml"
+            "composer run-example:xml",
+            "composer run-example:graphql"
         ],
         "run-example:binary": [
             "rm -f example/binary/pacts/binaryConsumer-binaryProvider.json",
@@ -126,6 +128,11 @@
             "rm -f example/xml/pacts/xmlConsumer-xmlProvider.json",
             "cd example/xml/consumer && phpunit",
             "cd example/xml/provider && phpunit"
+        ],
+        "run-example:graphql": [
+            "rm -f example/graphql/pacts/graphqlConsumer-graphqlProvider.json",
+            "cd example/graphql/consumer && phpunit",
+            "cd example/graphql/provider && phpunit"
         ]
     },
     "extra": {

--- a/example/graphql/consumer/autoload.php
+++ b/example/graphql/consumer/autoload.php
@@ -1,0 +1,5 @@
+<?php
+
+$loader = require __DIR__ . '/../../../vendor/autoload.php';
+$loader->addPsr4('GraphqlConsumer\\', __DIR__ . '/src');
+$loader->addPsr4('GraphqlConsumer\\Tests\\', __DIR__ . '/tests');

--- a/example/graphql/consumer/phpunit.xml
+++ b/example/graphql/consumer/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="PhpPact Example Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="PACT_LOGLEVEL" value="DEBUG"/>
+    </php>
+</phpunit>

--- a/example/graphql/consumer/src/Service/HttpClientService.php
+++ b/example/graphql/consumer/src/Service/HttpClientService.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace GraphqlConsumer\Service;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Uri;
+
+class HttpClientService
+{
+    private Client $httpClient;
+
+    private string $baseUri;
+
+    public function __construct(string $baseUri)
+    {
+        $this->httpClient = new Client();
+        $this->baseUri    = $baseUri;
+    }
+
+    public function query(): string
+    {
+        $response = $this->httpClient->post(new Uri("{$this->baseUri}/api"), [
+            'json' => [
+                'query' => <<<GRAPHQL
+                query {
+                    echo(message: "Hello World")
+                }
+                GRAPHQL,
+            ],
+            'headers' => ['Content-Type' => 'application/json']
+        ]);
+
+        return $response->getBody();
+    }
+
+    public function mutation(): string
+    {
+        $response = $this->httpClient->post(new Uri("{$this->baseUri}/api"), [
+            'json' => [
+                'query' => <<<GRAPHQL
+                mutation { sum(x: 2, y: 2) }
+                GRAPHQL,
+            ],
+            'headers' => ['Content-Type' => 'application/json']
+        ]);
+
+        return $response->getBody();
+    }
+}

--- a/example/graphql/consumer/tests/Service/HttpClientServiceTest.php
+++ b/example/graphql/consumer/tests/Service/HttpClientServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace GraphqlConsumer\Tests\Service;
+
+use PhpPact\Consumer\Matcher\Matcher;
+use GraphqlConsumer\Service\HttpClientService;
+use PhpPact\Consumer\InteractionBuilder;
+use PhpPact\Consumer\Model\ConsumerRequest;
+use PhpPact\Consumer\Model\ProviderResponse;
+use PhpPact\Standalone\MockService\MockServerConfig;
+use PHPUnit\Framework\TestCase;
+
+class HttpClientServiceTest extends TestCase
+{
+    public function testQuery()
+    {
+        $matcher = new Matcher();
+
+        $request = new ConsumerRequest();
+        $request
+            ->setMethod('POST')
+            ->setPath('/api')
+            ->addHeader('Content-Type', 'application/json')
+            ->setBody([
+                'query' => <<<GRAPHQL
+                query {
+                    echo(message: "Hello World")
+                }
+                GRAPHQL
+            ]);
+
+        $response = new ProviderResponse();
+        $response
+            ->setStatus(200)
+            ->addHeader('Content-Type', 'application/json')
+            ->setBody([
+                'data' => [
+                    'echo' => $matcher->string('Greetings Universe'),
+                ],
+            ]);
+
+        $config = new MockServerConfig();
+        $config
+            ->setConsumer('graphqlConsumer')
+            ->setProvider('graphqlProvider')
+            ->setPactDir(__DIR__.'/../../../pacts');
+        if ($logLevel = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($logLevel);
+        }
+        $builder = new InteractionBuilder($config);
+        $builder
+            ->given('User exist')
+            ->uponReceiving('A query request to /api')
+            ->with($request)
+            ->willRespondWith($response);
+
+        $service = new HttpClientService($config->getBaseUri());
+        $result = $service->query();
+        $verifyResult = $builder->verify();
+
+        $this->assertTrue($verifyResult);
+        $this->assertJson($result);
+        $this->assertJsonStringEqualsJsonString(json_encode([
+            'data' => [
+                'echo' => 'Greetings Universe',
+            ],
+        ]), $result);
+    }
+
+    public function testMutation()
+    {
+        $matcher = new Matcher();
+
+        $request = new ConsumerRequest();
+        $request
+            ->setMethod('POST')
+            ->setPath('/api')
+            ->addHeader('Content-Type', 'application/json')
+            ->setBody([
+                'query' => <<<GRAPHQL
+                mutation { sum(x: 2, y: 2) }
+                GRAPHQL
+            ]);
+
+        $response = new ProviderResponse();
+        $response
+            ->setStatus(200)
+            ->addHeader('Content-Type', 'application/json')
+            ->setBody([
+                'data' => [
+                    'sum' => $matcher->integerV3(4),
+                ],
+            ]);
+
+        $config = new MockServerConfig();
+        $config
+            ->setConsumer('graphqlConsumer')
+            ->setProvider('graphqlProvider')
+            ->setPactDir(__DIR__.'/../../../pacts');
+        if ($logLevel = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($logLevel);
+        }
+        $builder = new InteractionBuilder($config);
+        $builder
+            ->uponReceiving('A mutation request to /api')
+            ->with($request)
+            ->willRespondWith($response);
+
+        $service = new HttpClientService($config->getBaseUri());
+        $result = $service->mutation();
+        $verifyResult = $builder->verify();
+
+        $this->assertTrue($verifyResult);
+        $this->assertJson($result);
+        $this->assertJsonStringEqualsJsonString(json_encode([
+            'data' => [
+                'sum' => 4,
+            ],
+        ]), $result);
+    }
+}

--- a/example/graphql/pacts/graphqlConsumer-graphqlProvider.json
+++ b/example/graphql/pacts/graphqlConsumer-graphqlProvider.json
@@ -1,0 +1,97 @@
+{
+  "consumer": {
+    "name": "graphqlConsumer"
+  },
+  "interactions": [
+    {
+      "description": "A mutation request to /api",
+      "request": {
+        "body": {
+          "query": "mutation { sum(x: 2, y: 2) }"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api"
+      },
+      "response": {
+        "body": {
+          "data": {
+            "sum": 4
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data.sum": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    },
+    {
+      "description": "A query request to /api",
+      "providerStates": [
+        {
+          "name": "User exist"
+        }
+      ],
+      "request": {
+        "body": {
+          "query": "query {\n    echo(message: \"Hello World\")\n}"
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "method": "POST",
+        "path": "/api"
+      },
+      "response": {
+        "body": {
+          "data": {
+            "echo": "Greetings Universe"
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$.data.echo": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      }
+    }
+  ],
+  "metadata": {
+    "pactRust": {
+      "ffi": "0.4.23",
+      "mockserver": "1.2.10",
+      "models": "1.2.5"
+    },
+    "pactSpecification": {
+      "version": "3.0.0"
+    }
+  },
+  "provider": {
+    "name": "graphqlProvider"
+  }
+}

--- a/example/graphql/provider/autoload.php
+++ b/example/graphql/provider/autoload.php
@@ -1,0 +1,4 @@
+<?php
+
+$loader = require __DIR__ . '/../../../vendor/autoload.php';
+$loader->addPsr4('GraphqlProvider\\Tests\\', __DIR__ . '/tests');

--- a/example/graphql/provider/phpunit.xml
+++ b/example/graphql/provider/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="./autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="PhpPact Example Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="PACT_LOGLEVEL" value="DEBUG"/>
+    </php>
+</phpunit>

--- a/example/graphql/provider/public/index.php
+++ b/example/graphql/provider/public/index.php
@@ -1,0 +1,82 @@
+<?php
+
+use GraphQL\GraphQL;
+use GraphQL\Type\Definition\ObjectType;
+use GraphQL\Type\Definition\Type;
+use GraphQL\Type\Schema;
+use GraphQL\Type\SchemaConfig;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+require __DIR__ . '/../autoload.php';
+
+$app = AppFactory::create();
+
+$app->post('/api', function (Request $request, Response $response) {
+    try {
+        $queryType = new ObjectType([
+            'name' => 'Query',
+            'fields' => [
+                'echo' => [
+                    'type' => Type::string(),
+                    'args' => [
+                        'message' => ['type' => Type::string()],
+                    ],
+                    'resolve' => static fn ($rootValue, array $args): string => $rootValue['prefix'] . $args['message'],
+                ],
+            ],
+        ]);
+
+        $mutationType = new ObjectType([
+            'name' => 'Mutation',
+            'fields' => [
+                'sum' => [
+                    'type' => Type::int(),
+                    'args' => [
+                        'x' => ['type' => Type::int()],
+                        'y' => ['type' => Type::int()],
+                    ],
+                    'resolve' => static fn ($calc, array $args): int => $args['x'] + $args['y'],
+                ],
+            ],
+        ]);
+
+        // See docs on schema options:
+        // https://webonyx.github.io/graphql-php/schema-definition/#configuration-options
+        $schema = new Schema(
+            (new SchemaConfig())
+            ->setQuery($queryType)
+            ->setMutation($mutationType)
+        );
+
+        $rawInput = file_get_contents('php://input');
+        if ($rawInput === false) {
+            throw new RuntimeException('Failed to get php://input');
+        }
+
+        $input = json_decode($rawInput, true);
+        $query = $input['query'];
+        $variableValues = $input['variables'] ?? null;
+
+        $rootValue = ['prefix' => 'You said: '];
+        $result = GraphQL::executeQuery($schema, $query, $rootValue, null, $variableValues);
+        $output = $result->toArray();
+    } catch (Throwable $e) {
+        $output = [
+            'error' => [
+                'message' => $e->getMessage(),
+            ],
+        ];
+    }
+
+    $response->getBody()->write(json_encode($output, JSON_THROW_ON_ERROR));
+
+    return $response->withHeader('Content-Type', 'application/json; charset=UTF-8');
+});
+
+$app->post('/pact-change-state', function (Request $request, Response $response) {
+    return $response;
+});
+
+$app->run();

--- a/example/graphql/provider/tests/PactVerifyTest.php
+++ b/example/graphql/provider/tests/PactVerifyTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace GraphqlProvider\Tests;
+
+use GuzzleHttp\Psr7\Uri;
+use PhpPact\Standalone\ProviderVerifier\Model\VerifierConfig;
+use PhpPact\Standalone\ProviderVerifier\Verifier;
+use PhpPactTest\Helper\PhpProcess;
+use PHPUnit\Framework\TestCase;
+
+class PactVerifyTest extends TestCase
+{
+    private PhpProcess $process;
+
+    protected function setUp(): void
+    {
+        $this->process = new PhpProcess(__DIR__ . '/../public/');
+        $this->process->start();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->process->stop();
+    }
+
+    /**
+     * This test will run after the web server is started.
+     */
+    public function testPactVerifyConsumer()
+    {
+        $config = new VerifierConfig();
+        $config->getProviderInfo()
+            ->setName('graphqlConsumer') // Providers name to fetch.
+            ->setHost('localhost')
+            ->setPort($this->process->getPort());
+        $config->getProviderState()
+            ->setStateChangeUrl(new Uri(sprintf('http://localhost:%d/pact-change-state', $this->process->getPort())))
+        ;
+        if ($level = \getenv('PACT_LOGLEVEL')) {
+            $config->setLogLevel($level);
+        }
+
+        $verifier = new Verifier($config);
+        $verifier->addFile(__DIR__ . '/../../pacts/graphqlConsumer-graphqlProvider.json');
+
+        $verifyResult = $verifier->verify();
+
+        $this->assertTrue($verifyResult);
+    }
+}


### PR DESCRIPTION
Depend on https://github.com/pact-foundation/pact-php/pull/633


Currently we can only test json response. We can't test the query DSL.

I think we can take inspiration from pact-js https://docs.pact.io/implementation_guides/javascript/docs/graphql