### PR TITLE
fix: Fix PHPStan no error to ignore

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "ext-sockets": "*",
         "roave/security-advisories": "dev-latest",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpstan/phpstan": "^2.0",
+        "phpstan/phpstan": "^2.0.4",
         "phpunit/phpunit": "^10.1.0|^11.0",
         "guzzlehttp/guzzle": "^7.8",
         "behat/behat": "^3.13",

--- a/src/PhpPact/FFI/Model/ArrayData.php
+++ b/src/PhpPact/FFI/Model/ArrayData.php
@@ -47,7 +47,7 @@ class ArrayData
                 throw new CDataNotCreatedException();
             }
             FFI::memcpy($item, $value, $length);
-            $items[$index++] = $item; // @phpstan-ignore-line
+            $items[$index++] = $item;
         }
 
         return new self($items, $size);

--- a/tests/PhpPact/FFI/Model/ArrayDataTest.php
+++ b/tests/PhpPact/FFI/Model/ArrayDataTest.php
@@ -20,7 +20,7 @@ class ArrayDataTest extends TestCase
         $this->assertInstanceOf(ArrayData::class, $arrayData);
         $this->assertSame(count($branches), $arrayData->getSize());
         foreach ($branches as $index => $branch) {
-            // @phpstan-ignore offsetAccess.nonOffsetAccessible,argument.type
+            // @phpstan-ignore argument.type
             $this->assertSame($branch, FFI::string($arrayData->getItems()[$index]));
         }
     }


### PR DESCRIPTION
PHPStan [2.0.4](https://github.com/phpstan/phpstan/releases/tag/2.0.4) introduce new change that don't report the error `offsetAccess.nonOffsetAccessible` on PHP's `CDATA` anymore.