### PR TITLE
fix: Revert breaking changes to FFI\Client::call and FFI\Client::get

### DIFF
--- a/src/PhpPact/FFI/Client.php
+++ b/src/PhpPact/FFI/Client.php
@@ -624,12 +624,12 @@ class Client implements ClientInterface
         return $value;
     }
 
-    private function call(string $name, mixed ...$arguments): mixed
+    public function call(string $name, mixed ...$arguments): mixed
     {
         return $this->ffi->{$name}(...$arguments);
     }
 
-    private function get(string $name): mixed
+    public function get(string $name): mixed
     {
         return $this->ffi->{$name};
     }

--- a/src/PhpPact/FFI/ClientInterface.php
+++ b/src/PhpPact/FFI/ClientInterface.php
@@ -158,4 +158,18 @@ interface ClientInterface
     public function getLevelFilterError(): int;
 
     public function getLevelFilterOff(): int;
+
+    /**
+     * @deprecated 10.1.0 This method is deprecated and will be removed in a future release.
+     *                    Please use the more specific methods in this interface instead,
+     *                    as they provide clearer intent and stricter type definitions.
+     */
+    public function call(string $name, mixed ...$arguments): mixed;
+
+    /**
+     * @deprecated 10.1.0 This method is deprecated and will be removed in a future release.
+     *                    Please use the more specific methods in this interface instead,
+     *                    as they provide clearer intent and stricter type definitions.
+     */
+    public function get(string $name): mixed;
 }


### PR DESCRIPTION
Fix #713