### PR TITLE
chore: Don't validate example value with regex

### DIFF
--- a/compatibility-suite/tests/Service/MatchingRuleConverter.php
+++ b/compatibility-suite/tests/Service/MatchingRuleConverter.php
@@ -92,7 +92,7 @@ final class MatchingRuleConverter implements MatchingRuleConverterInterface
 
             case 'regex':
                 $regex = $rule->getMatcherAttribute('regex');
-                return new Regex($regex, $this->ignoreInvalidValue($regex, $value));
+                return new Regex($regex, $value);
 
             case 'statusCode':
                 return new StatusCode($rule->getMatcherAttribute('status'));
@@ -106,25 +106,6 @@ final class MatchingRuleConverter implements MatchingRuleConverterInterface
     {
         if (is_numeric($value)) {
             $value = $value + 0;
-        } else {
-            $value = null;
-        }
-
-        return $value;
-    }
-
-    private function ignoreInvalidValue(string $regex, mixed $value): string|array|null
-    {
-        if (is_string($value)) {
-            if (!preg_match("/$regex/", $value)) {
-                $value = null;
-            }
-        } elseif (is_array($value)) {
-            foreach (array_keys($value) as $key) {
-                if (!preg_match("/$regex/", $value[$key])) {
-                    $value[$key] = null;
-                }
-            }
         } else {
             $value = null;
         }

--- a/src/PhpPact/Consumer/Matcher/Exception/InvalidRegexException.php
+++ b/src/PhpPact/Consumer/Matcher/Exception/InvalidRegexException.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace PhpPact\Consumer\Matcher\Exception;
-
-class InvalidRegexException extends MatcherException
-{
-}

--- a/src/PhpPact/Consumer/Matcher/Matchers/Regex.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/Regex.php
@@ -3,16 +3,12 @@
 namespace PhpPact\Consumer\Matcher\Matchers;
 
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
-use PhpPact\Consumer\Matcher\Exception\InvalidRegexException;
 use PhpPact\Consumer\Matcher\Generators\Regex as RegexGenerator;
 use PhpPact\Consumer\Matcher\Model\Attributes;
 use PhpPact\Consumer\Matcher\Model\Expression;
 use PhpPact\Consumer\Matcher\Model\Matcher\ExpressionFormattableInterface;
 use PhpPact\Consumer\Matcher\Model\Matcher\JsonFormattableInterface;
 use PhpPact\Consumer\Matcher\Trait\JsonFormattableTrait;
-
-use function preg_last_error;
-use function preg_match;
 
 class Regex extends GeneratorAwareMatcher implements JsonFormattableInterface, ExpressionFormattableInterface
 {
@@ -27,26 +23,8 @@ class Regex extends GeneratorAwareMatcher implements JsonFormattableInterface, E
     ) {
         if ($values === null) {
             $this->setGenerator(new RegexGenerator($this->regex));
-        } else {
-            $this->validateRegex();
         }
         parent::__construct();
-    }
-
-    /**
-     * @todo Use json_validate()
-     */
-    private function validateRegex(): void
-    {
-        foreach ((array) $this->values as $value) {
-            $result = preg_match("/$this->regex/", $value);
-
-            if ($result !== 1) {
-                $errorCode = preg_last_error();
-
-                throw new InvalidRegexException("The value '{$value}' doesn't match pattern '{$this->regex}'. Failed with error code {$errorCode}.");
-            }
-        }
     }
 
     public function formatJson(): Attributes

--- a/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/EachValueTest.php
@@ -55,7 +55,7 @@ class EachValueTest extends TestCase
                         "value": null
                     }
                 ]
-                }
+            }
             JSON,
             $jsonEncoded
         );

--- a/tests/PhpPact/Consumer/Matcher/Matchers/RegexTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/RegexTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpPactTest\Consumer\Matcher\Matchers;
 
-use PhpPact\Consumer\Matcher\Exception\InvalidRegexException;
 use PhpPact\Consumer\Matcher\Exception\InvalidValueException;
 use PhpPact\Consumer\Matcher\Formatters\Expression\ExpressionFormatter;
 use PhpPact\Consumer\Matcher\Matchers\Regex;
@@ -13,17 +12,6 @@ use PHPUnit\Framework\TestCase;
 class RegexTest extends TestCase
 {
     private string $regex = '\d+';
-
-    #[TestWith(['number', true])]
-    #[TestWith(['integer', false])]
-    public function testInvalidRegex(string $value, bool $isArray): void
-    {
-        $values = $isArray ? [$value] : $value;
-        $this->expectException(InvalidRegexException::class);
-        $value = is_array($values) ? $values[0] : $values;
-        $this->expectExceptionMessage("The value '{$value}' doesn't match pattern '{$this->regex}'. Failed with error code 0.");
-        new Regex($this->regex, $values);
-    }
 
     /**
      * @param string|string[]|null $values


### PR DESCRIPTION
* Follow suggestion from @mefellows : the value must be correct type, no need to validate beforehand
* This change allows the use of an empty string (`''`) instead of `null` as an example value when a generator is set. This way, we don't need to find a value that matches the regex, since the generator will replace that value later anyway.