### PR TITLE
refactor: Define enums

### DIFF
--- a/compatibility-suite/tests/Context/V3/Message/ConsumerContext.php
+++ b/compatibility-suite/tests/Context/V3/Message/ConsumerContext.php
@@ -5,7 +5,7 @@ namespace PhpPactTest\CompatibilitySuite\Context\V3\Message;
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 use Exception;
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\MessageBuilder;
 use PhpPact\Standalone\PactMessage\PactMessageConfig;
 use PhpPactTest\CompatibilitySuite\Constant\Path;
@@ -41,7 +41,7 @@ final class ConsumerContext implements Context
             ->setProvider(PactPath::PROVIDER)
             ->setPactDir(Path::PACTS_PATH)
             ->setPactSpecificationVersion($specificationVersion)
-            ->setPactFileWriteMode(PactConfigInterface::MODE_OVERWRITE);
+            ->setPactFileWriteMode(WriteMode::OVERWRITE);
         $this->builder = new MessageBuilder($config);
     }
 

--- a/compatibility-suite/tests/Context/V4/CombinedContext.php
+++ b/compatibility-suite/tests/Context/V4/CombinedContext.php
@@ -3,7 +3,7 @@
 namespace PhpPactTest\CompatibilitySuite\Context\V4;
 
 use Behat\Behat\Context\Context;
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Model\Message;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 use PhpPactTest\CompatibilitySuite\Service\InteractionBuilderInterface;
@@ -51,10 +51,10 @@ final class CombinedContext implements Context
      */
     public function thePactFileForTheTestIsGenerated(): void
     {
-        $this->pactWriter->write($this->id, $this->pactPath, PactConfigInterface::MODE_MERGE);
+        $this->pactWriter->write($this->id, $this->pactPath, WriteMode::MERGE);
         $message = new Message();
         $message->setDescription('message interaction');
-        $this->messagePactWriter->write($message, $this->pactPath, PactConfigInterface::MODE_MERGE);
+        $this->messagePactWriter->write($message, $this->pactPath, WriteMode::MERGE);
     }
 
     /**

--- a/compatibility-suite/tests/Service/MessagePactWriter.php
+++ b/compatibility-suite/tests/Service/MessagePactWriter.php
@@ -2,7 +2,7 @@
 
 namespace PhpPactTest\CompatibilitySuite\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Factory\MessageDriverFactory;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\Standalone\MockService\MockServerConfig;
@@ -17,7 +17,7 @@ class MessagePactWriter implements MessagePactWriterInterface
     ) {
     }
 
-    public function write(Message $message, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void
+    public function write(Message $message, PactPath $pactPath, WriteMode $mode = WriteMode::OVERWRITE): void
     {
         $config = new MockServerConfig();
         $config

--- a/compatibility-suite/tests/Service/MessagePactWriterInterface.php
+++ b/compatibility-suite/tests/Service/MessagePactWriterInterface.php
@@ -2,11 +2,11 @@
 
 namespace PhpPactTest\CompatibilitySuite\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Model\Message;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 
 interface MessagePactWriterInterface
 {
-    public function write(Message $message, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void;
+    public function write(Message $message, PactPath $pactPath, WriteMode $mode = WriteMode::OVERWRITE): void;
 }

--- a/compatibility-suite/tests/Service/PactWriter.php
+++ b/compatibility-suite/tests/Service/PactWriter.php
@@ -2,7 +2,7 @@
 
 namespace PhpPactTest\CompatibilitySuite\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Factory\InteractionDriverFactory;
 use PhpPact\Standalone\MockService\MockServerConfig;
 use PhpPactTest\CompatibilitySuite\Constant\Path;
@@ -16,7 +16,7 @@ class PactWriter implements PactWriterInterface
     ) {
     }
 
-    public function write(int $id, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void
+    public function write(int $id, PactPath $pactPath, WriteMode $mode = WriteMode::OVERWRITE): void
     {
         $config = new MockServerConfig();
         $config

--- a/compatibility-suite/tests/Service/PactWriterInterface.php
+++ b/compatibility-suite/tests/Service/PactWriterInterface.php
@@ -2,10 +2,10 @@
 
 namespace PhpPactTest\CompatibilitySuite\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 
 interface PactWriterInterface
 {
-    public function write(int $id, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void;
+    public function write(int $id, PactPath $pactPath, WriteMode $mode = WriteMode::OVERWRITE): void;
 }

--- a/compatibility-suite/tests/Service/Server.php
+++ b/compatibility-suite/tests/Service/Server.php
@@ -2,7 +2,7 @@
 
 namespace PhpPactTest\CompatibilitySuite\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Driver\Interaction\InteractionDriverInterface;
 use PhpPact\Consumer\Factory\InteractionDriverFactory;
 use PhpPact\Standalone\MockService\MockServerConfig;
@@ -30,7 +30,7 @@ final class Server implements ServerInterface
             ->setProvider(PactPath::PROVIDER)
             ->setPactDir(Path::PACTS_PATH)
             ->setPactSpecificationVersion($specificationVersion)
-            ->setPactFileWriteMode(PactConfigInterface::MODE_OVERWRITE);
+            ->setPactFileWriteMode(WriteMode::OVERWRITE);
 
         if ($level = \getenv('PACT_LOGLEVEL')) {
             $this->config->setLogLevel($level);

--- a/compatibility-suite/tests/Service/SyncMessagePactWriter.php
+++ b/compatibility-suite/tests/Service/SyncMessagePactWriter.php
@@ -2,7 +2,7 @@
 
 namespace PhpPactTest\CompatibilitySuite\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Model\Message;
 use PhpPact\Standalone\MockService\MockServerConfig;
 use PhpPact\SyncMessage\Factory\SyncMessageDriverFactory;
@@ -16,7 +16,7 @@ class SyncMessagePactWriter implements SyncMessagePactWriterInterface
     ) {
     }
 
-    public function write(Message $message, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void
+    public function write(Message $message, PactPath $pactPath, WriteMode $mode = WriteMode::OVERWRITE): void
     {
         $config = new MockServerConfig();
         $config

--- a/compatibility-suite/tests/Service/SyncMessagePactWriterInterface.php
+++ b/compatibility-suite/tests/Service/SyncMessagePactWriterInterface.php
@@ -2,11 +2,11 @@
 
 namespace PhpPactTest\CompatibilitySuite\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Model\Message;
 use PhpPactTest\CompatibilitySuite\Model\PactPath;
 
 interface SyncMessagePactWriterInterface
 {
-    public function write(Message $message, PactPath $pactPath, string $mode = PactConfigInterface::MODE_OVERWRITE): void;
+    public function write(Message $message, PactPath $pactPath, WriteMode $mode = WriteMode::OVERWRITE): void;
 }

--- a/src/PhpPact/Config/Enum/WriteMode.php
+++ b/src/PhpPact/Config/Enum/WriteMode.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PhpPact\Config\Enum;
+
+enum WriteMode: string
+{
+    /**
+     * The entire file is overwritten
+     */
+    case OVERWRITE = 'overwrite';
+    /**
+     * Interactions are added
+     */
+    case MERGE = 'merge';
+}

--- a/src/PhpPact/Config/Exception/ConfigException.php
+++ b/src/PhpPact/Config/Exception/ConfigException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Config\Exception;
+
+use PhpPact\Exception\BaseException;
+
+class ConfigException extends BaseException
+{
+}

--- a/src/PhpPact/Config/Exception/InvalidWriteModeException.php
+++ b/src/PhpPact/Config/Exception/InvalidWriteModeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Config\Exception;
+
+class InvalidWriteModeException extends ConfigException
+{
+}

--- a/src/PhpPact/Config/PactConfigInterface.php
+++ b/src/PhpPact/Config/PactConfigInterface.php
@@ -2,7 +2,8 @@
 
 namespace PhpPact\Config;
 
-use InvalidArgumentException;
+use PhpPact\Config\Exception\InvalidWriteModeException;
+use PhpPact\Config\Enum\WriteMode;
 use UnexpectedValueException;
 
 /**
@@ -12,8 +13,15 @@ interface PactConfigInterface
 {
     public const DEFAULT_SPECIFICATION_VERSION = '3.0.0';
 
+    /**
+     * @deprecated Use WriteMode::OVERWRITE instead
+     */
     public const MODE_OVERWRITE = 'overwrite';
+    /**
+     * @deprecated Use WriteMode::MERGE instead
+     */
     public const MODE_MERGE = 'merge';
+
 
     public function getConsumer(): string;
 
@@ -65,15 +73,10 @@ interface PactConfigInterface
 
     public function setLogLevel(string $logLevel): self;
 
-    /**
-     * @return string 'merge' or 'overwrite' merge means that interactions are added and overwrite means that the entire file is overwritten
-     */
-    public function getPactFileWriteMode(): string;
+    public function getPactFileWriteMode(): WriteMode;
 
     /**
-     * @param string $pactFileWriteMode 'merge' or 'overwrite' merge means that interactions are added and overwrite means that the entire file is overwritten
-     *
-     * @throws InvalidArgumentException If mode is incorrect.
+     * @throws InvalidWriteModeException If mode is incorrect.
      */
-    public function setPactFileWriteMode(string $pactFileWriteMode): self;
+    public function setPactFileWriteMode(string|WriteMode $pactFileWriteMode): self;
 }

--- a/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
+++ b/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
@@ -3,6 +3,7 @@
 namespace PhpPact\Consumer\Driver\Pact;
 
 use Composer\Semver\Comparator;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Config\PactConfigInterface;
 use PhpPact\Consumer\Driver\Exception\MissingPactException;
 use PhpPact\Consumer\Driver\Exception\PactFileNotWrittenException;
@@ -34,7 +35,7 @@ class PactDriver implements PactDriverInterface
         $error = $this->client->pactHandleWriteFile(
             $this->getPact()->handle,
             $this->config->getPactDir(),
-            $this->config->getPactFileWriteMode() === PactConfigInterface::MODE_OVERWRITE
+            $this->config->getPactFileWriteMode() === WriteMode::OVERWRITE
         );
         if ($error) {
             throw new PactFileNotWrittenException($error);

--- a/src/PhpPact/Consumer/Matcher/Enum/HttpStatus.php
+++ b/src/PhpPact/Consumer/Matcher/Enum/HttpStatus.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Enum;
+
+use PhpPact\Consumer\Matcher\Model\Range;
+
+enum HttpStatus: string
+{
+    case INFORMATION = 'info';
+    case SUCCESS = 'success';
+    case REDIRECT = 'redirect';
+    case CLIENT_ERROR = 'clientError';
+    case SERVER_ERROR = 'serverError';
+    case NON_ERROR = 'nonError';
+    case ERROR = 'error';
+
+    public function range(): Range
+    {
+        return match($this) {
+            self::INFORMATION => new Range(100, 199),
+            self::SUCCESS => new Range(200, 299),
+            self::REDIRECT => new Range(300, 399),
+            self::CLIENT_ERROR => new Range(400, 499),
+            self::SERVER_ERROR => new Range(500, 599),
+            self::NON_ERROR => new Range(100, 399),
+            self::ERROR => new Range(400, 599),
+        };
+    }
+}

--- a/src/PhpPact/Consumer/Matcher/Enum/UuidFormat.php
+++ b/src/PhpPact/Consumer/Matcher/Enum/UuidFormat.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Enum;
+
+enum UuidFormat: string
+{
+    case SIMPLE = 'simple';
+    case LOWER_CASE_HYPHENATED = 'lower-case-hyphenated';
+    case UPPER_CASE_HYPHENATED = 'upper-case-hyphenated';
+    case URN = 'URN';
+}

--- a/src/PhpPact/Consumer/Matcher/Generators/Uuid.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/Uuid.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Consumer\Matcher\Generators;
 
+use PhpPact\Consumer\Matcher\Enum\UuidFormat;
 use PhpPact\Consumer\Matcher\Exception\InvalidUuidFormatException;
 
 /**
@@ -14,23 +15,39 @@ use PhpPact\Consumer\Matcher\Exception\InvalidUuidFormatException;
  */
 class Uuid extends AbstractGenerator
 {
+    /**
+     * @deprecated Use UuidFormat::SIMPLE instead
+     */
     public const SIMPLE_FORMAT = 'simple';
+    /**
+     * @deprecated Use UuidFormat::LOWER_CASE_HYPHENATED instead
+     */
     public const LOWER_CASE_HYPHENATED_FORMAT = 'lower-case-hyphenated';
+    /**
+     * @deprecated Use UuidFormat::UPPER_CASE_HYPHENATED instead
+     */
     public const UPPER_CASE_HYPHENATED_FORMAT = 'upper-case-hyphenated';
+    /**
+     * @deprecated Use UuidFormat::URN instead
+     */
     public const URN_FORMAT = 'URN';
 
-    public const FORMATS = [
-        self::SIMPLE_FORMAT,
-        self::LOWER_CASE_HYPHENATED_FORMAT,
-        self::UPPER_CASE_HYPHENATED_FORMAT,
-        self::URN_FORMAT,
-    ];
+    private null|UuidFormat $format;
 
-    public function __construct(private ?string $format = null)
+    public function __construct(null|string|UuidFormat $format = null)
     {
-        if ($format && !in_array($format, self::FORMATS, true)) {
-            throw new InvalidUuidFormatException(sprintf('Format %s is not supported. Supported formats are: %s', $format, implode(', ', self::FORMATS)));
+        if (is_string($format)) {
+            try {
+                $format = UuidFormat::from($format);
+            } catch (\Throwable $th) {
+                $all = implode(', ', array_map(
+                    fn (UuidFormat $status) => $status->value,
+                    UuidFormat::cases()
+                ));
+                throw new InvalidUuidFormatException(sprintf('Format %s is not supported. Supported formats are: %s', $format, $all));
+            }
         }
+        $this->format = $format;
     }
 
     public function getType(): string
@@ -44,7 +61,7 @@ class Uuid extends AbstractGenerator
     protected function getAttributesData(): array
     {
         return $this->format !== null ? [
-            'format' => $this->format,
+            'format' => $this->format->value,
         ] : [];
     }
 }

--- a/src/PhpPact/Consumer/Matcher/HttpStatus.php
+++ b/src/PhpPact/Consumer/Matcher/HttpStatus.php
@@ -2,6 +2,9 @@
 
 namespace PhpPact\Consumer\Matcher;
 
+/**
+ * @deprecated Use PhpPact\Consumer\Matcher\Enum\HttpStatus instead
+ */
 class HttpStatus
 {
     public const INFORMATION = 'info';
@@ -11,20 +14,4 @@ class HttpStatus
     public const SERVER_ERROR = 'serverError';
     public const NON_ERROR = 'nonError';
     public const ERROR = 'error';
-
-    /**
-     * @return array<int, string>
-     */
-    public static function all(): array
-    {
-        return [
-            self::INFORMATION,
-            self::SUCCESS,
-            self::REDIRECT,
-            self::CLIENT_ERROR,
-            self::SERVER_ERROR,
-            self::NON_ERROR,
-            self::ERROR,
-        ];
-    }
 }

--- a/src/PhpPact/Consumer/Matcher/Matcher.php
+++ b/src/PhpPact/Consumer/Matcher/Matcher.php
@@ -2,6 +2,7 @@
 
 namespace PhpPact\Consumer\Matcher;
 
+use PhpPact\Consumer\Matcher\Enum\HttpStatus;
 use PhpPact\Consumer\Matcher\Exception\MatcherException;
 use PhpPact\Consumer\Matcher\Generators\MockServerURL;
 use PhpPact\Consumer\Matcher\Generators\ProviderState;
@@ -386,7 +387,7 @@ class Matcher
     /**
      * Matches the response status code.
      */
-    public function statusCode(string $status, ?int $value = null): MatcherInterface
+    public function statusCode(string|HttpStatus $status, ?int $value = null): MatcherInterface
     {
         return $this->withFormatter(new StatusCode($status, $value));
     }

--- a/src/PhpPact/Consumer/Matcher/Model/Range.php
+++ b/src/PhpPact/Consumer/Matcher/Model/Range.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Model;
+
+class Range
+{
+    public function __construct(public readonly int $min, public readonly int $max)
+    {
+    }
+}

--- a/src/PhpPact/Consumer/Service/MockServer.php
+++ b/src/PhpPact/Consumer/Service/MockServer.php
@@ -3,6 +3,7 @@
 namespace PhpPact\Consumer\Service;
 
 use FFI;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Config\PactConfigInterface;
 use PhpPact\Consumer\Driver\Pact\PactDriverInterface;
 use PhpPact\Consumer\Exception\MockServerNotStartedException;
@@ -68,7 +69,7 @@ class MockServer implements MockServerInterface
         $error = $this->client->writePactFile(
             $this->config->getPort(),
             $this->config->getPactDir(),
-            $this->config->getPactFileWriteMode() === PactConfigInterface::MODE_OVERWRITE
+            $this->config->getPactFileWriteMode() === WriteMode::OVERWRITE
         );
         if ($error) {
             throw new MockServerPactFileNotWrittenException($error);

--- a/tests/PhpPact/Config/PactConfigTest.php
+++ b/tests/PhpPact/Config/PactConfigTest.php
@@ -2,6 +2,8 @@
 
 namespace PhpPactTest\Config;
 
+use PhpPact\Config\Enum\WriteMode;
+use PhpPact\Config\Exception\InvalidWriteModeException;
 use PhpPact\Config\PactConfig;
 use PhpPact\Config\PactConfigInterface;
 use PHPUnit\Framework\Attributes\TestWith;
@@ -41,7 +43,7 @@ class PactConfigTest extends TestCase
         static::assertSame($pactSpecificationVersion, $this->config->getPactSpecificationVersion());
         static::assertSame($log, $this->config->getLog());
         static::assertSame($logLevel, $this->config->getLogLevel());
-        static::assertSame($pactFileWriteMode, $this->config->getPactFileWriteMode());
+        static::assertSame(WriteMode::tryFrom($pactFileWriteMode), $this->config->getPactFileWriteMode());
     }
 
     public function testInvalidPactSpecificationVersion(): void
@@ -71,8 +73,8 @@ class PactConfigTest extends TestCase
 
     public function testInvalidPactFileWriteMode(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage("Invalid PhpPact File Write Mode, value must be one of the following: overwrite, merge.");
+        $this->expectException(InvalidWriteModeException::class);
+        $this->expectExceptionMessage("Mode 'APPEND' is not supported. Supported modes are: overwrite, merge");
         $this->config->setPactFileWriteMode('APPEND');
     }
 }

--- a/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpPactTest\Consumer\Driver\Pact;
 
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Config\PactConfigInterface;
 use PhpPact\Consumer\Driver\Exception\MissingPactException;
 use PhpPact\Consumer\Driver\Exception\PactFileNotWrittenException;
@@ -110,17 +111,17 @@ class PactDriverTest extends TestCase
         $this->driver->getPact();
     }
 
-    #[TestWith([0, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([1, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([2, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([3, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([4, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([0, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([1, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([2, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([3, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([4, PactConfigInterface::MODE_MERGE])]
-    public function testWritePact(int $error, string $writeMode): void
+    #[TestWith([0, WriteMode::OVERWRITE])]
+    #[TestWith([1, WriteMode::OVERWRITE])]
+    #[TestWith([2, WriteMode::OVERWRITE])]
+    #[TestWith([3, WriteMode::OVERWRITE])]
+    #[TestWith([4, WriteMode::OVERWRITE])]
+    #[TestWith([0, WriteMode::MERGE])]
+    #[TestWith([1, WriteMode::MERGE])]
+    #[TestWith([2, WriteMode::MERGE])]
+    #[TestWith([3, WriteMode::MERGE])]
+    #[TestWith([4, WriteMode::MERGE])]
+    public function testWritePact(int $error, WriteMode $writeMode): void
     {
         $this->assertConfig(null, '1.0.0');
         $this->config
@@ -133,7 +134,7 @@ class PactDriverTest extends TestCase
             ->willReturn($writeMode);
         $this->expectsNewPact($this->consumer, $this->provider, $this->pactHandle);
         $this->expectsWithSpecification($this->pactHandle, self::SPEC_V1, true);
-        $this->expectsPactHandleWriteFile($this->pactHandle, $this->pactDir, $writeMode === PactConfigInterface::MODE_OVERWRITE, $error);
+        $this->expectsPactHandleWriteFile($this->pactHandle, $this->pactDir, $writeMode === WriteMode::OVERWRITE, $error);
         $this->driver->setUp();
         if ($error) {
             $this->expectException(PactFileNotWrittenException::class);

--- a/tests/PhpPact/Consumer/Matcher/MatcherTest.php
+++ b/tests/PhpPact/Consumer/Matcher/MatcherTest.php
@@ -2,7 +2,7 @@
 
 namespace PhpPactTest\Consumer\Matcher;
 
-use PhpPact\Consumer\Matcher\Exception\MatcherException;
+use PhpPact\Consumer\Matcher\Enum\HttpStatus;
 use PhpPact\Consumer\Matcher\Exception\MatcherNotSupportedException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\RegexFormatter;
 use PhpPact\Consumer\Matcher\Formatters\Json\HasGeneratorFormatter;
@@ -10,7 +10,6 @@ use PhpPact\Consumer\Matcher\Generators\MockServerURL;
 use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Generators\RandomHexadecimal;
 use PhpPact\Consumer\Matcher\Generators\Uuid;
-use PhpPact\Consumer\Matcher\HttpStatus;
 use PhpPact\Consumer\Matcher\Matcher;
 use PhpPact\Consumer\Matcher\Matchers\ArrayContains;
 use PhpPact\Consumer\Matcher\Matchers\Boolean;

--- a/tests/PhpPact/Consumer/Service/MockServerTest.php
+++ b/tests/PhpPact/Consumer/Service/MockServerTest.php
@@ -2,7 +2,7 @@
 
 namespace PhpPactTest\Consumer\Service;
 
-use PhpPact\Config\PactConfigInterface;
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Consumer\Driver\Pact\PactDriverInterface;
 use PhpPact\Consumer\Exception\MockServerPactFileNotWrittenException;
 use PhpPact\Consumer\Model\Pact\Pact;
@@ -77,22 +77,22 @@ class MockServerTest extends TestCase
         $this->assertSame('', $result->mismatches);
     }
 
-    #[TestWith([0, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([1, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([2, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([3, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([4, PactConfigInterface::MODE_OVERWRITE])]
-    #[TestWith([0, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([1, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([2, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([3, PactConfigInterface::MODE_MERGE])]
-    #[TestWith([4, PactConfigInterface::MODE_MERGE])]
-    public function testWritePact(int $error, string $writeMode): void
+    #[TestWith([0, WriteMode::OVERWRITE])]
+    #[TestWith([1, WriteMode::OVERWRITE])]
+    #[TestWith([2, WriteMode::OVERWRITE])]
+    #[TestWith([3, WriteMode::OVERWRITE])]
+    #[TestWith([4, WriteMode::OVERWRITE])]
+    #[TestWith([0, WriteMode::MERGE])]
+    #[TestWith([1, WriteMode::MERGE])]
+    #[TestWith([2, WriteMode::MERGE])]
+    #[TestWith([3, WriteMode::MERGE])]
+    #[TestWith([4, WriteMode::MERGE])]
+    public function testWritePact(int $error, WriteMode $writeMode): void
     {
         $this->config->setPort($this->port);
         $this->config->setPactDir($this->pactDir);
         $this->config->setPactFileWriteMode($writeMode);
-        $this->expectsWritePactFile($this->port, $this->pactDir, $writeMode === PactConfigInterface::MODE_OVERWRITE, $error, true);
+        $this->expectsWritePactFile($this->port, $this->pactDir, $writeMode === WriteMode::OVERWRITE, $error, true);
         if ($error) {
             $this->expectException(MockServerPactFileNotWrittenException::class);
             $this->expectExceptionMessage(match ($error) {

--- a/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
+++ b/tests/PhpPact/Standalone/MockServer/MockServerConfigTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpPactTest\Standalone\MockServer;
 
+use PhpPact\Config\Enum\WriteMode;
 use PhpPact\Standalone\MockService\MockServerConfig;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -38,7 +39,7 @@ class MockServerConfigTest extends TestCase
         static::assertSame($provider, $subject->getProvider());
         static::assertSame($consumer, $subject->getConsumer());
         static::assertSame($pactDir, $subject->getPactDir());
-        static::assertSame($pactFileWriteMode, $subject->getPactFileWriteMode());
+        static::assertSame(WriteMode::tryFrom($pactFileWriteMode), $subject->getPactFileWriteMode());
         static::assertSame($log, $subject->getLog());
         static::assertSame($logLevel, $subject->getLogLevel());
         static::assertSame($pactSpecificationVersion, $subject->getPactSpecificationVersion());


### PR DESCRIPTION
Keep old constants and ability to set string for some backward compatible.

For #260