### PR TITLE
feat: Allow logging to multiple sinks

### DIFF
--- a/src/PhpPact/FFI/Client.php
+++ b/src/PhpPact/FFI/Client.php
@@ -510,6 +510,41 @@ class Client implements ClientInterface
         return $result;
     }
 
+    public function loggerInit(): void
+    {
+        $this->call('pactffi_logger_init');
+    }
+
+    public function loggerAttachSink(string $sinkSpecifier, int $levelFilter): int
+    {
+        $method = 'pactffi_logger_attach_sink';
+        $result = $this->call($method, $sinkSpecifier, $levelFilter);
+        if (!is_int($result)) {
+            throw new InvalidResultException(sprintf('Invalid result of "%s". Expected "integer", but got "%s"', $method, get_debug_type($result)));
+        }
+        return $result;
+    }
+
+    public function loggerApply(): int
+    {
+        $method = 'pactffi_logger_apply';
+        $result = $this->call($method);
+        if (!is_int($result)) {
+            throw new InvalidResultException(sprintf('Invalid result of "%s". Expected "integer", but got "%s"', $method, get_debug_type($result)));
+        }
+        return $result;
+    }
+
+    public function fetchLogBuffer(?string $logId = null): string
+    {
+        $method = 'pactffi_fetch_log_buffer';
+        $result = $this->call($method, $logId);
+        if (!is_string($result)) {
+            throw new InvalidResultException(sprintf('Invalid result of "%s". Expected "string", but got "%s"', $method, get_debug_type($result)));
+        }
+        return $result;
+    }
+
     public function getInteractionPartRequest(): int
     {
         return $this->getEnum('InteractionPart_Request');
@@ -548,6 +583,36 @@ class Client implements ClientInterface
     public function getPactSpecificationUnknown(): int
     {
         return $this->getEnum('PactSpecification_Unknown');
+    }
+
+    public function getLevelFilterTrace(): int
+    {
+        return $this->getEnum('LevelFilter_Trace');
+    }
+
+    public function getLevelFilterDebug(): int
+    {
+        return $this->getEnum('LevelFilter_Debug');
+    }
+
+    public function getLevelFilterInfo(): int
+    {
+        return $this->getEnum('LevelFilter_Info');
+    }
+
+    public function getLevelFilterWarn(): int
+    {
+        return $this->getEnum('LevelFilter_Warn');
+    }
+
+    public function getLevelFilterError(): int
+    {
+        return $this->getEnum('LevelFilter_Error');
+    }
+
+    public function getLevelFilterOff(): int
+    {
+        return $this->getEnum('LevelFilter_Off');
     }
 
     private function getEnum(string $name): int

--- a/src/PhpPact/FFI/ClientInterface.php
+++ b/src/PhpPact/FFI/ClientInterface.php
@@ -123,6 +123,14 @@ interface ClientInterface
 
     public function interactionContents(int $interaction, int $part, string $contentType, string $contents): int;
 
+    public function loggerInit(): void;
+
+    public function loggerAttachSink(string $sinkSpecifier, int $levelFilter): int;
+
+    public function loggerApply(): int;
+
+    public function fetchLogBuffer(?string $logId = null): string;
+
     public function getInteractionPartRequest(): int;
 
     public function getInteractionPartResponse(): int;
@@ -138,4 +146,16 @@ interface ClientInterface
     public function getPactSpecificationV4(): int;
 
     public function getPactSpecificationUnknown(): int;
+
+    public function getLevelFilterTrace(): int;
+
+    public function getLevelFilterDebug(): int;
+
+    public function getLevelFilterInfo(): int;
+
+    public function getLevelFilterWarn(): int;
+
+    public function getLevelFilterError(): int;
+
+    public function getLevelFilterOff(): int;
 }

--- a/src/PhpPact/Log/Enum/LogLevel.php
+++ b/src/PhpPact/Log/Enum/LogLevel.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PhpPact\Log\Enum;
+
+enum LogLevel: string
+{
+    case TRACE = 'TRACE';
+    case DEBUG = 'DEBUG';
+    case INFO = 'INFO';
+    case WARN = 'WARN';
+    case ERROR = 'ERROR';
+    case OFF = 'OFF';
+    case NONE = 'NONE';
+}

--- a/src/PhpPact/Log/Exception/LogException.php
+++ b/src/PhpPact/Log/Exception/LogException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PhpPact\Log\Exception;
+
+use PhpPact\Exception\BaseException;
+
+class LogException extends BaseException
+{
+}

--- a/src/PhpPact/Log/Exception/LoggerApplyException.php
+++ b/src/PhpPact/Log/Exception/LoggerApplyException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PhpPact\Log\Exception;
+
+class LoggerApplyException extends LoggerException
+{
+    public function __construct(int $code)
+    {
+        $message = match ($code) {
+            -1 => "Can't set logger (applying the logger failed, perhaps because one is applied already).",
+            default => 'Unknown error',
+        };
+        parent::__construct($message, $code);
+    }
+}

--- a/src/PhpPact/Log/Exception/LoggerAttachSinkException.php
+++ b/src/PhpPact/Log/Exception/LoggerAttachSinkException.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpPact\Log\Exception;
+
+class LoggerAttachSinkException extends LoggerException
+{
+    public function __construct(int $code)
+    {
+        $message = match ($code) {
+            -1 => "Can't set logger (applying the logger failed, perhaps because one is applied already).",
+            -2 => 'No logger has been initialized (call `pactffi_logger_init` before any other log function).',
+            -3 => 'The sink specifier was not UTF-8 encoded.',
+            -4 => 'The sink type specified is not a known type (known types: "stdout", "stderr", "buffer", or "file /some/path").',
+            -5 => 'No file path was specified in a file-type sink specification.',
+            -6 => 'Opening a sink to the specified file path failed (check permissions).',
+            default => 'Unknown error',
+        };
+        parent::__construct($message, $code);
+    }
+}

--- a/src/PhpPact/Log/Exception/LoggerException.php
+++ b/src/PhpPact/Log/Exception/LoggerException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Log\Exception;
+
+class LoggerException extends LogException
+{
+}

--- a/src/PhpPact/Log/Exception/LoggerUnserializeException.php
+++ b/src/PhpPact/Log/Exception/LoggerUnserializeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace PhpPact\Log\Exception;
+
+class LoggerUnserializeException extends LoggerException
+{
+}

--- a/src/PhpPact/Log/Logger.php
+++ b/src/PhpPact/Log/Logger.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace PhpPact\Log;
+
+use PhpPact\FFI\Client;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\Exception\LoggerApplyException;
+use PhpPact\Log\Exception\LoggerAttachSinkException;
+use PhpPact\Log\Exception\LoggerUnserializeException;
+use PhpPact\Log\Model\SinkInterface;
+
+final class Logger implements LoggerInterface
+{
+    private static ?self $instance = null;
+    /**
+     * @var SinkInterface[]
+     */
+    private array $sinks = [];
+    private bool $applied = false;
+
+    protected function __construct(private ClientInterface $client)
+    {
+        $this->client->loggerInit();
+    }
+
+    protected function __clone(): void
+    {
+    }
+
+    public function __wakeup(): never
+    {
+        throw new LoggerUnserializeException('Cannot unserialize a singleton.');
+    }
+
+    public static function instance(?ClientInterface $client = null): Logger
+    {
+        if (!isset(self::$instance)) {
+            self::$instance = new self($client ?? new Client());
+        }
+        return self::$instance;
+    }
+
+    public static function tearDown(): void
+    {
+        self::$instance = null;
+    }
+
+    public function attach(SinkInterface $sink): void
+    {
+        if ($this->applied) {
+            return;
+        }
+        $this->sinks[] = $sink;
+    }
+
+    public function apply(): void
+    {
+        if ($this->applied) {
+            return;
+        }
+        foreach ($this->sinks as $sink) {
+            $error = $this->client->loggerAttachSink($sink->getSpecifier(), $this->getLevelFilter($sink->getLevel()));
+            if ($error) {
+                throw new LoggerAttachSinkException($error);
+            }
+        }
+        $error = $this->client->loggerApply();
+        if ($error) {
+            throw new LoggerApplyException($error);
+        }
+        $this->applied = true;
+    }
+
+    public function fetchBuffer(): string
+    {
+        return $this->client->fetchLogBuffer();
+    }
+
+    private function getLevelFilter(LogLevel $level): int
+    {
+        return match ($level) {
+            LogLevel::TRACE => $this->client->getLevelFilterTrace(),
+            LogLevel::DEBUG => $this->client->getLevelFilterDebug(),
+            LogLevel::INFO => $this->client->getLevelFilterInfo(),
+            LogLevel::WARN => $this->client->getLevelFilterWarn(),
+            LogLevel::ERROR => $this->client->getLevelFilterError(),
+            LogLevel::OFF => $this->client->getLevelFilterOff(),
+            LogLevel::NONE => $this->client->getLevelFilterOff(),
+        };
+    }
+}

--- a/src/PhpPact/Log/LoggerInterface.php
+++ b/src/PhpPact/Log/LoggerInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace PhpPact\Log;
+
+use PhpPact\Log\Model\SinkInterface;
+
+interface LoggerInterface
+{
+    public function attach(SinkInterface $sink): void;
+
+    public function apply(): void;
+
+    public function fetchBuffer(): string;
+}

--- a/src/PhpPact/Log/Model/AbstractSink.php
+++ b/src/PhpPact/Log/Model/AbstractSink.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PhpPact\Log\Model;
+
+use PhpPact\Log\Enum\LogLevel;
+
+abstract class AbstractSink implements SinkInterface
+{
+    public function __construct(private LogLevel $level)
+    {
+    }
+
+    public function getLevel(): LogLevel
+    {
+        return $this->level;
+    }
+}

--- a/src/PhpPact/Log/Model/Buffer.php
+++ b/src/PhpPact/Log/Model/Buffer.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpPact\Log\Model;
+
+class Buffer extends AbstractSink
+{
+    public function getSpecifier(): string
+    {
+        return 'buffer';
+    }
+}

--- a/src/PhpPact/Log/Model/File.php
+++ b/src/PhpPact/Log/Model/File.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PhpPact\Log\Model;
+
+use PhpPact\Log\Enum\LogLevel;
+
+class File extends AbstractSink
+{
+    public function __construct(private string $path, LogLevel $level)
+    {
+        parent::__construct($level);
+    }
+
+    public function getSpecifier(): string
+    {
+        return "file {$this->path}";
+    }
+}

--- a/src/PhpPact/Log/Model/SinkInterface.php
+++ b/src/PhpPact/Log/Model/SinkInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PhpPact\Log\Model;
+
+use PhpPact\Log\Enum\LogLevel;
+
+interface SinkInterface
+{
+    public function getLevel(): LogLevel;
+
+    public function getSpecifier(): string;
+}

--- a/src/PhpPact/Log/Model/Stderr.php
+++ b/src/PhpPact/Log/Model/Stderr.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpPact\Log\Model;
+
+class Stderr extends AbstractSink
+{
+    public function getSpecifier(): string
+    {
+        return 'stderr';
+    }
+}

--- a/src/PhpPact/Log/Model/Stdout.php
+++ b/src/PhpPact/Log/Model/Stdout.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpPact\Log\Model;
+
+class Stdout extends AbstractSink
+{
+    public function getSpecifier(): string
+    {
+        return 'stdout';
+    }
+}

--- a/src/PhpPact/Log/PHPUnit/PactLoggingExtension.php
+++ b/src/PhpPact/Log/PHPUnit/PactLoggingExtension.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PhpPact\Log\PHPUnit;
+
+use PhpPact\Log\Logger;
+use PHPUnit\Runner\Extension\Extension;
+use PHPUnit\Runner\Extension\Facade;
+use PHPUnit\Runner\Extension\ParameterCollection;
+use PHPUnit\TextUI\Configuration\Configuration;
+
+final class PactLoggingExtension implements Extension
+{
+    public function bootstrap(Configuration $configuration, Facade $facade, ParameterCollection $parameters): void
+    {
+        $facade->registerSubscriber(new PactLoggingSubscriber(Logger::instance()));
+    }
+}

--- a/src/PhpPact/Log/PHPUnit/PactLoggingSubscriber.php
+++ b/src/PhpPact/Log/PHPUnit/PactLoggingSubscriber.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PhpPact\Log\PHPUnit;
+
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\LoggerInterface;
+use PhpPact\Log\Model\File;
+use PhpPact\Log\Model\Stdout;
+use PHPUnit\Event\Application\Started;
+use PHPUnit\Event\Application\StartedSubscriber;
+
+final class PactLoggingSubscriber implements StartedSubscriber
+{
+    public function __construct(private LoggerInterface $logger)
+    {
+    }
+
+    public function notify(Started $event): void
+    {
+        $logFile = \getenv('PACT_LOG');
+        $logLevel = \getenv('PACT_LOGLEVEL');
+        if (is_string($logFile) && is_string($logLevel)) {
+            $this->logger->attach(new File($logFile, LogLevel::from(\strtoupper($logLevel))));
+        }
+        if ($logFile === false && is_string($logLevel)) {
+            $this->logger->attach(new Stdout(LogLevel::from(\strtoupper($logLevel))));
+        }
+        if (is_string($logFile) && $logLevel === false) {
+            $this->logger->attach(new File($logFile, LogLevel::INFO));
+        }
+        if (is_string($logFile) || is_string($logLevel)) {
+            $this->logger->apply();
+        }
+    }
+}

--- a/tests/PhpPact/FFI/ClientTest.php
+++ b/tests/PhpPact/FFI/ClientTest.php
@@ -385,6 +385,30 @@ class ClientTest extends TestCase
         $this->assertSame(5, $result);
     }
 
+    public function testLoggerInit(): void
+    {
+        $this->client->loggerInit();
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testLoggerAttachSink(): void
+    {
+        $result = $this->client->loggerAttachSink('stdout', 0);
+        $this->assertSame(0, $result);
+    }
+
+    public function testLoggerApply(): void
+    {
+        $result = $this->client->loggerApply();
+        $this->assertSame(-1, $result);
+    }
+
+    public function testFetchLogBuffer(): void
+    {
+        $result = $this->client->fetchLogBuffer();
+        $this->assertSame('', $result);
+    }
+
     public function testGetInteractionPartRequest(): void
     {
         $this->assertSame(0, $this->client->getInteractionPartRequest());
@@ -423,5 +447,35 @@ class ClientTest extends TestCase
     public function testGetPactSpecificationUnknown(): void
     {
         $this->assertSame(0, $this->client->getPactSpecificationUnknown());
+    }
+
+    public function testGetLevelFilterTrace(): void
+    {
+        $this->assertSame(5, $this->client->getLevelFilterTrace());
+    }
+
+    public function testGetLevelFilterDebug(): void
+    {
+        $this->assertSame(4, $this->client->getLevelFilterDebug());
+    }
+
+    public function testGetLevelFilterInfo(): void
+    {
+        $this->assertSame(3, $this->client->getLevelFilterInfo());
+    }
+
+    public function testGetLevelFilterWarn(): void
+    {
+        $this->assertSame(2, $this->client->getLevelFilterWarn());
+    }
+
+    public function testGetLevelFilterError(): void
+    {
+        $this->assertSame(1, $this->client->getLevelFilterError());
+    }
+
+    public function testGetLevelFilterOff(): void
+    {
+        $this->assertSame(0, $this->client->getLevelFilterOff());
     }
 }

--- a/tests/PhpPact/Log/LoggerTest.php
+++ b/tests/PhpPact/Log/LoggerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace PhpPactTest\Log;
+
+use Error;
+use PhpPact\FFI\ClientInterface;
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\Exception\LoggerApplyException;
+use PhpPact\Log\Exception\LoggerAttachSinkException;
+use PhpPact\Log\Exception\LoggerUnserializeException;
+use PhpPact\Log\Logger;
+use PhpPact\Log\LoggerInterface;
+use PhpPact\Log\Model\Buffer;
+use PhpPact\Log\Model\File;
+use PhpPact\Log\Model\Stderr;
+use PhpPact\Log\Model\Stdout;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class LoggerTest extends TestCase
+{
+    protected ClientInterface&MockObject $client;
+    private LoggerInterface $logger;
+
+    public function setUp(): void
+    {
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->client
+            ->expects($this->any())
+            ->method('getLevelFilterTrace')
+            ->willReturn(5);
+        $this->client
+            ->expects($this->any())
+            ->method('getLevelFilterDebug')
+            ->willReturn(4);
+        $this->client
+            ->expects($this->any())
+            ->method('getLevelFilterInfo')
+            ->willReturn(3);
+        $this->client
+            ->expects($this->any())
+            ->method('getLevelFilterWarn')
+            ->willReturn(2);
+        $this->client
+            ->expects($this->any())
+            ->method('getLevelFilterError')
+            ->willReturn(1);
+        $this->client
+            ->expects($this->any())
+            ->method('getLevelFilterOff')
+            ->willReturn(0);
+        $this->logger = Logger::instance($this->client);
+    }
+
+    public function tearDown(): void
+    {
+        Logger::tearDown();
+    }
+
+    public function testSameInstance(): void
+    {
+        $this->assertSame(Logger::instance($this->client), $this->logger);
+    }
+
+    public function testClone(): void
+    {
+        $this->expectException(Error::class);
+        $this->expectExceptionMessage('Call to protected PhpPact\Log\Logger::__clone()');
+        clone $this->logger;
+    }
+
+    public function testSerialize(): void
+    {
+        $this->expectException(LoggerUnserializeException::class);
+        $this->expectExceptionMessage('Cannot unserialize a singleton.');
+        $result = serialize($this->logger);
+        unserialize($result);
+    }
+
+    public function testApply(): void
+    {
+        $this->logger->attach(new File('/path/to/file', LogLevel::DEBUG));
+        $this->logger->attach(new Buffer(LogLevel::ERROR));
+        $this->logger->attach(new Stdout(LogLevel::WARN));
+        $this->logger->attach(new Stderr(LogLevel::INFO));
+        $calls = [
+            [
+                'args' => ['file /path/to/file', 4],
+                'return' => 0
+            ],
+            [
+                'args' => ['buffer', 1],
+                'return' => 0
+            ],
+            [
+                'args' => ['stdout', 2],
+                'return' => 0
+            ],
+            [
+                'args' => ['stderr', 3],
+                'return' => 0
+            ]
+        ];
+        $this->client
+            ->expects($this->exactly(4))
+            ->method('loggerAttachSink')
+            ->willReturnCallback(function (...$args) use (&$calls) {
+                $call = array_shift($calls);
+                $this->assertSame($call['args'], $args);
+
+                return $call['return'];
+            });
+        $this->client
+            ->expects($this->once())
+            ->method('loggerApply')
+            ->willReturn(0);
+        $this->logger->apply();
+        $this->logger->attach(new Stderr(LogLevel::TRACE));
+        $this->logger->apply();
+        $this->logger->apply();
+    }
+
+    #[TestWith([0])]
+    #[TestWith([-1])]
+    #[TestWith([-2])]
+    #[TestWith([-3])]
+    #[TestWith([-4])]
+    #[TestWith([-5])]
+    #[TestWith([-6])]
+    #[TestWith([-7])]
+    public function testAttachSinkReturnError(int $error): void
+    {
+        $this->logger->attach(new Stderr(LogLevel::INFO));
+        $this->client
+            ->expects($this->once())
+            ->method('loggerAttachSink')
+            ->with('stderr', 3)
+            ->willReturn($error);
+        if ($error) {
+            $this->expectException(LoggerAttachSinkException::class);
+            $this->expectExceptionMessage(match ($error) {
+                -1 => "Can't set logger (applying the logger failed, perhaps because one is applied already).",
+                -2 => 'No logger has been initialized (call `pactffi_logger_init` before any other log function).',
+                -3 => 'The sink specifier was not UTF-8 encoded.',
+                -4 => 'The sink type specified is not a known type (known types: "stdout", "stderr", "buffer", or "file /some/path").',
+                -5 => 'No file path was specified in a file-type sink specification.',
+                -6 => 'Opening a sink to the specified file path failed (check permissions).',
+                default => 'Unknown error',
+            });
+        }
+        $this->logger->apply();
+    }
+
+    #[TestWith([0])]
+    #[TestWith([-1])]
+    #[TestWith([-2])]
+    public function testApplyReturnError(int $error): void
+    {
+        $this->logger->attach(new Stderr(LogLevel::OFF));
+        $this->client
+            ->expects($this->once())
+            ->method('loggerAttachSink')
+            ->with('stderr', 0)
+            ->willReturn(0);
+        $this->client
+            ->expects($this->once())
+            ->method('loggerApply')
+            ->willReturn($error);
+        if ($error) {
+            $this->expectException(LoggerApplyException::class);
+            $this->expectExceptionMessage(match ($error) {
+                -1 => "Can't set logger (applying the logger failed, perhaps because one is applied already).",
+                default => 'Unknown error',
+            });
+        }
+        $this->logger->apply();
+    }
+
+    public function testFetchBuffer(): void
+    {
+        $log = 'log from pact';
+        $this->client
+            ->expects($this->once())
+            ->method('fetchLogBuffer')
+            ->willReturn($log);
+        $this->assertSame($log, $this->logger->fetchBuffer());
+    }
+}

--- a/tests/PhpPact/Log/Model/BufferTest.php
+++ b/tests/PhpPact/Log/Model/BufferTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPactTest\Log\Model;
+
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\Model\Buffer;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class BufferTest extends TestCase
+{
+    #[TestWith([LogLevel::TRACE])]
+    #[TestWith([LogLevel::DEBUG])]
+    #[TestWith([LogLevel::INFO])]
+    #[TestWith([LogLevel::WARN])]
+    #[TestWith([LogLevel::ERROR])]
+    #[TestWith([LogLevel::OFF])]
+    #[TestWith([LogLevel::NONE])]
+    public function testConstructor(LogLevel $logLevel): void
+    {
+        $sink = new Buffer($logLevel);
+        $this->assertSame('buffer', $sink->getSpecifier());
+        $this->assertSame($logLevel, $sink->getLevel());
+    }
+}

--- a/tests/PhpPact/Log/Model/FileTest.php
+++ b/tests/PhpPact/Log/Model/FileTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpPactTest\Log\Model;
+
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\Model\File;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class FileTest extends TestCase
+{
+    #[TestWith([LogLevel::TRACE])]
+    #[TestWith([LogLevel::DEBUG])]
+    #[TestWith([LogLevel::INFO])]
+    #[TestWith([LogLevel::WARN])]
+    #[TestWith([LogLevel::ERROR])]
+    #[TestWith([LogLevel::OFF])]
+    #[TestWith([LogLevel::NONE])]
+    public function testConstructor(LogLevel $logLevel): void
+    {
+        $path = '/path/to/log.txt';
+        $sink = new File($path, $logLevel);
+        $this->assertSame("file {$path}", $sink->getSpecifier());
+        $this->assertSame($logLevel, $sink->getLevel());
+    }
+}

--- a/tests/PhpPact/Log/Model/StderrTest.php
+++ b/tests/PhpPact/Log/Model/StderrTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPactTest\Log\Model;
+
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\Model\Stderr;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class StderrTest extends TestCase
+{
+    #[TestWith([LogLevel::TRACE])]
+    #[TestWith([LogLevel::DEBUG])]
+    #[TestWith([LogLevel::INFO])]
+    #[TestWith([LogLevel::WARN])]
+    #[TestWith([LogLevel::ERROR])]
+    #[TestWith([LogLevel::OFF])]
+    #[TestWith([LogLevel::NONE])]
+    public function testConstructor(LogLevel $logLevel): void
+    {
+        $sink = new Stderr($logLevel);
+        $this->assertSame('stderr', $sink->getSpecifier());
+        $this->assertSame($logLevel, $sink->getLevel());
+    }
+}

--- a/tests/PhpPact/Log/Model/StdoutTest.php
+++ b/tests/PhpPact/Log/Model/StdoutTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpPactTest\Log\Model;
+
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\Model\Stdout;
+use PHPUnit\Framework\Attributes\TestWith;
+use PHPUnit\Framework\TestCase;
+
+class StdoutTest extends TestCase
+{
+    #[TestWith([LogLevel::TRACE])]
+    #[TestWith([LogLevel::DEBUG])]
+    #[TestWith([LogLevel::INFO])]
+    #[TestWith([LogLevel::WARN])]
+    #[TestWith([LogLevel::ERROR])]
+    #[TestWith([LogLevel::OFF])]
+    #[TestWith([LogLevel::NONE])]
+    public function testConstructor(LogLevel $logLevel): void
+    {
+        $sink = new Stdout($logLevel);
+        $this->assertSame('stdout', $sink->getSpecifier());
+        $this->assertSame($logLevel, $sink->getLevel());
+    }
+}

--- a/tests/PhpPact/Log/PHPUnit/PactLoggingSubscriberTest.php
+++ b/tests/PhpPact/Log/PHPUnit/PactLoggingSubscriberTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace PhpPactTest\Log\PHPUnit;
+
+use PhpPact\Log\Enum\LogLevel;
+use PhpPact\Log\LoggerInterface;
+use PhpPact\Log\Model\File;
+use PhpPact\Log\Model\SinkInterface;
+use PhpPact\Log\Model\Stdout;
+use PhpPact\Log\PHPUnit\PactLoggingSubscriber;
+use PHPUnit\Event\Application\Started;
+use PHPUnit\Event\Runtime\Runtime;
+use PHPUnit\Event\Telemetry\Duration;
+use PHPUnit\Event\Telemetry\GarbageCollectorStatus;
+use PHPUnit\Event\Telemetry\HRTime;
+use PHPUnit\Event\Telemetry\Info;
+use PHPUnit\Event\Telemetry\MemoryUsage;
+use PHPUnit\Event\Telemetry\Snapshot;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class PactLoggingSubscriberTest extends TestCase
+{
+    private LoggerInterface&MockObject $logger;
+    private PactLoggingSubscriber $subscriber;
+    private Started $event;
+
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->subscriber = new PactLoggingSubscriber($this->logger);
+        $this->event = new Started(
+            new Info(
+                new Snapshot(HRTime::fromSecondsAndNanoseconds(0, 0), MemoryUsage::fromBytes(0), MemoryUsage::fromBytes(0), new GarbageCollectorStatus(0, 0, 0, 0, null, null, null, null, null, null, null, null)),
+                Duration::fromSecondsAndNanoseconds(0, 0),
+                MemoryUsage::fromBytes(0),
+                Duration::fromSecondsAndNanoseconds(0, 0),
+                MemoryUsage::fromBytes(0)
+            ),
+            new Runtime()
+        );
+    }
+
+    public function testDoNotLog(): void
+    {
+        putenv('PACT_LOG');
+        putenv('PACT_LOGLEVEL');
+        $this->logger
+            ->expects($this->never())
+            ->method('attach');
+        $this->logger
+            ->expects($this->never())
+            ->method('apply');
+        $this->subscriber->notify($this->event);
+    }
+
+    public function testLogToFile(): void
+    {
+        putenv('PACT_LOG=./log/pact.txt');
+        putenv('PACT_LOGLEVEL=trace');
+        $this->logger
+            ->expects($this->once())
+            ->method('attach')
+            ->with($this->callback(function (SinkInterface $sink) {
+                $this->assertInstanceOf(File::class, $sink);
+                $this->assertSame('file ./log/pact.txt', $sink->getSpecifier());
+                $this->assertSame(LogLevel::TRACE, $sink->getLevel());
+
+                return true;
+            }));
+        $this->logger
+            ->expects($this->once())
+            ->method('apply');
+        $this->subscriber->notify($this->event);
+    }
+
+    public function testLogToFileWithDefaultLevel(): void
+    {
+        putenv('PACT_LOG=./log/pact.txt');
+        putenv('PACT_LOGLEVEL');
+        $this->logger
+            ->expects($this->once())
+            ->method('attach')
+            ->with($this->callback(function (SinkInterface $sink) {
+                $this->assertInstanceOf(File::class, $sink);
+                $this->assertSame('file ./log/pact.txt', $sink->getSpecifier());
+                $this->assertSame(LogLevel::INFO, $sink->getLevel());
+
+                return true;
+            }));
+        $this->logger
+            ->expects($this->once())
+            ->method('apply');
+        $this->subscriber->notify($this->event);
+    }
+
+    public function testLogToStandardOutput(): void
+    {
+        putenv('PACT_LOG');
+        putenv('PACT_LOGLEVEL=debug');
+        $this->logger
+            ->expects($this->once())
+            ->method('attach')
+            ->with($this->callback(function (SinkInterface $sink) {
+                $this->assertInstanceOf(Stdout::class, $sink);
+                $this->assertSame('stdout', $sink->getSpecifier());
+                $this->assertSame(LogLevel::DEBUG, $sink->getLevel());
+
+                return true;
+            }));
+        $this->logger
+            ->expects($this->once())
+            ->method('apply');
+        $this->subscriber->notify($this->event);
+    }
+}


### PR DESCRIPTION
* Allow logging to multiple sinks: file, buffer, stdout, stderr
  * Usage

    ```php
    $logger = Logger::instance();
    $logger->attach(new File('/path/to/file', LogLevel::DEBUG));
    $logger->attach(new Buffer(LogLevel::ERROR));
    $logger->attach(new Stdout(LogLevel::WARN));
    $logger->attach(new Stderr(LogLevel::INFO));
    $logger->apply();
    ````

* Add PHPUnit logging extension
  * It define sinks base on values of `PACT_LOGLEVEL` and `PACT_LOG` then apply logger. These environment variables are already defined from v9 but only `PACT_LOGLEVEL` is used in v10
  * Implements #341
  * Usage

    ```xml
    <?xml version="1.0" encoding="UTF-8"?>
    <phpunit bootstrap="./autoload.php" colors="true">
        <testsuites>
            <testsuite name="PhpPact Example Tests">
                <directory>./tests</directory>
            </testsuite>
        </testsuites>
        <php>
            <env name="PACT_LOG" value="./log/pact.txt"/>
            <env name="PACT_LOGLEVEL" value="DEBUG"/>
        </php>
        <extensions>
            <bootstrap class="PhpPact\Log\PHPUnit\PactLoggingExtension"/>
        </extensions>
    </phpunit>

    ```