### PR TITLE
refactor: Replace Slim Framework by Framework X

### DIFF
--- a/compatibility-suite/public/generators/index.php
+++ b/compatibility-suite/public/generators/index.php
@@ -1,33 +1,30 @@
 <?php
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../../../vendor/autoload.php';
 
-$app = AppFactory::create();
+$app = new FrameworkX\App();
 
-$app->put('/request-generators', function (Request $request, Response $response) {
+$app->put('/request-generators', function (ServerRequestInterface $request) {
     file_put_contents(__DIR__ . '/body.json', $request->getBody()->getContents());
     file_put_contents(__DIR__ . '/headers.json', json_encode($request->getHeaders()));
     file_put_contents(__DIR__ . '/queryParams.json', json_encode($request->getQueryParams()));
 
-    return $response;
+    return new Response();
 });
 
-$app->post('/return-provider-state-values', function (Request $request, Response $response) {
+$app->post('/return-provider-state-values', function (ServerRequestInterface $request) {
     $values = $request->getQueryParams();
 
-    $response->getBody()->write(json_encode($values));
-
-    return $response->withHeader('Content-Type', 'application/json');
+    return Response::json($values);
 });
 
-$app->any('{path:.*}', function (Request $request, Response $response, array $args) {
-    file_put_contents(__DIR__ . '/path.txt', $args['path']);
+$app->any('{path:.*}', function (ServerRequestInterface $request) {
+    file_put_contents(__DIR__ . '/path.txt', $request->getAttribute('path'));
 
-    return $response;
+    return new Response();
 });
 
 $app->run();

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
     "require-dev": {
         "ext-sockets": "*",
         "roave/security-advisories": "dev-latest",
-        "slim/slim": "^4.13",
         "friendsofphp/php-cs-fixer": "^3.0",
         "php-amqplib/php-amqplib": "^3.0",
         "phpstan/phpstan": "^1.9",
@@ -41,7 +40,8 @@
         "ramsey/uuid": "^4.7",
         "pact-foundation/example-protobuf-sync-message-provider": "@dev",
         "webonyx/graphql-php": "^15.14",
-        "rector/rector": "^1.2"
+        "rector/rector": "^1.2",
+        "clue/framework-x": "^0.16.0"
     },
     "autoload": {
         "psr-4": {

--- a/example/binary/provider/public/index.php
+++ b/example/binary/provider/public/index.php
@@ -1,0 +1,14 @@
+<?php
+
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
+
+require __DIR__ . '/../autoload.php';
+
+$app = new FrameworkX\App();
+
+$app->get('/image.jpg', function (ServerRequestInterface $request) {
+    return new Response(200, ['Content-Type' => 'image/jpeg'], file_get_contents(__DIR__.'/image.jpg'));
+});
+
+$app->run();

--- a/example/csv/provider/public/index.php
+++ b/example/csv/provider/public/index.php
@@ -2,14 +2,19 @@
 
 require __DIR__.'/../autoload.php';
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
-$app = AppFactory::create();
+require __DIR__ . '/../autoload.php';
 
-$app->post('/pact-change-state', function (Request $request, Response $response) {
-    return $response;
+$app = new FrameworkX\App();
+
+$app->get('/report.csv', function (ServerRequestInterface $request) {
+    return new Response(200, ['Content-Type' => 'text/csv;charset=utf-8'], file_get_contents(__DIR__.'/report.csv'));
+});
+
+$app->post('/pact-change-state', function (ServerRequestInterface $request) {
+    return new Response();
 });
 
 $app->run();

--- a/example/generators/provider/public/index.php
+++ b/example/generators/provider/public/index.php
@@ -1,17 +1,16 @@
 <?php
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../autoload.php';
 
-$app = AppFactory::create();
-$app->addBodyParsingMiddleware();
+$app = new FrameworkX\App();
 
-$app->get('/generators', function (Request $request, Response $response) {
-    $body = $request->getParsedBody();
-    $response->getBody()->write(\json_encode([
+$app->get('/generators', function (ServerRequestInterface $request) {
+    $body = json_decode((string) $request->getBody(), true);
+
+    return Response::json([
         'regex' => '800 kilometers',
         'boolean' => true,
         'integer' => 11,
@@ -25,21 +24,14 @@ $app->get('/generators', function (Request $request, Response $response) {
         'number' => 112.3,
         'url' => 'https://www.example.com/users/1234/posts/latest',
         'requestId' => $body['id'],
-    ]));
-
-    return $response
-        ->withHeader('Content-Type', 'application/json')
-        ->withStatus(400);
+    ])
+    ->withStatus(400);
 });
 
-$app->post('/pact-change-state', function (Request $request, Response $response) {
-    $response->getBody()->write(\json_encode([
+$app->post('/pact-change-state', function (ServerRequestInterface $request) {
+    return Response::json([
         'id' => 222,
-    ]));
-
-    return $response
-        ->withHeader('Content-Type', 'application/json')
-        ->withStatus(200);
+    ]);
 });
 
 $app->run();

--- a/example/graphql/provider/public/index.php
+++ b/example/graphql/provider/public/index.php
@@ -5,16 +5,14 @@ use GraphQL\Type\Definition\ObjectType;
 use GraphQL\Type\Definition\Type;
 use GraphQL\Type\Schema;
 use GraphQL\Type\SchemaConfig;
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../autoload.php';
 
-$app = AppFactory::create();
-$app->addBodyParsingMiddleware();
+$app = new FrameworkX\App();
 
-$app->post('/api', function (Request $request, Response $response) {
+$app->post('/api', function (ServerRequestInterface $request) {
     try {
         $queryType = new ObjectType([
             'name' => 'Query',
@@ -51,7 +49,7 @@ $app->post('/api', function (Request $request, Response $response) {
             ->setMutation($mutationType)
         );
 
-        $body = $request->getParsedBody();
+        $body = json_decode((string) $request->getBody(), true);
         $query = $body['query'];
         $variableValues = $body['variables'] ?? null;
 
@@ -66,13 +64,11 @@ $app->post('/api', function (Request $request, Response $response) {
         ];
     }
 
-    $response->getBody()->write(json_encode($output, JSON_THROW_ON_ERROR));
-
-    return $response->withHeader('Content-Type', 'application/json; charset=UTF-8');
+    return Response::json($output);
 });
 
-$app->post('/pact-change-state', function (Request $request, Response $response) {
-    return $response;
+$app->post('/pact-change-state', function (ServerRequestInterface $request) {
+    return new Response();
 });
 
 $app->run();

--- a/example/json/provider/public/index.php
+++ b/example/json/provider/public/index.php
@@ -1,36 +1,32 @@
 <?php
 
 use JsonProvider\ExampleProvider;
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../autoload.php';
 
-$app = AppFactory::create();
-$app->addBodyParsingMiddleware();
+$app = new FrameworkX\App();
 
 $provider = new ExampleProvider();
 
-$app->get('/hello/{name}', function (Request $request, Response $response) use ($provider) {
+$app->get('/hello/{name}', function (ServerRequestInterface $request) use ($provider) {
     $name = $request->getAttribute('name');
-    $response->getBody()->write(\json_encode(['message' => $provider->sayHello($name)]));
 
-    return $response->withHeader('Content-Type', 'application/json');
+    return Response::json(['message' => $provider->sayHello($name)]);
 });
 
-$app->get('/goodbye/{name}', function (Request $request, Response $response) use ($provider) {
+$app->get('/goodbye/{name}', function (ServerRequestInterface $request) use ($provider) {
     $name = $request->getAttribute('name');
-    $response->getBody()->write(\json_encode(['message' => $provider->sayGoodbye($name)]));
 
-    return $response->withHeader('Content-Type', 'application/json');
+    return Response::json(['message' => $provider->sayGoodbye($name)]);
 });
 
-$app->post('/pact-change-state', function (Request $request, Response $response) use ($provider) {
-    $body = $request->getParsedBody();
+$app->post('/pact-change-state', function (ServerRequestInterface $request) use ($provider) {
+    $body = json_decode((string) $request->getBody(), true);
     $provider->changeSate($body['action'], $body['state'], $body['params']);
 
-    return $response;
+    return new Response();
 });
 
 $app->run();

--- a/example/matchers/provider/public/index.php
+++ b/example/matchers/provider/public/index.php
@@ -1,16 +1,14 @@
 <?php
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../autoload.php';
 
-$app = AppFactory::create();
-$app->addBodyParsingMiddleware();
+$app = new FrameworkX\App();
 
-$app->get('/matchers', function (Request $request, Response $response) {
-    $response->getBody()->write(\json_encode([
+$app->get('/matchers', function (ServerRequestInterface $request) {
+    return Response::json([
         'like' => ['key' => 'another value'],
         'likeNull' => null,
         'eachLike' => ['item 1', 'item 2'],
@@ -89,24 +87,19 @@ $app->get('/matchers', function (Request $request, Response $response) {
 
         // Don't mind this. This is for demonstrating what query values provider will received.
         'query' => $request->getQueryParams(),
-    ]));
-
-    return $response
-        ->withHeader('Content-Type', 'application/json')
-        ->withStatus(503)
-        ->withHeader('X-Powered-By', [
-            'PHP',
-            'Nginx',
-            'Slim',
-        ]);
+    ])
+    ->withStatus(503)
+    ->withHeader('X-Powered-By', [
+        'PHP',
+        'Nginx',
+        'Slim',
+    ]);
 });
 
-$app->post('/pact-change-state', function (Request $request, Response $response) {
-    $body = $request->getParsedBody();
+$app->post('/pact-change-state', function (ServerRequestInterface $request) {
+    $body = json_decode((string) $request->getBody(), true);
 
-    printf('%s provider state %s with params: %s', $body['action'], $body['state'], json_encode($body['params']));
-
-    return $response;
+    return Response::plaintext(sprintf('%s provider state %s with params: %s', $body['action'], $body['state'], json_encode($body['params'])));
 });
 
 $app->run();

--- a/example/message/provider/public/index.php
+++ b/example/message/provider/public/index.php
@@ -1,20 +1,19 @@
 <?php
 
 use MessageProvider\ExampleProvider;
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../autoload.php';
 
-$app = AppFactory::create();
-$app->addBodyParsingMiddleware();
+$app = new FrameworkX\App();
 
 $provider = new ExampleProvider();
 
-$app->post('/pact-messages', function (Request $request, Response $response) use ($provider) {
-    $body = $request->getParsedBody();
+$app->post('/pact-messages', function (ServerRequestInterface $request) use ($provider) {
+    $body = json_decode((string) $request->getBody(), true);
     $message = $provider->dispatchMessage($body['description'], $body['providerStates']);
+    $response = new Response();
     if ($message) {
         $response->getBody()->write(\json_encode($message->getContents()));
 
@@ -26,11 +25,11 @@ $app->post('/pact-messages', function (Request $request, Response $response) use
     return $response;
 });
 
-$app->post('/pact-change-state', function (Request $request, Response $response) use ($provider) {
-    $body = $request->getParsedBody();
+$app->post('/pact-change-state', function (ServerRequestInterface $request) use ($provider) {
+    $body = json_decode((string) $request->getBody(), true);
     $provider->changeSate($body['action'], $body['state'], $body['params']);
 
-    return $response;
+    return new Response();
 });
 
 $app->run();

--- a/example/multipart/provider/public/index.php
+++ b/example/multipart/provider/public/index.php
@@ -1,23 +1,20 @@
 <?php
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../autoload.php';
 
-$app = AppFactory::create();
-$app->addBodyParsingMiddleware();
+$app = new FrameworkX\App();
 
-$app->post('/user-profile', function (Request $request, Response $response) {
+$app->post('/user-profile', function (ServerRequestInterface $request) {
     $fileName = (string)$request->getUploadedFiles()['profile_image']->getClientFilename();
-    $response->getBody()->write(\json_encode([
+
+    return Response::json([
         'full_name' => (string)$request->getUploadedFiles()['full_name']->getStream(),
         'profile_image' => "http://example.test/$fileName",
         'personal_note' => (string)$request->getUploadedFiles()['personal_note']->getStream(),
-    ]));
-
-    return $response->withHeader('Content-Type', 'application/json');
+    ]);
 });
 
 $app->run();

--- a/example/xml/provider/public/index.php
+++ b/example/xml/provider/public/index.php
@@ -1,15 +1,14 @@
 <?php
 
-use Psr\Http\Message\ResponseInterface as Response;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Slim\Factory\AppFactory;
+use React\Http\Message\Response;
+use Psr\Http\Message\ServerRequestInterface;
 
 require __DIR__ . '/../autoload.php';
 
-$app = AppFactory::create();
+$app = new FrameworkX\App();
 
-$app->get('/movies', function (Request $request, Response $response) {
-    $response->getBody()->write(
+$app->get('/movies', function (ServerRequestInterface $request) {
+    return Response::xml(
         <<<XML
         <?xml version='1.0' standalone='yes'?>
         <movies>
@@ -39,13 +38,12 @@ $app->get('/movies', function (Request $request, Response $response) {
             </movie>
         </movies>
         XML
-    );
-
-    return $response->withHeader('Content-Type', 'application/movies+xml');
+    )
+    ->withHeader('Content-Type', 'application/movies+xml');
 });
 
-$app->post('/pact-change-state', function (Request $request, Response $response) {
-    return $response;
+$app->post('/pact-change-state', function (ServerRequestInterface $request) {
+    return new Response();
 });
 
 $app->run();

--- a/helper/PhpProcess.php
+++ b/helper/PhpProcess.php
@@ -24,7 +24,7 @@ class PhpProcess extends AbstractProcess
 
     protected function getProcess(): Process
     {
-        return new Process(['php', '-S', '127.0.0.1:' . $this->getPort(), '-t', $this->publicPath]);
+        return new Process(['php', 'index.php'], $this->publicPath, ['X_LISTEN' => '127.0.0.1:' . $this->getPort()]);
     }
 
     private function findAvailablePort(): int


### PR DESCRIPTION
Try to fix these issues:
* #672
* #641
* #549

[Slim Framework](https://www.slimframework.com/) + [PHP Built-in web server](https://www.php.net/manual/en/features.commandline.webserver.php) -> slow
> The web server runs only one single-threaded process, so PHP applications will stall if a request is blocked. 


[Framework X](https://framework-x.org/) + [ReactPHP](https://reactphp.org/) -> faster 2x -> 4x
> Supports async and non-blocking execution for maximum performance

Another option is [AMPHP](https://amphp.org/http-server-router), but it's a bit slower, and the syntax is not  similar to Slim Framework than Framework X