### PR TITLE
chore: Update PHPStan level to max

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: max
     paths:
         - src
         - tests


### PR DESCRIPTION
max level is currently `9`

Depends on:
* #663
* #664
* #665
* #666
* #667
* #668
* #669
* #670