### PR TITLE
deps: Tell renovate to ignore docker-compose.yml

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,5 +3,8 @@
   "extends": ["config:best-practices"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "automerge": true
+  "automerge": true,
+  "ignorePaths": [
+    "docker-compose.yml"
+  ]
 }


### PR DESCRIPTION
`docker-compose.yml` is not used anywhere. It's just an example file. We can tell Renovate to ignore that file, prevent it from keep pinning dependencies on that file.