### PR TITLE
ci: Test PHP 8.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [ '8.1', '8.2', '8.3' ]
+        php: [ '8.1', '8.2', '8.3', '8.4' ]
         dependencies: [ 'lowest', 'locked' ]
 
     steps:


### PR DESCRIPTION
PHP 8.4.1 has been released. This PR add that version into the list of PHP versions for unit testing.