### PR TITLE
feat: Support fromProviderState generator in matching expression

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Generators/ProviderState.php
+++ b/src/PhpPact/Consumer/Matcher/Generators/ProviderState.php
@@ -3,6 +3,8 @@
 namespace PhpPact\Consumer\Matcher\Generators;
 
 use PhpPact\Consumer\Matcher\Model\Attributes;
+use PhpPact\Consumer\Matcher\Model\Expression;
+use PhpPact\Consumer\Matcher\Model\Generator\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Generator\JsonFormattableInterface;
 
 /**
@@ -10,7 +12,7 @@ use PhpPact\Consumer\Matcher\Model\Generator\JsonFormattableInterface;
  *
  * Example expression: /products/${id}
  */
-class ProviderState extends AbstractGenerator implements JsonFormattableInterface
+class ProviderState extends AbstractGenerator implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     public function __construct(private string $expression)
     {
@@ -22,5 +24,10 @@ class ProviderState extends AbstractGenerator implements JsonFormattableInterfac
             'pact:generator:type' => 'ProviderState',
             'expression' => $this->expression,
         ]);
+    }
+
+    public function formatExpression(): Expression
+    {
+        return new Expression('fromProviderState(%expression%, %value%)', ['expression' => $this->expression]);
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/AbstractDateTime.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/AbstractDateTime.php
@@ -7,11 +7,13 @@ use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
+use PhpPact\Consumer\Matcher\Trait\ExpressionFormattableTrait;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 
 abstract class AbstractDateTime extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     use JsonFormattableTrait;
+    use ExpressionFormattableTrait;
 
     public function __construct(protected string $format, private ?string $value = null)
     {
@@ -35,13 +37,13 @@ abstract class AbstractDateTime extends GeneratorAwareMatcher implements JsonFor
 
         $type = $this->getType();
 
-        return new Expression(
+        return $this->mergeExpression(new Expression(
             "matching({$type}, %format%, %value%)",
             [
                 'format' => $this->format,
                 'value' => $this->value,
             ],
-        );
+        ));
     }
 
     abstract protected function getType(): string;

--- a/src/PhpPact/Consumer/Matcher/Matchers/Decimal.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Decimal.php
@@ -8,6 +8,7 @@ use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
+use PhpPact\Consumer\Matcher\Trait\ExpressionFormattableTrait;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 
 /**
@@ -16,6 +17,7 @@ use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 class Decimal extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     use JsonFormattableTrait;
+    use ExpressionFormattableTrait;
 
     public function __construct(private ?float $value = null)
     {
@@ -38,6 +40,6 @@ class Decimal extends GeneratorAwareMatcher implements JsonFormattableInterface,
         if (!is_float($this->value)) {
             throw new InvalidValueException(sprintf("Decimal matching expression doesn't support value of type %s", gettype($this->value)));
         }
-        return new Expression('matching(decimal, %value%)', ['value' => $this->value]);
+        return $this->mergeExpression(new Expression('matching(decimal, %value%)', ['value' => $this->value]));
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Equality.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Equality.php
@@ -6,6 +6,7 @@ use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
+use PhpPact\Consumer\Matcher\Trait\ExpressionFormattableTrait;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 
 /**
@@ -14,6 +15,7 @@ use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 class Equality extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     use JsonFormattableTrait;
+    use ExpressionFormattableTrait;
 
     public function __construct(private mixed $value)
     {
@@ -30,6 +32,6 @@ class Equality extends GeneratorAwareMatcher implements JsonFormattableInterface
 
     public function formatExpression(): Expression
     {
-        return new Expression('matching(equalTo, %value%)', ['value' => $this->value]);
+        return $this->mergeExpression(new Expression('matching(equalTo, %value%)', ['value' => $this->value]));
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Integer.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Integer.php
@@ -8,6 +8,7 @@ use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
+use PhpPact\Consumer\Matcher\Trait\ExpressionFormattableTrait;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 
 /**
@@ -16,6 +17,7 @@ use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 class Integer extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     use JsonFormattableTrait;
+    use ExpressionFormattableTrait;
 
     public function __construct(private ?int $value = null)
     {
@@ -38,6 +40,6 @@ class Integer extends GeneratorAwareMatcher implements JsonFormattableInterface,
         if (!is_int($this->value)) {
             throw new InvalidValueException(sprintf("Integer matching expression doesn't support value of type %s", gettype($this->value)));
         }
-        return new Expression('matching(integer, %value%)', ['value' => $this->value]);
+        return $this->mergeExpression(new Expression('matching(integer, %value%)', ['value' => $this->value]));
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/NotEmpty.php
@@ -6,6 +6,7 @@ use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
+use PhpPact\Consumer\Matcher\Trait\ExpressionFormattableTrait;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 
 /**
@@ -14,6 +15,7 @@ use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 class NotEmpty extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     use JsonFormattableTrait;
+    use ExpressionFormattableTrait;
 
     public function __construct(private mixed $value)
     {
@@ -30,6 +32,6 @@ class NotEmpty extends GeneratorAwareMatcher implements JsonFormattableInterface
 
     public function formatExpression(): Expression
     {
-        return new Expression('notEmpty(%value%)', ['value' => $this->value]);
+        return $this->mergeExpression(new Expression('notEmpty(%value%)', ['value' => $this->value]));
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Number.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Number.php
@@ -8,6 +8,7 @@ use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
+use PhpPact\Consumer\Matcher\Trait\ExpressionFormattableTrait;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 
 /**
@@ -16,6 +17,7 @@ use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 class Number extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     use JsonFormattableTrait;
+    use ExpressionFormattableTrait;
 
     public function __construct(private int|float|null $value = null)
     {
@@ -38,6 +40,6 @@ class Number extends GeneratorAwareMatcher implements JsonFormattableInterface, 
         if (null === $this->value) {
             throw new InvalidValueException(sprintf("Number matching expression doesn't support value of type %s", gettype($this->value)));
         }
-        return new Expression('matching(number, %value%)', ['value' => $this->value]);
+        return $this->mergeExpression(new Expression('matching(number, %value%)', ['value' => $this->value]));
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/Type.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Type.php
@@ -6,6 +6,7 @@ use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
+use PhpPact\Consumer\Matcher\Trait\ExpressionFormattableTrait;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 
 /**
@@ -14,6 +15,7 @@ use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
 class Type extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
     use JsonFormattableTrait;
+    use ExpressionFormattableTrait;
 
     public function __construct(private mixed $value)
     {
@@ -30,6 +32,6 @@ class Type extends GeneratorAwareMatcher implements JsonFormattableInterface, Ex
 
     public function formatExpression(): Expression
     {
-        return new Expression('matching(type, %value%)', ['value' => $this->value]);
+        return $this->mergeExpression(new Expression('matching(type, %value%)', ['value' => $this->value]));
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Model/Expression.php
+++ b/src/PhpPact/Consumer/Matcher/Model/Expression.php
@@ -15,6 +15,19 @@ class Expression implements JsonSerializable
         $this->setValues($values);
     }
 
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getValues(): array
+    {
+        return $this->values;
+    }
+
     public function jsonSerialize(): string
     {
         return $this->format();

--- a/src/PhpPact/Consumer/Matcher/Model/Generator/ExpressionFormattableInterface.php
+++ b/src/PhpPact/Consumer/Matcher/Model/Generator/ExpressionFormattableInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Model\Generator;
+
+use PhpPact\Consumer\Matcher\Model\Expression;
+
+interface ExpressionFormattableInterface
+{
+    public function formatExpression(): Expression;
+}

--- a/src/PhpPact/Consumer/Matcher/Trait/ExpressionFormattableTrait.php
+++ b/src/PhpPact/Consumer/Matcher/Trait/ExpressionFormattableTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace PhpPact\Consumer\Matcher\Trait;
+
+use PhpPact\Consumer\Matcher\Model\Expression;
+use PhpPact\Consumer\Matcher\Model\GeneratorAwareInterface;
+use PhpPact\Consumer\Matcher\Model\Generator\ExpressionFormattableInterface as GeneratorExpressionFormattableInterface;
+
+trait ExpressionFormattableTrait
+{
+    public function mergeExpression(Expression $expression): Expression
+    {
+        if ($this instanceof GeneratorAwareInterface) {
+            $generator = $this->getGenerator();
+            if ($generator instanceof GeneratorExpressionFormattableInterface) {
+                $generated = $generator->formatExpression();
+
+                return new Expression(
+                    str_replace('%value%', $generated->getFormat(), $expression->getFormat()),
+                    [
+                        ...$expression->getValues(),
+                        ...$generated->getValues(),
+                    ]
+                );
+            }
+        }
+        return $expression;
+    }
+}

--- a/tests/PhpPact/Consumer/Matcher/Matchers/DateTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/DateTest.php
@@ -4,7 +4,9 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Matchers\Date;
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +36,16 @@ class DateTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new Date("contains single quote '", '2012-04-12'), new ProviderState('${value}'), '"matching(date, \'contains single quote \\\\\'\', fromProviderState(\'${value}\', \'2012-04-12\'))"'])]
+    #[TestWith([new Date('yyyy-MM-dd', "contains single quote '"), new ProviderState('${value}'), '"matching(date, \'yyyy-MM-dd\', fromProviderState(\'${value}\', \'contains single quote \\\\\'\'))"'])]
+    #[TestWith([new Date('yyyy-MM-dd', '2012-04-12'), new ProviderState('${value}'), '"matching(date, \'yyyy-MM-dd\', fromProviderState(\'${value}\', \'2012-04-12\'))"'])]
+    public function testFormatExpressionWithGenerator(Date $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/DateTimeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/DateTimeTest.php
@@ -4,7 +4,9 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Matchers\DateTime;
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +37,16 @@ class DateTimeTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new DateTime("contains single quote '", '2020-05-21 16:44:32+10:00'), new ProviderState('${value}'), '"matching(datetime, \'contains single quote \\\\\'\', fromProviderState(\'${value}\', \'2020-05-21 16:44:32+10:00\'))"'])]
+    #[TestWith([new DateTime('yyyy-MM-dd HH:mm:ssZZZZZ', "contains single quote '"), new ProviderState('${value}'), '"matching(datetime, \'yyyy-MM-dd HH:mm:ssZZZZZ\', fromProviderState(\'${value}\', \'contains single quote \\\\\'\'))"'])]
+    #[TestWith([new DateTime('yyyy-MM-dd HH:mm:ssZZZZZ', '2020-05-21 16:44:32+10:00'), new ProviderState('${value}'), '"matching(datetime, \'yyyy-MM-dd HH:mm:ssZZZZZ\', fromProviderState(\'${value}\', \'2020-05-21 16:44:32+10:00\'))"'])]
+    public function testFormatExpressionWithGenerator(DateTime $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/DecimalTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/DecimalTest.php
@@ -4,7 +4,9 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Matchers\Decimal;
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -35,6 +37,17 @@ class DecimalTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new Decimal(-99), new ProviderState('${value}'), '"matching(decimal, fromProviderState(\'${value}\', -99))"'])] // Provider verification will fail on this case
+    #[TestWith([new Decimal(100), new ProviderState('${value}'), '"matching(decimal, fromProviderState(\'${value}\', 100))"'])] // Provider verification will fail on this case
+    #[TestWith([new Decimal(100.01), new ProviderState('${value}'), '"matching(decimal, fromProviderState(\'${value}\', 100.01))"'])]
+    #[TestWith([new Decimal(-100.003), new ProviderState('${value}'), '"matching(decimal, fromProviderState(\'${value}\', -100.003))"'])]
+    public function testFormatExpressionWithGenerator(Decimal $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EqualityTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EqualityTest.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\Equality;
 use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
@@ -45,6 +46,22 @@ class EqualityTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new Equality("contains single quote '"), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', \'contains single quote \\\\\'\'))"'])]
+    #[TestWith([new Equality('example value'), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', \'example value\'))"'])]
+    #[TestWith([new Equality(100.09), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', 100.09))"'])]
+    #[TestWith([new Equality(-99.99), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', -99.99))"'])]
+    #[TestWith([new Equality(100), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', 100))"'])]
+    #[TestWith([new Equality(-99), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', -99))"'])]
+    #[TestWith([new Equality(true), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', true))"'])]
+    #[TestWith([new Equality(false), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', false))"'])]
+    #[TestWith([new Equality(null), new ProviderState('${value}'), '"matching(equalTo, fromProviderState(\'${value}\', null))"'])]
+    public function testFormatExpressionWithGenerator(Equality $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/IntegerTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/IntegerTest.php
@@ -4,7 +4,9 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Matchers\Integer;
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +36,15 @@ class IntegerTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new Integer(-99), new ProviderState('${value}'), '"matching(integer, fromProviderState(\'${value}\', -99))"'])]
+    #[TestWith([new Integer(100), new ProviderState('${value}'), '"matching(integer, fromProviderState(\'${value}\', 100))"'])]
+    public function testFormatExpressionWithGenerator(Integer $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/NotEmptyTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/NotEmptyTest.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\NotEmpty;
 use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
@@ -42,6 +43,19 @@ class NotEmptyTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new NotEmpty("contains single quote '"), new ProviderState('${value}'), '"notEmpty(fromProviderState(\'${value}\', \'contains single quote \\\\\'\'))"'])]
+    #[TestWith([new NotEmpty('example value'), new ProviderState('${value}'), '"notEmpty(fromProviderState(\'${value}\', \'example value\'))"'])]
+    #[TestWith([new NotEmpty(100.09), new ProviderState('${value}'), '"notEmpty(fromProviderState(\'${value}\', 100.09))"'])]
+    #[TestWith([new NotEmpty(100), new ProviderState('${value}'), '"notEmpty(fromProviderState(\'${value}\', 100))"'])]
+    #[TestWith([new NotEmpty(true), new ProviderState('${value}'), '"notEmpty(fromProviderState(\'${value}\', true))"'])]
+    #[TestWith([new NotEmpty(false), new ProviderState('${value}'), '"notEmpty(fromProviderState(\'${value}\', false))"'])]
+    public function testFormatExpressionWithGenerator(NotEmpty $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/NumberTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/NumberTest.php
@@ -4,7 +4,9 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Matchers\Number;
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -37,6 +39,17 @@ class NumberTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new Number(-99), new ProviderState('${value}'), '"matching(number, fromProviderState(\'${value}\', -99))"'])]
+    #[TestWith([new Number(100), new ProviderState('${value}'), '"matching(number, fromProviderState(\'${value}\', 100))"'])]
+    #[TestWith([new Number(100.01), new ProviderState('${value}'), '"matching(number, fromProviderState(\'${value}\', 100.01))"'])]
+    #[TestWith([new Number(-100.003), new ProviderState('${value}'), '"matching(number, fromProviderState(\'${value}\', -100.003))"'])]
+    public function testFormatExpressionWithGenerator(Number $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/TimeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/TimeTest.php
@@ -4,7 +4,9 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Matchers\Time;
+use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
 use PhpPact\Consumer\Matcher\Model\MatcherInterface;
 use PHPUnit\Framework\Attributes\TestWith;
 use PHPUnit\Framework\TestCase;
@@ -35,5 +37,15 @@ class TimeTest extends TestCase
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
         $this->assertSame($json, json_encode($matcher));
+    }
+
+    #[TestWith([new Time("contains single quote '", '22:04'), new ProviderState('${value}'), '"matching(time, \'contains single quote \\\\\'\', fromProviderState(\'${value}\', \'22:04\'))"'])]
+    #[TestWith([new Time('HH:mm', "contains single quote '"), new ProviderState('${value}'), '"matching(time, \'HH:mm\', fromProviderState(\'${value}\', \'contains single quote \\\\\'\'))"'])]
+    #[TestWith([new Time('HH:mm', '22:04'), new ProviderState('${value}'), '"matching(time, \'HH:mm\', fromProviderState(\'${value}\', \'22:04\'))"'])]
+    public function testFormatExpressionWithGenerator(Time $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
+        $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/TypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/TypeTest.php
@@ -4,6 +4,7 @@ namespace PhpPactTest\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
+use PhpPact\Consumer\Matcher\Generators\ProviderState;
 use PhpPact\Consumer\Matcher\Generators\RandomString;
 use PhpPact\Consumer\Matcher\Matchers\Type;
 use PhpPact\Consumer\Matcher\Model\GeneratorInterface;
@@ -47,6 +48,22 @@ class TypeTest extends TestCase
     public function testFormatExpression(MatcherInterface $matcher, string $expression): void
     {
         $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $this->assertSame($expression, json_encode($matcher));
+    }
+
+    #[TestWith([new Type("contains single quote '"), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', \'contains single quote \\\\\'\'))"'])]
+    #[TestWith([new Type('example value'), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', \'example value\'))"'])]
+    #[TestWith([new Type(100.09), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', 100.09))"'])]
+    #[TestWith([new Type(-99.99), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', -99.99))"'])]
+    #[TestWith([new Type(100), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', 100))"'])]
+    #[TestWith([new Type(-99), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', -99))"'])]
+    #[TestWith([new Type(true), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', true))"'])]
+    #[TestWith([new Type(false), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', false))"'])]
+    #[TestWith([new Type(null), new ProviderState('${value}'), '"matching(type, fromProviderState(\'${value}\', null))"'])]
+    public function testFormatExpressionWithGenerator(Type $matcher, GeneratorInterface $generator, string $expression): void
+    {
+        $matcher = $matcher->withFormatter(new ExpressionFormatter());
+        $matcher = $matcher->withGenerator($generator);
         $this->assertSame($expression, json_encode($matcher));
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Model/ExpressionTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Model/ExpressionTest.php
@@ -11,7 +11,8 @@ class ExpressionTest extends TestCase
 {
     public function testFormat(): void
     {
-        $expression = new Expression('values(%quote%, %noQuote%, %true%, %false%, %integer%, %double%, %empty%)', [
+        $format = 'values(%quote%, %noQuote%, %true%, %false%, %integer%, %double%, %empty%)';
+        $values = [
             'quote' => "it's fine",
             'noQuote' => 'right',
             'true' => true,
@@ -19,7 +20,10 @@ class ExpressionTest extends TestCase
             'integer' => -123,
             'double' => -12.3,
             'empty' => null,
-        ]);
+        ];
+        $expression = new Expression($format, $values);
+        $this->assertSame($format, $expression->getFormat());
+        $this->assertSame($values, $expression->getValues());
         $this->assertSame("\"values('it\\\'s fine', 'right', true, false, -123, -12.3, null)\"", json_encode($expression));
         $this->assertSame("values('it\'s fine', 'right', true, false, -123, -12.3, null)", (string)$expression);
     }


### PR DESCRIPTION
Depends on #678

Support this syntax `matching(equalTo, fromProviderState('${Auth}', 'AST00004'))`