### PR TITLE
fix: Fix matching rules not working with protobuf's repeated field

### DIFF
--- a/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MaxType.php
@@ -35,6 +35,6 @@ class MaxType extends AbstractMatcher implements JsonFormattableInterface, Expre
 
     public function formatExpression(): Expression
     {
-        return new Expression("atMost({$this->max}), eachValue(matching(type, %value%))", ['value' => $this->value]);
+        return new Expression("eachValue(matching(type, %value%)), atMost({$this->max})", ['value' => $this->value]);
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/MinMaxType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MinMaxType.php
@@ -43,6 +43,6 @@ class MinMaxType extends AbstractMatcher implements JsonFormattableInterface, Ex
 
     public function formatExpression(): Expression
     {
-        return new Expression("atLeast({$this->min}), atMost({$this->max}), eachValue(matching(type, %value%))", ['value' => $this->value]);
+        return new Expression("eachValue(matching(type, %value%)), atLeast({$this->min}), atMost({$this->max})", ['value' => $this->value]);
     }
 }

--- a/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
+++ b/src/PhpPact/Consumer/Matcher/Matchers/MinType.php
@@ -37,6 +37,6 @@ class MinType extends AbstractMatcher implements JsonFormattableInterface, Expre
 
     public function formatExpression(): Expression
     {
-        return new Expression("atLeast({$this->min}), eachValue(matching(type, %value%))", ['value' => $this->value]);
+        return new Expression("eachValue(matching(type, %value%)), atLeast({$this->min})", ['value' => $this->value]);
     }
 }

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MaxTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MaxTypeTest.php
@@ -19,9 +19,9 @@ class MaxTypeTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
     }
 
-    #[TestWith(["contains single quote '", 2, "\"atMost(2), eachValue(matching(type, 'contains single quote \\\''))\""])]
-    #[TestWith([null, 2, '"atMost(2), eachValue(matching(type, null))"'])]
-    #[TestWith(['example value', 2, "\"atMost(2), eachValue(matching(type, 'example value'))\""])]
+    #[TestWith(["contains single quote '", 2, "\"eachValue(matching(type, 'contains single quote \\\'')), atMost(2)\""])]
+    #[TestWith([null, 2, '"eachValue(matching(type, null)), atMost(2)"'])]
+    #[TestWith(['example value', 2, "\"eachValue(matching(type, 'example value')), atMost(2)\""])]
     public function testFormatExpression(mixed $value, int $max, string $expression): void
     {
         $matcher = new MaxType($value, $max);

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MinMaxTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MinMaxTypeTest.php
@@ -21,9 +21,9 @@ class MinMaxTypeTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
     }
 
-    #[TestWith(["contains single quote '", 2, 3, "\"atLeast(2), atMost(3), eachValue(matching(type, 'contains single quote \\\''))\""])]
-    #[TestWith([null, 2, 3, '"atLeast(2), atMost(3), eachValue(matching(type, null))"'])]
-    #[TestWith(['example value', 2, 3, "\"atLeast(2), atMost(3), eachValue(matching(type, 'example value'))\""])]
+    #[TestWith(["contains single quote '", 2, 3, "\"eachValue(matching(type, 'contains single quote \\\'')), atLeast(2), atMost(3)\""])]
+    #[TestWith([null, 2, 3, '"eachValue(matching(type, null)), atLeast(2), atMost(3)"'])]
+    #[TestWith(['example value', 2, 3, "\"eachValue(matching(type, 'example value')), atLeast(2), atMost(3)\""])]
     public function testFormatExpression(mixed $value, int $min, int $max, string $expression): void
     {
         $matcher = new MinMaxType($value, $min, $max);

--- a/tests/PhpPact/Consumer/Matcher/Matchers/MinTypeTest.php
+++ b/tests/PhpPact/Consumer/Matcher/Matchers/MinTypeTest.php
@@ -19,9 +19,9 @@ class MinTypeTest extends TestCase
         $this->assertJsonStringEqualsJsonString($json, $jsonEncoded);
     }
 
-    #[TestWith(["contains single quote '", 1, "\"atLeast(1), eachValue(matching(type, 'contains single quote \\\''))\""])]
-    #[TestWith([null, 1, '"atLeast(1), eachValue(matching(type, null))"'])]
-    #[TestWith(['example value', 1, "\"atLeast(1), eachValue(matching(type, 'example value'))\""])]
+    #[TestWith(["contains single quote '", 1, "\"eachValue(matching(type, 'contains single quote \\\'')), atLeast(1)\""])]
+    #[TestWith([null, 1, '"eachValue(matching(type, null)), atLeast(1)"'])]
+    #[TestWith(['example value', 1, "\"eachValue(matching(type, 'example value')), atLeast(1)\""])]
     public function testFormatExpression(mixed $value, int $min, string $expression): void
     {
         $matcher = new MinType($value, $min);


### PR DESCRIPTION
The syntax `atLeast(1), atMost(2), eachValue(matching(type, 'text'))` is allowed in the documents:
* https://github.com/pact-foundation/pact-reference/blob/master/rust/pact_models/src/matchingrules/expressions.rs#L101-L104
* https://github.com/pactflow/pact-protobuf-plugin?tab=readme-ov-file#matching-repeated-fields

But it is not working as expected. It's probably a bug. We will track it at https://github.com/pactflow/pact-protobuf-plugin/issues/179

This pull request is a temporary solution: move `eachValue` to the beginning of the expression:

`eachValue(matching(type, 'text')), atLeast(1), atMost(2)`