### PR TITLE
deps: Allow update to PHPUnit 11.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^10.1.0|^11.3",
+        "phpunit/phpunit": "^10.1.0|^11.0",
         "guzzlehttp/guzzle": "^7.8",
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
         "phpstan/phpstan": "^1.9",
-        "phpunit/phpunit": "^10.1.0|>=11.0 <11.3",
+        "phpunit/phpunit": "^10.1.0|^11.3",
         "guzzlehttp/guzzle": "^7.8",
         "behat/behat": "^3.13",
         "galbar/jsonpath": "^3.0",


### PR DESCRIPTION
Depend on https://github.com/pact-foundation/pact-php/pull/633


Look like this issue https://github.com/pact-foundation/pact-php/pull/622 doesn't happen anymore with PHPUnit 11.3.6? I'm not so sure