### PR TITLE
chore(ci): prevent duplicate ci triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,11 @@ name: Code Analysis & Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
-  # Once on the first of the month at 06:00 UTC
-  schedule:
-    - cron: 0 6 1 * *
+    branches:
+      - master
 
 concurrency:
   group: ${{ github.ref }}

--- a/.github/workflows/compatibility-suite.yml
+++ b/.github/workflows/compatibility-suite.yml
@@ -1,6 +1,12 @@
 name: Compatibility Suite
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 env:
   PACT_DO_NOT_TRACK: true


### PR DESCRIPTION
Triggering on all 'push' and 'pull_request' events will result in duplicated CI runs in PRs (due to both conditions being met).

Instead, trigger only on pushes to `master`, or updates to PRs targetting `master`.

Also removed cron job as all updates to `master` are checked anyway.