### PR TITLE
fix(compatibility-suite): Clean up mock server

### DIFF
--- a/.github/workflows/compatibility-suite.yml
+++ b/.github/workflows/compatibility-suite.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Run Behat
         run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V1 --colors
+        env:
+          PACT_LOGLEVEL: debug
   v2:
     runs-on: ubuntu-latest
     steps:
@@ -38,6 +40,8 @@ jobs:
 
       - name: Run Behat
         run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V2 --colors
+        env:
+          PACT_LOGLEVEL: debug
   v3:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +58,8 @@ jobs:
 
       - name: Run Behat
         run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V3 --name '/^((?!binary body \(negative|Message provider).)*$/' --colors
+        env:
+          PACT_LOGLEVEL: debug
   v4:
     runs-on: ubuntu-latest
     steps:
@@ -70,3 +76,5 @@ jobs:
 
       - name: Run Behat
         run: vendor/bin/behat compatibility-suite/pact-compatibility-suite/features/V4 --colors
+        env:
+          PACT_LOGLEVEL: debug

--- a/compatibility-suite/tests/Service/Server.php
+++ b/compatibility-suite/tests/Service/Server.php
@@ -77,4 +77,10 @@ final class Server implements ServerInterface
     {
         return $this->config->getPort();
     }
+
+    public function __destruct()
+    {
+        // Clean up mock server
+        $this->getVerifyResult();
+    }
 }

--- a/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
+++ b/src/PhpPact/Consumer/Driver/Pact/PactDriver.php
@@ -23,6 +23,9 @@ class PactDriver implements PactDriverInterface
 
     public function cleanUp(): void
     {
+        if (!$this->pact) {
+            return;
+        }
         $success = $this->client->freePactHandle($this->getPact()->handle) === 0;
         if (!$success) {
             trigger_error('Can not free pact handle. The handle is not valid or does not refer to a valid Pact. Could be that it was previously deleted.', E_USER_WARNING);

--- a/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
+++ b/tests/PhpPact/Consumer/Driver/Pact/PactDriverTest.php
@@ -81,7 +81,7 @@ class PactDriverTest extends TestCase
 
     public function testCleanUpWithoutPact(): void
     {
-        $this->expectException(MissingPactException::class);
+        $this->expectNotToPerformAssertions();
         $this->driver->cleanUp();
     }
 

--- a/tests/PhpPact/Plugin/Driver/Pact/AbstractPluginPactDriverTestCase.php
+++ b/tests/PhpPact/Plugin/Driver/Pact/AbstractPluginPactDriverTestCase.php
@@ -2,7 +2,6 @@
 
 namespace PhpPactTest\Plugin\Driver\Pact;
 
-use PhpPact\Consumer\Driver\Exception\MissingPactException;
 use PhpPact\Plugin\Driver\Pact\AbstractPluginPactDriver;
 use PhpPact\Plugin\Exception\PluginNotSupportedBySpecificationException;
 use PhpPactTest\Consumer\Driver\Pact\PactDriverTest;
@@ -51,7 +50,7 @@ abstract class AbstractPluginPactDriverTestCase extends PactDriverTest
 
     public function testCleanUpPluginWithoutPact(): void
     {
-        $this->expectException(MissingPactException::class);
+        $this->expectNotToPerformAssertions();
         $this->driver->cleanUp();
     }
 


### PR DESCRIPTION
* Fix the root cause described in https://github.com/pact-foundation/pact-php/issues/687#issuecomment-2425363210 for random issue like:
  * #687
  * #549
  * #685
* Make mock server's clean up method idempotent

Depends on #686
Tested [150 times](https://github.com/pact-foundation/pact-php/actions/runs/11429024507/job/31803486191?pr=688).