### PR TITLE
test: Fix 'offset might not exist on array' errors

### DIFF
--- a/tests/PhpPact/Log/LoggerTest.php
+++ b/tests/PhpPact/Log/LoggerTest.php
@@ -103,11 +103,13 @@ class LoggerTest extends TestCase
                 'return' => 0
             ]
         ];
+        $matcher = $this->exactly(count($calls));
         $this->client
-            ->expects($this->exactly(4))
+            ->expects($matcher)
             ->method('loggerAttachSink')
-            ->willReturnCallback(function (...$args) use (&$calls) {
-                $call = array_shift($calls);
+            ->willReturnCallback(function (...$args) use ($calls, $matcher) {
+                $index = $matcher->numberOfInvocations() - 1;
+                $call = $calls[$index];
                 $this->assertSame($call['args'], $args);
 
                 return $call['return'];


### PR DESCRIPTION
PHPStan report these 2 errors in https://github.com/pact-foundation/pact-php/pull/724/files:
* Offset 'args' might not exist on array{args: array{literal-string&non-falsy-string, 1|2|3|4}, return: 0}|null.
* Offset 'return' might not exist on array{args: array{literal-string&non-falsy-string, 1|2|3|4}, return: 0}|null.

This PR solve them.